### PR TITLE
Add missing functionality for StopAllSounds and StopLoopingSounds macros

### DIFF
--- a/server/events/clients.ts
+++ b/server/events/clients.ts
@@ -319,12 +319,20 @@ App.on(
   },
 );
 App.on("stopAllSounds", ({simulatorId, station}) => {
+  // If Random Station is selected, pick a random station from the list of available stations
+  if (station === "random") {
+    station = App.clients[Math.floor(Math.random() * App.clients.length)].station;
+  }
   const clients = App.clients.filter(s => {
     if (s.simulatorId !== simulatorId) return false;
     if (station) {
+      // If the currently iterated station matches the requested station, return true to stop the sound on that station.
+      // If All Sound Players is selected, and the selected station has a sound player, return true.
+      // If All Stations is selected, return true.
       if (
         s.station === station ||
         s.id === station ||
+        station === "all" ||
         (station === "Sound" && s.soundPlayer)
       )
         return true;
@@ -341,10 +349,23 @@ App.on("stopAllSounds", ({simulatorId, station}) => {
   pubsub.publish("cancelAllSounds", clients);
 });
 App.on("cancelLoopingSounds", ({simulatorId, station}) => {
+  // If Random Station is selected, pick a random station from the list of available stations
+  if (station === "random") {
+    station = App.clients[Math.floor(Math.random() * App.clients.length)].station;
+  }
   const clients = App.clients.filter(s => {
     if (s.simulatorId !== simulatorId) return false;
     if (station) {
-      if (s.station === station || s.id === station) return true;
+      // If the currently iterated station matches the requested station, return true to stop the sound on that station.
+      // If All Sound Players is selected, and the selected station has a sound player, return true.
+      // If All Stations is selected, return true.
+      if (
+        s.station === station ||
+        s.id === station ||
+        station === "all" ||
+        (station === "Sound" && s.soundPlayer)
+      )
+        return true;
       return false;
     }
     return true;


### PR DESCRIPTION
## Description

The StopLoopingSounds macro for the Thorium keyboard was missing functionality. The "Sound Player," "All Stations," and "Random Station" options had no functionality behind them, and sounds would only stop looping if the station was explicitly selected. This was possible in the Macros Core, but not with the keyboard because you can't select a station or client outside of a flight.

This fix adds the required functionality so that those options work. When the macro is set to All Stations, all stations will stop looping their sounds. When it's set to Sound Players, all stations with sound players will stop. When it's set to Random Station, a random active station will have any looping sounds stopped.

The functionality for the "All Stations" and "Random Station" logic was missing from the StopAllSounds macro as well, so I added it. The "Sound Player" option had already been coded. The selection logic should now be identical and functional for both.

## Related Issue

https://github.com/Thorium-Sim/thorium/issues/3165
