### PR TITLE
Printable officer log

### DIFF
--- a/client/src/app.scss
+++ b/client/src/app.scss
@@ -85,8 +85,4 @@ pre {
   #root {
     display: none;    /* Speeds up printing as most of the DOM is not displayed */
   }
-
-  .printable * {
-    visibility: visible;
-  }
 }

--- a/client/src/app.scss
+++ b/client/src/app.scss
@@ -75,3 +75,18 @@ pre {
     max-width: 50%;
   }
 }
+
+/* See also printable.scss */
+@media print {
+  * {
+    visibility: hidden;
+  }
+
+  #root {
+    display: none;    /* Speeds up printing as most of the DOM is not displayed */
+  }
+
+  .printable * {
+    visibility: visible;
+  }
+}

--- a/client/src/components/views/OfficerLog/index.js
+++ b/client/src/components/views/OfficerLog/index.js
@@ -4,6 +4,7 @@ import gql from "graphql-tag";
 import { Container, Row, Col, Card, Input, Button } from "reactstrap";
 import uuid from "uuid";
 import SubscriptionHelper from "helpers/subscriptionHelper";
+import Printable from "helpers/printable";
 
 import "./style.scss";
 
@@ -55,6 +56,9 @@ class OfficerLog extends Component {
       });
     });
   };
+  printLog = () => {
+    window.print();
+  };
   render() {
     const { loading, officerLogs } = this.props.data;
     if (loading || !officerLogs) return null;
@@ -105,6 +109,9 @@ class OfficerLog extends Component {
             <Button block color="primary" onClick={this.startLog}>
               Start Log
             </Button>
+            <Button block color="info" onClick={this.printLog}>
+              Print
+            </Button>
           </Col>
           {logText !== null && (
             <Col sm={8} style={{ display: "flex", flexDirection: "column" }}>
@@ -144,6 +151,22 @@ class OfficerLog extends Component {
             </Col>
           )}
         </Row>
+        <Printable>
+          <div>
+            <h1>Officer Log</h1>
+            {officerLogs.map(l => (
+              <div
+                key={l.id}
+                className={`log-entry`}
+              >
+                <p className="stardate"><b>Stardate {stardate(l.timestamp)}</b></p>
+                <p>
+                  {l.log}
+                </p>
+              </div>
+            ))}
+          </div>
+        </Printable>
       </Container>
     );
   }

--- a/client/src/components/views/OfficerLog/index.js
+++ b/client/src/components/views/OfficerLog/index.js
@@ -153,7 +153,7 @@ class OfficerLog extends Component {
         </Row>
         <Printable>
           <div>
-            <h1>Officer Log</h1>
+            <h1>Officer Log &mdash; {this.props.clientObj.loginName}</h1>
             {officerLogs.map(l => (
               <div
                 key={l.id}

--- a/client/src/helpers/printable.js
+++ b/client/src/helpers/printable.js
@@ -1,0 +1,14 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import './printable.scss';
+
+export default function Printable(props) {
+  // Render printable outside the root React element
+  return ReactDOM.createPortal((
+      <div className='printable'>
+        { props.children }
+      </div>
+    ), 
+    document.body
+  );
+}

--- a/client/src/helpers/printable.scss
+++ b/client/src/helpers/printable.scss
@@ -1,0 +1,12 @@
+/* See also app.scss */
+
+.printable {
+  visibility: hidden;
+  color: black;
+}
+
+@media print {
+  .printable * {
+    visibility: visible;
+  }
+}


### PR DESCRIPTION
## Description
- In `app.scss`, added `@media print {...}` to make all components invisible during printing
- Added `helpers/printable.js` and `helpers/printable.scss`, which provide a `<Printable>` component that is rendered outside of the root React node and  _is_ visible during printing
- Modified `components/views/OfficerLog/index.js` to include a print button for printing the officer's log. The view now contains a `<Printable>` which contains the full log.

The location of the print button in the OfficersLog was sort of arbitrary, I'm open to suggestions to moving it, replacing it with a print icon, etc.

I'm also open to improving the styling of the printed log, it's kind of boring right now.

## Related Issue
#1430 

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/6345617/47796649-6339f200-dcea-11e8-87f7-a32f3b4587cc.png)

![image](https://user-images.githubusercontent.com/6345617/47796762-99777180-dcea-11e8-9b7c-59d7b90875cb.png)


- [ ] I submitted a pull request or created an issue for documenting this feature on the [Thorium Docs](https://github.com/Thorium-Sim/thorium-docs) repo. (Include the issue or pull request url below.)