### PR TITLE
Temporary fix to stop the Torpedo Core from crashing

### DIFF
--- a/src/components/views/TorpedoLoading/core.js
+++ b/src/components/views/TorpedoLoading/core.js
@@ -32,7 +32,7 @@ const TorpedoView = ({torpedo}) => {
           if (torpedo.state === "idle") return "No Torpedos Loaded";
 
           return `${capitalCase(
-            loaded ? loaded.type : lastLoaded && lastLoaded.type,
+            loaded ? loaded.type : (lastLoaded ? lastLoaded.type : ""),
           )} Torpedo ${torpedo.state === "loaded" ? "Loaded" : "Fired"}`;
         })()}
       </OutputField>


### PR DESCRIPTION
## Description

Fixing the problem as a whole was taking me longer than expected, so I wanted to submit a temporary fix to stop the core from crashing while I work on fully resolving the issue.

The reason the torpedo core crashes is because the `capitalCase` method does not support undefined values. In the Torpedo core, you can select which launcher you want to view. If a player fires the selected launcher, then fires a different one while the launcher is still in the "fired" state, the values of `loaded` and `lastLoaded` will both be undefined causing the core to crash and have to be reloaded. The problem _might_ be that firing a torpedo from any launcher forces them all to update, so `lastLoaded` becomes undefined, but I haven't had a chance to test this yet.

This temporary fix makes it so that if they are both undefined, it will send an empty string to the method. This stops the core from crashing but it is still not perfect. When two launchers are fired quickly, the core will just say "Torpedo Fired" without saying what type. But it should work for now until I can get to the root of the problem.

## Related Issue

https://github.com/Thorium-Sim/thorium/issues/3179