### PR TITLE
Change to a relevant card when crew member clicks on a notification, 2nd try

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2854,11 +2854,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -2871,15 +2873,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -2982,7 +2987,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -2992,6 +2998,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -3004,6 +3011,7 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -3103,7 +3111,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -3113,6 +3122,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -3218,6 +3228,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -5654,11 +5665,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5675,7 +5688,8 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -5804,6 +5818,7 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }

--- a/client/src/components/client/Card.js
+++ b/client/src/components/client/Card.js
@@ -9,7 +9,6 @@ import TrainingPlayer from "helpers/trainingPlayer";
 import { subscribe } from "../../helpers/pubsub";
 import { Mutation } from "react-apollo";
 import gql from "graphql-tag";
-import { subscribe } from "../../helpers/pubsub";
 
 const Blackout = () => {
   return (

--- a/client/src/components/client/Card.js
+++ b/client/src/components/client/Card.js
@@ -8,6 +8,7 @@ import Reset from "./reset";
 import TrainingPlayer from "helpers/trainingPlayer";
 import { Mutation } from "react-apollo";
 import gql from "graphql-tag";
+import { subscribe } from "../../helpers/pubsub";
 
 const Blackout = () => {
   return (
@@ -139,6 +140,29 @@ export default class CardFrame extends Component {
         card: this.props.station.cards && this.props.station.cards[0].name
       };
     }
+  }
+  componentDidMount() {
+    this.cardChangeRequestSubscription =
+    subscribe("cardChangeRequest", payload => {
+      // Searching in order of priority, find a matching card by component (card
+      // names may have been changed to protect the innocent) then change to that card's name.
+      let found = false;
+      for(let i=0; i<payload.changeToCard.length; i++) {
+        let matchingCard = this.props.station.cards.find(c => c.component === payload.changeToCard[i]);
+        if(matchingCard) {
+          this.changeCard(matchingCard.name);
+          found = true;
+          break;
+        }
+      }
+      if(!found) {
+        // TODO: See if we can open a relevant widget instead
+      }
+    });
+  }
+  componentWillUnmount() {
+    // Unsubscribe
+    this.cardChangeRequestSubscription();
   }
   componentDidUpdate(prevProps) {
     if (prevProps.station.name !== this.props.station.name) {

--- a/client/src/components/generic/Alerts.js
+++ b/client/src/components/generic/Alerts.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import FontAwesome from "react-fontawesome";
 import gql from "graphql-tag";
 import { withApollo } from "react-apollo";
-import { subscribe } from "helpers/pubsub";
+import { subscribe, publish } from "helpers/pubsub";
 // Speech Handling
 const synth = window.speechSynthesis;
 const holderStyle = {
@@ -21,6 +21,7 @@ const NOTIFY_SUB = gql`
       type
       color
       duration
+      relevantCards
     }
   }
 `;
@@ -99,7 +100,7 @@ class Alerts extends Component {
       this.onDismiss(id);
     }, timeoutDuration);
   }
-  onDismiss = id => {
+  onDismiss = (id, changeToCard) => {
     const alerts = this.state.alerts;
     this.setState({
       alerts: alerts.map(a => {
@@ -112,6 +113,9 @@ class Alerts extends Component {
         alerts: this.state.alerts.filter(a => a.id !== id)
       });
     }, 2000);
+    if(changeToCard) {
+      publish("cardChangeRequest", { changeToCard });
+    }
   };
   render() {
     return <AlertsHolder alerts={this.state.alerts} dismiss={this.onDismiss} />;
@@ -128,7 +132,7 @@ export const AlertsHolder = ({ alerts, dismiss }) => (
 
 const AlertItem = ({ dismiss, notify }) => {
   return (
-    <div onClick={() => dismiss(notify.id)}>
+    <div onClick={() => dismiss(notify.id, notify.relevantCards)}>
       <div className={`alert alert-${notify.color}`}>
         <h5 className="alert-heading">
           {notify.title}{" "}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5126,12 +5126,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5146,17 +5148,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5273,7 +5278,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5285,6 +5291,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5299,6 +5306,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5410,7 +5418,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5422,6 +5431,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5543,6 +5553,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/server/src/events/internalComm.js
+++ b/server/src/events/internalComm.js
@@ -89,7 +89,8 @@ App.on("internalCommCallIncoming", ({ id, incoming }) => {
       station: s.name,
       title: `New Internal Call`,
       body: incoming,
-      color: "info"
+      color: "info",
+      relevantCards: [ "CommInternal" ]
     });
   });
 });

--- a/server/src/events/lrComm.js
+++ b/server/src/events/lrComm.js
@@ -46,7 +46,8 @@ App.on(
             station: s.name,
             title: `New Long Range Message Queued`,
             body: `Message composed by ${sender}`,
-            color: "info"
+            color: "info",
+            relevantCards: [ cardName ]
           });
         }
       });
@@ -63,7 +64,8 @@ App.on(
             station: s.name,
             title: `New Long Range Message`,
             body: `From ${sender}`,
-            color: "info"
+            color: "info",
+            relevantCards: [ "CommDecoding" ]
           });
         }
       });
@@ -133,7 +135,8 @@ App.on("approveLongRangeMessage", ({ id, message }) => {
       station: s.name,
       title: `New Long Range Message Queued`,
       body: `Message composed by ${messageObj.sender}`,
-      color: "info"
+      color: "info",
+      relevantCards: [ "LongRangeComm" ]
     });
   });
 });

--- a/server/src/events/probes.js
+++ b/server/src/events/probes.js
@@ -141,7 +141,8 @@ App.on("probeProcessedData", ({ id, simulatorId, data = "", flash }) => {
       station: s.name,
       title: `New Processed Data`,
       body: data,
-      color: "info"
+      color: "info",
+      relevantCards: [ "ProbeNetwork" ]
     });
   });
   pubsub.publish("probesUpdate", App.systems.filter(s => s.type === "Probes"));

--- a/server/src/events/sensors.js
+++ b/server/src/events/sensors.js
@@ -69,7 +69,8 @@ App.on("sensorScanResult", ({ id, result }) => {
       station: s.name,
       title: `Sensor Scan Answered`,
       body: result,
-      color: "info"
+      color: "info",
+      relevantCards: system.domain === "external" ? [ "SensorScans", "Sensors" ] : [ "SecurityScans" ]
     });
   });
   pubsub.publish(
@@ -133,7 +134,8 @@ App.on(
         station: s.name,
         title: `New Processed Data`,
         body: data,
-        color: "info"
+        color: "info",
+        relevantCards: [ "Sensors", "JrSensors" ] 
       });
     });
   }

--- a/server/src/events/sickbay.js
+++ b/server/src/events/sickbay.js
@@ -223,7 +223,8 @@ App.on("completeDeconProgram", ({ id }) => {
           station: s,
           title: `Decon Program Complete`,
           body: `${sys.deconProgram}: ${sys.deconLocation}`,
-          color: "success"
+          color: "success",
+          relevantCards: [ "Decontamination" ]
         });
       });
     sys.endDeconProgram();

--- a/server/src/events/systems.js
+++ b/server/src/events/systems.js
@@ -339,7 +339,8 @@ App.on("setDamageStepValidation", ({ id, validation }) => {
         station: s,
         title: `Damage report step validation rejected`,
         body: sys.name,
-        color: "danger"
+        color: "danger",
+        relevantCards: [ "DamageControl" ]
       })
     );
   } else {
@@ -388,7 +389,8 @@ App.on("validateDamageStep", ({ id }) => {
       station: s,
       title: `Damage report step validation accepted`,
       body: sys.name,
-      color: "success"
+      color: "success",
+      relevantCards: [ "DamageControl" ]
     })
   );
   sendUpdate(sys);

--- a/server/src/schema/types/flightStructure.js
+++ b/server/src/schema/types/flightStructure.js
@@ -165,5 +165,6 @@ type Notification {
   type: String
   trigger: String
   duration: Int
+  relevantCards: [String]
 }
 `;


### PR DESCRIPTION
## Description
Second try (see #1567)

- Added a `relevantCards` property to the `Notification` type, which is an array of strings indicating the component name of the card or cards that would be relevant to the notification, in order of preference.
- Changed `Alerts.js` so that when a user clicks on a notification, a `cardChangeRequest` for the relevant cards is published.
- Changed `Cards.js` to subscribe to `cardChangeRequest`. When a request is received, it finds a matching card on the station and changes to it.
- Added relevant cards for sensor scan results, internal comms, long range comms, comm decoding, probe data, decontamination program, and damage control.

## Additional work needed

Not ready to merge yet. Work is still in progress. Just looking for feedback to see if this is going in the right direction. If so, here is what's left to be done:

- [ ] Add support for opening relevant widgets as well
- [x] Add relevant cards (or widgets) for all other kinds of notifications
- [ ] Training or some other visual cue that you can click on a notification to switch cards

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#1559


- [ ] I submitted a pull request or created an issue for documenting this feature on the [Thorium Docs](https://github.com/Thorium-Sim/thorium-docs) repo. (Include the issue or pull request url below.)