### PR TITLE
Shortened hide delay for Widget tooltips

### DIFF
--- a/client/src/components/layouts/LayoutCorners/Widgets.js
+++ b/client/src/components/layouts/LayoutCorners/Widgets.js
@@ -200,6 +200,7 @@ export class Widget extends Component {
             isOpen={this.state.tooltipOpen}
             target={`widget-${wkey}`}
             toggle={this.toggle}
+            delay={{ show: 0, hide: 20 }}
           >
             {widget.name}
           </Tooltip>


### PR DESCRIPTION
## Description
Shortens the delay time for Widget tooltips from the default 250 ms to 20 ms, preventing more than one tooltip from being displayed at a time

## Related Issue
None

- [ ] I submitted a pull request or created an issue for documenting this feature on the [Thorium Docs](https://github.com/Thorium-Sim/thorium-docs) repo. (Include the issue or pull request url below.)