### PR TITLE
Fixed bug causing transporter charge speed to be unchangeable on core

### DIFF
--- a/client/src/components/views/Transporters/core.js
+++ b/client/src/components/views/Transporters/core.js
@@ -117,7 +117,7 @@ class TransporterCore extends Component {
                     action({
                       variables: {
                         id: transporter.id,
-                        chargeSpeed: e.target.value
+                        chargeSpeed: parseFloat(e.target.value)
                       }
                     })
                   }


### PR DESCRIPTION
## Description
Fixed issue where the charge speed of transporters couldn't be changed on TransporterCore. 