### PR TITLE
Shuttlebay ui improvements

### DIFF
--- a/client/src/components/views/Shuttles/core.js
+++ b/client/src/components/views/Shuttles/core.js
@@ -18,6 +18,7 @@ const SHUTTLE_SUB = gql`
       damage {
         damaged
       }
+      direction
     }
   }
 `;
@@ -65,6 +66,7 @@ class Shuttles extends Component {
               <th title="Compress">Co</th>
               <th title="Doors">Do</th>
               <th title="Present">Pr</th>
+              <th title="Direction">Dir</th>
               <th>Image</th>
             </tr>
           </thead>
@@ -140,6 +142,19 @@ class Shuttles extends Component {
                 <td>
                   <select
                     style={{ height: "18px" }}
+                    value={d.direction}
+                    onChange={evt =>
+                      this.updateShuttle(d.id, "direction", evt.target.value)
+                    }
+                  >
+                    <option value='unspecified'>Unspecified</option>
+                    <option value='arriving'>Arriving</option>
+                    <option value='departing'>Departing</option>
+                  </select>
+                </td>
+                <td>
+                  <select
+                    style={{ height: "18px" }}
                     value={d.image}
                     onChange={evt =>
                       this.updateShuttle(d.id, "image", evt.target.value)
@@ -176,6 +191,7 @@ const SHUTTLE_QUERY = gql`
       damage {
         damaged
       }
+      direction
     }
     assetFolders(names: $names) {
       id

--- a/client/src/components/views/Shuttles/index.js
+++ b/client/src/components/views/Shuttles/index.js
@@ -152,24 +152,34 @@ class ShuttleBay extends Component {
     const { animating } = this.state;
 
     let hint = '';
-    if(!animating) {
-      if(direction === 'departing') {
-        if(clamps) hint = 'clamps';
-        else if(compress) hint = 'compress';
-        else if(doors) hint = 'doors';
-      }
-      else if (direction === 'arriving' && !docked) {
-        if(clamps) hint = 'clamps';
-        else if(compress) hint = 'compress';
-        else if(doors) hint = 'doors';
-      }
-      else if (direction === 'arriving' && docked) {
-        if(!doors) hint = 'doors';
-        else if(!compress) hint = 'compress';
-        else if(!clamps) hint = 'clamps';
-      }
+    let shuttleStatusMsg = '';
+    if(direction === 'departing' && docked) {
+      shuttleStatusMsg = 'Preparing shuttle for departure.';
+      if(clamps) hint = 'clamps';
+      else if(compress) hint = 'compress';
+      else if(doors) hint = 'doors';
+      else shuttleStatusMsg = 'Shuttle is departing.';
     }
-    // Also add close out procedure after a shuttle has departed?
+    else if (direction === 'departing' && !docked) {
+      // No hints in this case, we don't particularly care what the
+      // crew does with the shuttle bay once the shuttle has left.
+      shuttleStatusMsg = 'Shuttle has departed.';
+    }
+    else if (direction === 'arriving' && !docked) {
+      shuttleStatusMsg = 'Shuttle approaching. Prepare for arrival.';
+      if(clamps) hint = 'clamps';
+      else if(compress) hint = 'compress';
+      else if(doors) hint = 'doors';
+      else shuttleStatusMsg = 'The shuttle is entering the bay.';
+    }
+    else if (direction === 'arriving' && docked) {
+      shuttleStatusMsg = 'Shuttle has arrived. Please secure shuttle.';
+      if(!doors) hint = 'doors';
+      else if(!compress) hint = 'compress';
+      else if(!clamps) hint = 'clamps';
+      else shuttleStatusMsg = 'Shuttle secured.';
+    }
+    if(animating) hint = '';
 
     return (
       <Card>
@@ -243,6 +253,9 @@ class ShuttleBay extends Component {
                   {doors ? "Open" : "Close"} Doors
                 </Button>
                 <div className={`docking-hint ${hint !== 'doors' ? 'hidden' : ''}`}/>
+              </div>
+              <div className='docking-status-message'>
+                { shuttleStatusMsg }
               </div>
             </Col>
             <Col sm={5}>

--- a/client/src/components/views/Shuttles/index.js
+++ b/client/src/components/views/Shuttles/index.js
@@ -140,33 +140,48 @@ class ShuttleBay extends Component {
           <h3 className="text-center">{name}</h3>
           <Row>
             <Col sm={6}>
-              <Button
-                block
-                className="clamps-button"
-                disabled={!!animating}
-                color="primary"
-                onClick={() => this.toggleShuttle(id, "clamps")}
-              >
-                {clamps ? "Detach" : "Attach"} Clamps
-              </Button>
-              <Button
-                block
-                disabled={!!animating || !doors}
-                color="primary"
-                className="compress-button"
-                onClick={() => this.toggleShuttle(id, "compress")}
-              >
-                {compress ? "Decompress" : "Compress"} Bay
-              </Button>
-              <Button
-                block
-                disabled={!!animating || compress}
-                color="primary"
-                className="doors-button"
-                onClick={() => this.toggleShuttle(id, "doors")}
-              >
-                {doors ? "Open" : "Close"} Doors
-              </Button>
+              <div className='docking-icon-wrapper'>
+                <div className='docking-icon'>
+                  <Clamps transform={clamps}/>
+                </div>
+                <Button
+                  block
+                  className="clamps-button"
+                  disabled={!!animating}
+                  color="primary"
+                  onClick={() => this.toggleShuttle(id, "clamps")}
+                  >
+                  {clamps ? "Detach" : "Attach"} Clamps
+                </Button>
+              </div>
+              <div className='docking-icon-wrapper'>
+                <div className='docking-icon'>
+                  <Decompress on={compress} />
+                </div>              
+                <Button
+                  block
+                  disabled={!!animating || !doors}
+                  color="primary"
+                  className="compress-button"
+                  onClick={() => this.toggleShuttle(id, "compress")}
+                >
+                  {compress ? "Decompress" : "Compress"}
+                </Button>
+              </div>
+              <div className='docking-icon-wrapper'>
+                <div className='docking-icon'>
+                  <Door open={!doors} number={"0" + (i + 1)} />
+                </div>
+                <Button
+                  block
+                  disabled={!!animating || compress}
+                  color="primary"
+                  className="doors-button"
+                  onClick={() => this.toggleShuttle(id, "doors")}
+                >
+                  {doors ? "Open" : "Close"} Doors
+                </Button>
+              </div>
             </Col>
             <Col sm={6}>
               {animating === "clamps" && <Clamps transform={clamps} />}
@@ -193,7 +208,7 @@ class ShuttleBay extends Component {
                   style={{ display: !animating ? "flex" : "none" }}
                   className="shuttle"
                 >
-                  <h2>No Shuttle</h2>
+                  <h2>Shuttlebay Empty</h2>
                   <div className="spacer" />
                 </div>
               )}

--- a/client/src/components/views/Shuttles/index.js
+++ b/client/src/components/views/Shuttles/index.js
@@ -36,9 +36,14 @@ const trainingSteps = [
       "Shuttles are small ships which can be stored inside of your ship. Most shuttles are piloted and can transport large amounts of supplies or personnel great distances."
   },
   {
+    selector: ".departure-button",
+    content:
+      "To use a shuttle, first click \"Prepare for departure\" to begin the departure sequence."
+  },
+  {
     selector: ".clamps-button",
     content:
-      "To undock a shuttle, you must first release the docking clamps which hold the shuttle in place with this button."
+      "You must then release the docking clamps which hold the shuttle in place. This button shows whether the clamps are attached or detached."
   },
   {
     selector: ".compress-button",
@@ -256,7 +261,7 @@ class ShuttleBay extends Component {
                   color="primary"
                   onClick={() => this.toggleShuttle(id, "clamps")}
                   >
-                  {clamps ? "Detach" : "Attach"} Clamps
+                  Clamps {clamps ? "attached" : "detached"}
                 </Button>
               </div>
               <div className='docking-icon-wrapper'>
@@ -271,7 +276,7 @@ class ShuttleBay extends Component {
                   className="compress-button"
                   onClick={() => this.toggleShuttle(id, "compress")}
                 >
-                  {compress ? "Decompress" : "Compress"}
+                  {compress ? "Compressed" : "Decompressed"}
                 </Button>
               </div>
               <div className='docking-icon-wrapper'>
@@ -285,7 +290,7 @@ class ShuttleBay extends Component {
                   className="doors-button"
                   onClick={() => this.toggleShuttle(id, "doors")}
                 >
-                  {doors ? "Open" : "Close"} Doors
+                  Doors {doors ? "closed" : "open"}
                 </Button>
               </div>
               <div className='docking-status-message'>

--- a/client/src/components/views/Shuttles/index.js
+++ b/client/src/components/views/Shuttles/index.js
@@ -151,35 +151,71 @@ class ShuttleBay extends Component {
     } = this.props;
     const { animating } = this.state;
 
-    let hint = '';
+    let hint = { clamps: '', compress: '', doors: '' };
+
     let shuttleStatusMsg = '';
     if(direction === 'departing' && docked) {
       shuttleStatusMsg = 'Preparing shuttle for departure.';
-      if(clamps) hint = 'clamps';
-      else if(compress) hint = 'compress';
-      else if(doors) hint = 'doors';
+      
+      if(!clamps) hint.clamps = 'ok';
+      if(!compress) hint.compress = 'ok';
+      if(!doors) hint.doors = 'ok';
+
+      if(clamps) hint.clamps = 'attention';
+      else if(compress) hint.compress = 'attention';
+      else if(doors) hint.doors = 'attention';
       else shuttleStatusMsg = 'Shuttle is departing.';
     }
     else if (direction === 'departing' && !docked) {
-      // No hints in this case, we don't particularly care what the
-      // crew does with the shuttle bay once the shuttle has left.
-      shuttleStatusMsg = 'Shuttle has departed.';
+      shuttleStatusMsg = 'Shuttle has departed. Secure shuttle bay.';
+
+      if(!clamps) hint.clamps = 'ok';
+      if(compress) hint.compress = 'ok';
+      if(doors) hint.doors = 'ok';
+      
+      if(!doors) hint.doors = 'attention';
+      else if(!compress) hint.compress = 'attention';
+      else shuttleStatusMsg = 'Shuttle bay secured.';
     }
     else if (direction === 'arriving' && !docked) {
       shuttleStatusMsg = 'Shuttle approaching. Prepare for arrival.';
-      if(clamps) hint = 'clamps';
-      else if(compress) hint = 'compress';
-      else if(doors) hint = 'doors';
-      else shuttleStatusMsg = 'The shuttle is entering the bay.';
+
+      if(!clamps) hint.clamps = 'ok';
+      if(!compress) hint.compress = 'ok';
+      if(!doors) hint.doors = 'ok';
+
+      if(clamps) hint.clamps = 'attention';
+      else if(compress) hint.compress = 'attention';
+      else if(doors) hint.doors = 'attention';
+      else shuttleStatusMsg = 'The shuttle is entering the bay. Please wait.';
     }
     else if (direction === 'arriving' && docked) {
       shuttleStatusMsg = 'Shuttle has arrived. Please secure shuttle.';
-      if(!doors) hint = 'doors';
-      else if(!compress) hint = 'compress';
-      else if(!clamps) hint = 'clamps';
+
+      if(clamps) hint.clamps = 'ok';
+      if(compress) hint.compress = 'ok';
+      if(doors) hint.doors = 'ok';
+
+      if(!doors) hint.doors = 'attention';
+      else if(!compress) hint.compress = 'attention';
+      else if(!clamps) hint.clamps = 'attention';
       else shuttleStatusMsg = 'Shuttle secured.';
     }
-    if(animating) hint = '';
+    else if (!docked) {
+      if(!clamps) hint.clamps = 'ok';
+      if(compress) hint.compress = 'ok';
+      if(doors) hint.doors = 'ok';
+    }
+    else if (docked) {
+      if(clamps) hint.clamps = 'ok';
+      if(compress) hint.compress = 'ok';
+      if(doors) hint.doors = 'ok';
+    }
+
+    var hintStrings = {
+      'ok': '\u2713',
+      'attention': '\u2794'
+    };
 
     return (
       <Card>
@@ -210,23 +246,23 @@ class ShuttleBay extends Component {
               </Button>
               }
               <div className='docking-icon-wrapper'>
-                <div className='docking-icon'>
-                  <Clamps transform={clamps}/>
+                <div className={`docking-icon ${hint.clamps}`}>
+                  { hintStrings[hint.clamps] }
                 </div>
                 <Button
                   block
                   className="clamps-button"
-                  disabled={!!animating}
+                  disabled={!!animating || !docked}
                   color="primary"
                   onClick={() => this.toggleShuttle(id, "clamps")}
                   >
                   {clamps ? "Detach" : "Attach"} Clamps
                 </Button>
-                <div className={`docking-hint ${hint !== 'clamps' ? 'hidden' : ''}`}/>
               </div>
               <div className='docking-icon-wrapper'>
-                <div className='docking-icon'>
-                  <Decompress on={compress} />
+                <div className={`docking-icon ${hint.compress}`}>
+                  { hintStrings[hint.compress] }
+             
                 </div>              
                 <Button
                   block
@@ -237,11 +273,10 @@ class ShuttleBay extends Component {
                 >
                   {compress ? "Decompress" : "Compress"}
                 </Button>
-                <div className={`docking-hint ${hint !== 'compress' ? 'hidden' : ''}`}/>
               </div>
               <div className='docking-icon-wrapper'>
-                <div className='docking-icon'>
-                  <Door open={!doors} number={"0" + (i + 1)} />
+              <div className={`docking-icon ${hint.doors}`}>
+                  { hintStrings[hint.doors] }             
                 </div>
                 <Button
                   block
@@ -252,7 +287,6 @@ class ShuttleBay extends Component {
                 >
                   {doors ? "Open" : "Close"} Doors
                 </Button>
-                <div className={`docking-hint ${hint !== 'doors' ? 'hidden' : ''}`}/>
               </div>
               <div className='docking-status-message'>
                 { shuttleStatusMsg }

--- a/client/src/components/views/Shuttles/style.scss
+++ b/client/src/components/views/Shuttles/style.scss
@@ -24,12 +24,26 @@
     background-repeat: no-repeat;
     h2 {
       align-self: center;
+      text-align: center;
     }
   }
   .docking-graphic {
     width: 100%;
     height: 100%;
     margin-bottom: 100%;
+  }
+  .docking-icon-wrapper {
+    display: flex;
+    align-items: center;
+    .btn {
+      flex-grow: 1;
+    }
+  }
+  .docking-icon {
+    width: 32px;
+    height: 32px;
+    margin-right: 15px;
+    flex-shrink: 0 
   }
   .door {
     background-color: #222;

--- a/client/src/components/views/Shuttles/style.scss
+++ b/client/src/components/views/Shuttles/style.scss
@@ -40,24 +40,21 @@
     }
   }
   .docking-icon {
-    width: 32px;
-    height: 32px;
-    margin-right: 15px;
-    flex-shrink: 0 
-  }
-  .docking-hint {
     width: 12px;
-    height: 12px;
-    border-bottom:solid white 3px;
-    border-left:solid white 3px;
-    flex: 0 0 auto;
-    animation-name: docking-hint-animation;
+    margin-right: 15px;
+    flex-shrink: 0;
+    font-size: 1.5em;
+    font-weight: bold;
+  }
+  .docking-icon.ok {
+    color: #0f0;
+  }
+  .docking-icon.attention {
+    color: #ff0;
+    animation-name: docking-icon-attention-animation;
     animation-duration: 1s;
     animation-iteration-count: infinite;
-    animation-timing-function: linear;
-  }
-  .docking-hint.hidden {
-    visibility: hidden;
+    animation-timing-function: ease-in-out;
   }
   .docking-status-message {
     margin-top: 4px;
@@ -86,18 +83,11 @@
     }
   }
 }
-
-@keyframes docking-hint-animation {
+@keyframes docking-icon-attention-animation {
   from {
-    transform: translate(15px, 0) scale(1, 0.8) rotate(45deg);
-    opacity: 1;    
-  }
-  50% {
-    transform: translate(5px, 0) scale(1, 0.8) rotate(45deg);
-    opacity: 1;    
+    transform: translate(-15px, 0);
   }
   to {
-    transform: translate(-5px, 0) scale(1, 0.8) rotate(45deg);
-    opacity: 0;    
+    transform: translate(0px, 0);
   }
 }

--- a/client/src/components/views/Shuttles/style.scss
+++ b/client/src/components/views/Shuttles/style.scss
@@ -45,6 +45,19 @@
     margin-right: 15px;
     flex-shrink: 0 
   }
+  .docking-hint {
+    width: 12px;
+    height: 12px;
+    border-bottom:solid white 3px;
+    border-left:solid white 3px;
+    flex: 0 0 auto;
+    animation-name: docking-hint-animation;
+    animation-duration: 1s;
+    animation-iteration-count: infinite;
+  }
+  .docking-hint.hidden {
+    visibility: hidden;
+  }
   .door {
     background-color: #222;
     border: solid 2px white;
@@ -67,5 +80,16 @@
       padding: 4px;
       border: solid 2px white;
     }
+  }
+}
+
+@keyframes docking-hint-animation {
+  from {
+    transform: translate(5px, 0) scale(1, 0.8) rotate(45deg);
+    opacity: 1;    
+  }
+  to {
+    transform: translate(-5px, 0) scale(1, 0.8) rotate(45deg);
+    opacity: 0;    
   }
 }

--- a/client/src/components/views/Shuttles/style.scss
+++ b/client/src/components/views/Shuttles/style.scss
@@ -54,9 +54,13 @@
     animation-name: docking-hint-animation;
     animation-duration: 1s;
     animation-iteration-count: infinite;
+    animation-timing-function: linear;
   }
   .docking-hint.hidden {
     visibility: hidden;
+  }
+  .docking-status-message {
+    margin-top: 4px;
   }
   .door {
     background-color: #222;
@@ -85,6 +89,10 @@
 
 @keyframes docking-hint-animation {
   from {
+    transform: translate(15px, 0) scale(1, 0.8) rotate(45deg);
+    opacity: 1;    
+  }
+  50% {
     transform: translate(5px, 0) scale(1, 0.8) rotate(45deg);
     opacity: 1;    
   }

--- a/server/src/classes/docking.js
+++ b/server/src/classes/docking.js
@@ -18,8 +18,9 @@ export default class DockingPort extends System {
       this.image = params.image || "/Docking Images/Default.png";
       this.docked = params.docked || false;
     }
+    this.direction = params.direction || 'unspecified';    // or 'arriving' or 'departing'
   }
-  updateDockingPort({ name, type, clamps, compress, doors, image, docked }) {
+  updateDockingPort({ name, type, clamps, compress, doors, image, docked, direction }) {
     if (name || name === "") {
       this.name = name;
     }
@@ -40,6 +41,9 @@ export default class DockingPort extends System {
     }
     if (docked || docked === false) {
       this.docked = docked;
+    }
+    if (direction) {
+      this.direction = direction;
     }
   }
 }

--- a/server/src/schema/types/docking.js
+++ b/server/src/schema/types/docking.js
@@ -9,7 +9,8 @@ type DockingPort {
   doors: Boolean
   image: String
   docked: Boolean
-  damage: Damage  
+  damage: Damage
+  direction: DOCKING_DIRECTION
 }
 
 input DockingPortInput {
@@ -22,10 +23,17 @@ input DockingPortInput {
   doors: Boolean
   image: String
   docked: Boolean
+  direction: DOCKING_DIRECTION
 }
 
 enum DOCKING_TYPES {
   shuttlebay
   dockingport
+}
+
+enum DOCKING_DIRECTION {
+  unspecified
+  arriving
+  departing
 }
 `;

--- a/server/tests/classes/docking.test.js
+++ b/server/tests/classes/docking.test.js
@@ -22,6 +22,7 @@ describe('DockingPort', () => {
       expect(dock.doors).toBe(true);
       expect(dock.image).toBe('/Docking Images/Default.png');
       expect(dock.docked).toBe(true);
+      expect(dock.direction).toBe('unspecified');
 
       const dock2 = new DockingPort({ type: 'not_a_shuttlebay' });
       expect(dock2.type).toBe('not_a_shuttlebay');
@@ -30,13 +31,14 @@ describe('DockingPort', () => {
       expect(dock2.doors).toBe(false);
       expect(dock2.image).toBe('/Docking Images/Default.png');
       expect(dock2.docked).toBe(false);
+      expect(dock2.direction).toBe('unspecified');
     });
   });
 
   describe('updateDockingPort', () => {
     test('should update a docking port', () => {
       const dock = new DockingPort();
-      dock.updateDockingPort({ name: 'Emergency Exit', type: 'screen_door', clamps: false, compress: false, doors: false, docked: false, image: '404_NOT_FOUND' });
+      dock.updateDockingPort({ name: 'Emergency Exit', type: 'screen_door', clamps: false, compress: false, doors: false, docked: false, image: '404_NOT_FOUND', direction: 'arriving' });
       expect(dock.name).toBe('Emergency Exit');
       expect(dock.type).toBe('screen_door');
       expect(dock.clamps).toBe(false);
@@ -44,6 +46,7 @@ describe('DockingPort', () => {
       expect(dock.doors).toBe(false);
       expect(dock.image).toBe('404_NOT_FOUND');
       expect(dock.docked).toBe(false);
+      expect(dock.direction).toBe('arriving');
     })
   })
 });


### PR DESCRIPTION
## Description
- Added a "docking direction" state that shows hints for the crew on what the next action should be.
- Green checkmarks are shown for clamps, compression, and doors that are in a "good" state according to the docking direction and whether the shuttle is present or not. Yellow animated arrows are shown for items that need the crew member's attention.
- After adding the checkmarks, I realized it would make more sense to change the wording on the buttons to reflect the current state, rather than the action that the button will perform. A checkmark next to an item indicates that the item is "good", or, that the state of the item is good, and therefore the text next to the checkmark should reflect the current state. If desired, we can add a tooltip indicating what the button will do if it is clicked. I realize this is a big change but I think it will be less confusing overall to the crew member. Clicking the button simply toggles the state. Or we could have a two-state button that slides back and forth--that's pretty common.
- Added a message below the buttons helping the crew member to know if the shuttle is arriving or departing.
- Added a training step for the new "prepare for departure" button.

## Related Issue
#1354 

## Screenshots (if appropriate):

Default view when shuttle is in the bay:

![image](https://user-images.githubusercontent.com/6345617/48328046-5dec7980-e5ff-11e8-922f-39742c88d645.png)

Crew member presses "Prepare for departure" and then, after decompressing the bay:

![image](https://user-images.githubusercontent.com/6345617/48328083-9724e980-e5ff-11e8-9b43-7104c7dbd155.png)

Crew member opens the doors, and flight director removes the shuttle from the bay:

![image](https://user-images.githubusercontent.com/6345617/48328189-3c3fc200-e600-11e8-961d-1c883115ed87.png)

Crew member closes the doors and compresses the bay. Later, flight director sets the docking direction to "arriving":

![image](https://user-images.githubusercontent.com/6345617/48328253-78732280-e600-11e8-9539-b4aa347e8487.png)

Crew member decompresses bay and opens doors, then flight director puts shuttle in bay:

![image](https://user-images.githubusercontent.com/6345617/48328397-f0d9e380-e600-11e8-902c-a51f96e9721a.png)

Crew member closes doors, compresses bay, and attaches clamps:

![image](https://user-images.githubusercontent.com/6345617/48328507-85dcdc80-e601-11e8-94dc-cb34815a921d.png)


- [ ] I submitted a pull request or created an issue for documenting this feature on the [Thorium Docs](https://github.com/Thorium-Sim/thorium-docs) repo. (Include the issue or pull request url below.)