### PR TITLE
Stop overriding style of alerted chat messages

### DIFF
--- a/src/containers/config.scss
+++ b/src/containers/config.scss
@@ -19,7 +19,7 @@
     .list-group {
       background: transparent;
     }
-    .list-group-item {
+    .list-group-item:not(.alerted) {
       background-color: rgba(0, 0, 0, 0.8);
     }
     .list-group-item.selected,


### PR DESCRIPTION
## Description

This file was overriding the Messaging Core's ability to change color based on how long the message had been left unread. Once the keyframe animation completed, the message would switch back to the black color instead of staying red. This fix sets all `.list-group-items` to the black color _unless_ they have the `.alerted` class, which stops the color from being overriden.

The issue also mentions that only the topmost message would change color, but I was unable to reproduce that bug.

## Related Issue

https://github.com/Thorium-Sim/thorium/issues/3137
