### PR TITLE
Corrected wording of removing a trigger macro.

### DIFF
--- a/server/src/typeDefs/trigger.js
+++ b/server/src/typeDefs/trigger.js
@@ -34,7 +34,7 @@ const schema = gql`
     addTriggerToSimulator(simulatorId: ID!, trigger: ID!): String
 
     """
-    Macro: Triggers: Remove trigger to simulator
+    Macro: Triggers: Remove trigger from simulator
     """
     removeTriggerFromSimulator(simulatorId: ID!, trigger: ID!): String
   }


### PR DESCRIPTION
## Description
changed 
"Remove trigger to simulator"
to "Remove trigger from simulator" when selecting the macro on core. 


Closes #2191