### PR TITLE
Adds dilithium stress status to the Status page

### DIFF
--- a/client/src/components/views/Status/components/dilithiumStress.js
+++ b/client/src/components/views/Status/components/dilithiumStress.js
@@ -1,0 +1,89 @@
+import React, { Component } from "react";
+import { Label } from "reactstrap";
+import gql from "graphql-tag";
+import { graphql } from "react-apollo";
+import Dots from "./dots";
+import SubscriptionHelper from "../../../../helpers/subscriptionHelper";
+const SUB = gql`
+  subscription DilithiumStress($simulatorId: ID!) {
+    reactorUpdate(simulatorId: $simulatorId) {
+      id
+      alphaLevel
+      alphaTarget
+      betaLevel
+      betaTarget
+      model
+      heat
+    }
+  }
+`;
+
+class DilithiumStress extends Component {
+  // This calculation came from client/src/components/views/DilithiumStress/dilithiumStress.js
+  calcStressLevel = (reactor) => {
+    const { alphaTarget, betaTarget } = reactor;
+    const { alphaLevel, betaLevel } = reactor;
+    const alphaDif = Math.abs(alphaTarget - alphaLevel);
+    const betaDif = Math.abs(betaTarget - betaLevel);
+    const stressLevel = alphaDif + betaDif > 100 ? 100 : alphaDif + betaDif;
+    return stressLevel;
+  }
+
+  // Not sure if this is the best way to get this card. Perhaps the parent react
+  // node should decide if this component should render or not since it contains
+  // the props necessary to decide whether or not it would be appropriate to
+  // render this? ¯\_(ツ)_/¯
+  getDilithiumStressCard = (station) => {
+    if (!station) return null;
+    return station.cards.find(card => card.component === 'DilithiumStress');
+  }
+
+  render() {
+    if (this.props.data.loading || !this.props.data.reactors) return null;
+    const dilithiumStressCard = this.getDilithiumStressCard(this.props.station)
+    if (!dilithiumStressCard) return null;
+    // I'm assuming this is the way to get the reactor info.
+    const reactor = this.props.data.reactors && this.props.data.reactors[0];
+    if (!reactor) return null;
+    const stressLevel = this.calcStressLevel(reactor) / 100
+    return (
+      <div>
+        <SubscriptionHelper
+          subscribe={() =>
+            this.props.data.subscribeToMore({
+              document: SUB,
+              variables: { simulatorId: this.props.simulator.id },
+              updateQuery: (previousResult, { subscriptionData }) => {
+                return Object.assign({}, previousResult, {
+                  reators: subscriptionData.data.reactors
+                });
+              }
+            })
+          }
+        />
+        <Label>{dilithiumStressCard.name}</Label>
+        <Dots level={stressLevel} color="rgb(255,60,40)" />
+      </div>
+    );
+  }
+}
+const QUERY = gql`
+  query DilithiumStress($simulatorId: ID!) {
+    reactors(simulatorId: $simulatorId) {
+      id
+      alphaLevel
+      alphaTarget
+      betaLevel
+      betaTarget
+      model
+      heat
+    }
+  }
+`;
+
+export default graphql(QUERY, {
+  options: ownProps => ({
+    fetchPolicy: "cache-and-network",
+    variables: { simulatorId: ownProps.simulator.id }
+  })
+})(DilithiumStress);

--- a/client/src/components/views/Status/components/dilithiumStress.js
+++ b/client/src/components/views/Status/components/dilithiumStress.js
@@ -29,10 +29,6 @@ class DilithiumStress extends Component {
     return stressLevel;
   }
 
-  // Not sure if this is the best way to get this card. Perhaps the parent react
-  // node should decide if this component should render or not since it contains
-  // the props necessary to decide whether or not it would be appropriate to
-  // render this? ¯\_(ツ)_/¯
   getDilithiumStressCard = (station) => {
     if (!station) return null;
     return station.cards.find(card => card.component === 'DilithiumStress');
@@ -42,7 +38,6 @@ class DilithiumStress extends Component {
     if (this.props.data.loading || !this.props.data.reactors) return null;
     const dilithiumStressCard = this.getDilithiumStressCard(this.props.station)
     if (!dilithiumStressCard) return null;
-    // I'm assuming this is the way to get the reactor info.
     const reactor = this.props.data.reactors && this.props.data.reactors[0];
     if (!reactor) return null;
     const stressLevel = this.calcStressLevel(reactor) / 100

--- a/client/src/components/views/Status/components/index.js
+++ b/client/src/components/views/Status/components/index.js
@@ -3,6 +3,7 @@ export { default as Destination } from "./destination";
 export { default as Speed } from "./speed";
 export { default as Population } from "./population";
 export { default as Coolant } from "./coolant";
+export { default as DilithiumStress } from "./dilithiumStress";
 export { default as Targeted } from "./targeted";
 export { default as Battery } from "./battery";
 export { default as Damaged } from "./damaged";

--- a/client/src/components/views/Status/index.js
+++ b/client/src/components/views/Status/index.js
@@ -5,6 +5,7 @@ import {
   Speed,
   Population,
   Coolant,
+  DilithiumStress,
   Targeted,
   Battery,
   Damaged,
@@ -29,7 +30,7 @@ const trainingSteps = [
   }
 ];
 
-export default props => {
+const Status = props => {
   return (
     <Container fluid className="status-card">
       <Row>
@@ -43,6 +44,7 @@ export default props => {
           <Dots level={0.5} color={"rgb(0,128,255)"} />*/}
           <Battery {...props} />
           <Coolant {...props} />
+          <DilithiumStress {...props} />
         </Col>
         <Col sm={6}>
           <Stealth {...props} />
@@ -56,3 +58,5 @@ export default props => {
     </Container>
   );
 };
+
+export default Status

--- a/server/src/resolvers/reactor.js
+++ b/server/src/resolvers/reactor.js
@@ -3,10 +3,13 @@ import { pubsub } from "../helpers/subscriptionManager.js";
 import { withFilter } from "graphql-subscriptions";
 
 export const ReactorQueries = {
-  reactors(root, { simulatorId }) {
+  reactors(root, { simulatorId, model }) {
     let returnVal = App.systems.filter(s => s.type === "Reactor");
     if (simulatorId) {
       returnVal = returnVal.filter(s => s.simulatorId === simulatorId);
+    }
+    if (model) {
+      returnVal = returnVal.filter(s => s.model === model);
     }
     return returnVal;
   },

--- a/server/src/schema/queries/reactor.js
+++ b/server/src/schema/queries/reactor.js
@@ -1,4 +1,4 @@
 export default `
-reactors(simulatorId: ID): [Reactor]
+reactors(simulatorId: ID, model: String): [Reactor]
 reactor(id:ID!): Reactor
 `;


### PR DESCRIPTION
This pulls the reactor information much like the

## Description
This adds Dilithium Stress status to the Status page (if the station is configured with the Dilithium Stress Card)

## Related Issue
https://github.com/Thorium-Sim/thorium/issues/1175 - From the workshop items
https://github.com/Thorium-Sim/thorium/issues/1189

## Screenshots (if appropriate):

<img width="444" alt="screen shot 2018-08-25 at 17 51 27" src="https://user-images.githubusercontent.com/1906967/44623586-ce50ed80-a88f-11e8-9547-9285f80f412f.png">


- [ ] I submitted a pull request or created an issue for documenting this feature on the [Thorium Docs](https://github.com/Thorium-Sim/thorium-docs) repo. (Include the issue or pull request url below.)