### PR TITLE
Stop the issue body from turning into a code block

### DIFF
--- a/server/resolvers/issueTracker.js
+++ b/server/resolvers/issueTracker.js
@@ -6,13 +6,13 @@ const issuesUrl =
 export const IssueTrackerMutations = {
   addIssue(rootValue, { title, body, person, priority, type }) {
     // Create our body
-    var postBody = `### Requested By: ${person}
+    var postBody = `
+      ### Requested By: ${person}
 
-    ### Priority: ${priority}
-    
-    ### Version: ${require("../../package.json").version}
-    
-    ${body}`;
+      ### Priority: ${priority}
+
+      ### Version: ${require("../../package.json").version}
+    `.replace(/^\s+/gm, '').replace(/\s+$/m, '\n\n') + body;
 
     var postOptions = {
       title,


### PR DESCRIPTION
## Description
Template literals don’t trim or dedent their contents. This trims them manually before sending the body to the API.

## Related Issue

Fixes #518

## Screenshots (if appropriate):

- [ ] I submitted a pull request or created an issue for documenting this feature on the [Thorium Docs](https://github.com/Thorium-Sim/thorium-docs) repo. (Include the issue or pull request url below.)