### PR TITLE
Removes padding from ul in credits scroll

### DIFF
--- a/client/src/components/client/credits.js
+++ b/client/src/components/client/credits.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import { Container, Button } from "reactstrap";
+import './credits.scss';
 
 const creditList = [
   {
@@ -33,7 +34,7 @@ const creditList = [
   {
     header: "Code Contributors",
     content: (
-      <ul style={{ listStyle: "none" }}>
+      <ul>
         <li>
           <code>G33kX</code>
         </li>
@@ -61,7 +62,7 @@ const creditList = [
   {
     header: "Bug Reports & Feature Suggestions",
     content: (
-      <ul style={{ listStyle: "none" }}>
+      <ul>
         <li>Ryan Anderson</li>
         <li>Alex DeBirk</li>
         <li>James Porter</li>
@@ -82,7 +83,7 @@ const creditList = [
   {
     header: "Donors",
     content: (
-      <ul style={{ listStyle: "none" }}>
+      <ul>
         <li>
           Thomas Delclite{" "}
           <span role="img" aria-label="donor-tag">

--- a/client/src/components/client/credits.scss
+++ b/client/src/components/client/credits.scss
@@ -1,0 +1,4 @@
+.creditSection ul {
+  list-style: none;
+  padding: 0;
+}


### PR DESCRIPTION
## Description
- Moves credit styles into its own stylesheet
- Sets `padding: 0` so that credit sections within a `<ul>` are centered

## Related Issue
#1495 

![image](https://user-images.githubusercontent.com/6345617/47864984-a1a1e080-ddc0-11e8-9084-7631e69745bb.png)
