### PR TITLE
Fix duplicate task problem

### DIFF
--- a/src/components/views/Tasks/core/ValueInput.js
+++ b/src/components/views/Tasks/core/ValueInput.js
@@ -9,6 +9,7 @@ import InventoryInput from "./inputs/InventoryInput";
 
 const ValueInput = ({
   label,
+  taskId = "",
   type,
   placeholder = "",
   value,
@@ -26,6 +27,7 @@ const ValueInput = ({
               <Input
                 type="text"
                 placeholder={placeholder || definitionValue}
+                key={taskId}
                 defaultValue={value}
                 onBlur={e => onBlur(e.target.value)}
               />
@@ -39,6 +41,7 @@ const ValueInput = ({
                 type="textarea"
                 rows={3}
                 placeholder={placeholder || definitionValue}
+                key={taskId}
                 defaultValue={value}
                 onBlur={e => onBlur(e.target.value)}
               />

--- a/src/containers/FlightDirector/TaskTemplates/flowTaskConfig.tsx
+++ b/src/containers/FlightDirector/TaskTemplates/flowTaskConfig.tsx
@@ -80,6 +80,7 @@ const FlowTaskConfig = () => {
         <ValueInput
           key={v}
           label={v}
+          taskId={id}
           type={definition.valuesInput[v]}
           value={task.values?.[v]}
           definitionValue={definition.valuesValue[v]}


### PR DESCRIPTION
## Description

The issue states that, when editing a task with a certain definition, any sibling tasks with that definition would also be updated. It appears this way but it is not the case. The tasks were being updated correctly, but when clicking on their siblings, the input boxes for the values would not update until you leave the window or click on a task of a different type. So it looked like your changes were applying to each task, but in reality it was just a flaw with the textboxes.

The reason for this is because the task values were being put into the input fields via the `defaultValue` property, which only updates upon initial loading. State changes do not affect it for whatever reason.

The solution was to change the `key` property of the input field, as that forces the component to update. I decided to use the task's ID as a key because it's certain to be unique for each task.

## Related Issue

https://github.com/Thorium-Sim/thorium/issues/3197

## Screenshots (if appropriate):

- [ ] I submitted a pull request or created an issue for documenting this
      feature on the [Thorium Docs](https://github.com/Thorium-Sim/thorium-docs)
      repo. (Include the issue or pull request url below.)
