### PR TITLE
Adjustments to ship not in range scanning preset

### DIFF
--- a/client/src/components/views/Sensors/ScanPresets.js
+++ b/client/src/components/views/Sensors/ScanPresets.js
@@ -41,8 +41,8 @@ export default which =>
       value: "Unable to complete scan.  No probe has been launched."
     },
     {
-      label: "Not in range",
-      value: "Unable to complete scan. USS ***** is not within range."
+      label: "Ship not in range",
+      value: "Unable to complete scan. Ship is not within range."
     },
     {
       label: "Radiation from nebula",


### PR DESCRIPTION
## Description
Changed "Not in range" scanning preset to "Ship not in range" do differentiate between that answer and the "None in range". 
Made adjustment to the answer being "Ship is not in scanning range" replacing "USS **** is not in scanning range" for ease of use in changing the name of the ship, and more generic for both quick use, and use in simulators not within the Star Trek universe where the "USS" prefix is not used. 

## Related Issue
https://github.com/Thorium-Sim/thorium/issues/2074