### PR TITLE
Stop passing nonexistent parameter to defaultValue

### DIFF
--- a/src/components/macros/documentAdd.tsx
+++ b/src/components/macros/documentAdd.tsx
@@ -33,7 +33,7 @@ const DocumentAdd: React.FC<PrintPDFProps> = props => {
       <Label>Name</Label>
       <Input
         type="text"
-        defaultValue={args.data}
+        defaultValue={args.name}
         onBlur={evt => updateArgs("name", evt.target.value)}
       />
       <p>Print PDF</p>


### PR DESCRIPTION
## Description

I was working on fixing issue #3194 and noticed a small problem with the macro creation screen, specifically with the Add Document action. When you exit out of the menu and go back in, you can't see what name you put in for the document. This is because the data being passed into the `defaultValue` prop of the input field is incorrect. The document name is stored under `args.name`, not `args.data`. Now, if you exit the editing screen and return, you should see the document name as you entered it.
## Related Issue

https://github.com/Thorium-Sim/thorium/issues/3194
