### PR TITLE
Reorganize macro buttons

### DIFF
--- a/server/classes/macro.js
+++ b/server/classes/macro.js
@@ -10,7 +10,7 @@ function move(array, old_index, new_index) {
       array.push(undefined); // put a null value at that point in the array
     }
   }
-  array.splice(new_index, 0, array.splice(old_index, 1)[0]); // remove the item at the old index and put it in the new index
+  array.splice(new_index, 0, array.splice(old_index, 1)[0]); // remove the item at the old index and replace it at the new index
   return array; // for testing purposes
 }
 
@@ -90,5 +90,9 @@ export class MacroButtonConfig {
   }
   getButton(id) {
     return this.buttons.find(b => b.id === id);
+  }
+  // For reordering macro buttons
+  reorderButton(oldIndex, newIndex) {
+    this.buttons = move(this.buttons, oldIndex, newIndex);
   }
 }

--- a/server/classes/macro.js
+++ b/server/classes/macro.js
@@ -1,5 +1,19 @@
 import uuid from "uuid";
 
+// from ./taskFlow.ts
+function move(array, old_index, new_index) {
+  if (new_index >= array.length) {
+    // if new spot is outside of the array
+    var k = new_index - array.length; // take the amount of new elements
+    while (k-- + 1) {
+      // and if that's greater than zero
+      array.push(undefined); // put a null value at that point in the array
+    }
+  }
+  array.splice(new_index, 0, array.splice(old_index, 1)[0]); // remove the item at the old index and put it in the new index
+  return array; // for testing purposes
+}
+
 class Action {
   constructor(params) {
     this.id = params.id || uuid.v4();
@@ -34,6 +48,10 @@ export default class Macro {
     const newAction = new Action({...action, id: undefined});
     this.actions.push(newAction);
     return newAction.id;
+  }
+  // For reordering macro button actions
+  reorderAction(oldIndex, newIndex) {
+    this.actions = move(this.actions, oldIndex, newIndex);
   }
 }
 

--- a/server/events/eventMacro.js
+++ b/server/events/eventMacro.js
@@ -114,7 +114,7 @@ App.on("triggerMacroButton", ({simulatorId, configId, buttonId}) => {
     App.handleEvent({simulatorId, macros}, "triggerMacros");
 });
 
-// Reorder Macro Action by Sam Hill
+// Reorder Macro Action
 App.on("reorderMacroAction", ({configId, id, oldIndex, newIndex}) => {
   performButtonAction(configId, macro =>
     macro.getButton(id).reorderAction(oldIndex, newIndex),

--- a/server/events/eventMacro.js
+++ b/server/events/eventMacro.js
@@ -114,6 +114,13 @@ App.on("triggerMacroButton", ({simulatorId, configId, buttonId}) => {
     App.handleEvent({simulatorId, macros}, "triggerMacros");
 });
 
+// Reorder Macro Button
+App.on("reorderMacroButton", ({configId, oldIndex, newIndex}) => {
+  performButtonAction(configId, macro =>
+    macro.reorderButton(oldIndex, newIndex),
+  );
+});
+
 // Reorder Macro Action
 App.on("reorderMacroAction", ({configId, id, oldIndex, newIndex}) => {
   performButtonAction(configId, macro =>

--- a/server/events/eventMacro.js
+++ b/server/events/eventMacro.js
@@ -113,3 +113,10 @@ App.on("triggerMacroButton", ({simulatorId, configId, buttonId}) => {
   if (macros.length > 0)
     App.handleEvent({simulatorId, macros}, "triggerMacros");
 });
+
+// Reorder Macro Action by Sam Hill
+App.on("reorderMacroAction", ({configId, id, oldIndex, newIndex}) => {
+  performButtonAction(configId, macro =>
+    macro.getButton(id).reorderAction(oldIndex, newIndex),
+  );
+});

--- a/server/typeDefs/macro.ts
+++ b/server/typeDefs/macro.ts
@@ -54,6 +54,7 @@ const schema = gql`
     """
     Reorder Macros
     """
+    reorderMacroButton(configId: ID!, oldIndex: Int!, newIndex: Int!): String
     reorderMacroAction(
       configId: ID!
       id: ID!

--- a/server/typeDefs/macro.ts
+++ b/server/typeDefs/macro.ts
@@ -51,6 +51,15 @@ const schema = gql`
       id: ID!
       actions: [ActionInput]
     ): String
+    """
+    Reorder Macros (by Sam Hill)
+    """
+    reorderMacroAction(
+      configId: ID!
+      id: ID!
+      oldIndex: Int!
+      newIndex: Int!
+    ): String
 
     triggerMacroButton(simulatorId: ID!, configId: ID!, buttonId: ID!): String
   }

--- a/server/typeDefs/macro.ts
+++ b/server/typeDefs/macro.ts
@@ -52,7 +52,7 @@ const schema = gql`
       actions: [ActionInput]
     ): String
     """
-    Reorder Macros (by Sam Hill)
+    Reorder Macros
     """
     reorderMacroAction(
       configId: ID!

--- a/src/components/client/credits.tsx
+++ b/src/components/client/credits.tsx
@@ -115,6 +115,9 @@ const creditList = [
         <li>
           <code>ericman314</code>
         </li>
+        <li>
+          <code>SoshJam</code>
+        </li>
       </ul>
     ),
   },

--- a/src/containers/FlightDirector/MacroButtons/macroConfig.js
+++ b/src/containers/FlightDirector/MacroButtons/macroConfig.js
@@ -1,3 +1,4 @@
+import {css} from "@emotion/core";
 import React, {Fragment} from "react";
 import {
   Container,
@@ -17,6 +18,9 @@ import uuid from "uuid";
 import {capitalCase} from "change-case";
 import {FaBan} from "react-icons/fa";
 import {ActionConfig} from "../Macros/macroConfig";
+import SortableActionList from "./sortableActionList";
+
+//import { useTaskFlowReorderStepMutation } from "generated/graphql";
 
 const colors = [
   "primary",
@@ -40,6 +44,8 @@ const ActionList = ({
   addAction,
   removeAction,
 }) => {
+  //const [reorder] = useTaskFlowReorderStepMutation();
+
   return (
     <Fragment>
       <h3>Actions</h3>
@@ -123,6 +129,35 @@ const ActionList = ({
         className={"btn btn-sm btn-success"}
         handleChange={e => addAction(e.target.value)}
       />
+      {console.log(actions)}
+
+      {/* TESTING SORTABLE ACTION LIST */}
+      <br />
+      <SortableActionList
+        css={css`
+          flex: 1;
+          overflow-y: auto;
+        `}
+        distance={20}
+        actions={actions}
+        id={id}
+        selectedAction={selectedAction}
+        setSelectedAction={setSelectedAction}
+        removeAction={removeAction}
+      />
+      {/**/}
+
+      {/*
+      onSortEnd={({oldIndex, newIndex}) =>
+            reorder({
+              variables: {
+                id: id,
+                stepId: selectedAction,
+                order: newIndex,
+              },
+            })
+          }
+      */}
     </Fragment>
   );
 };

--- a/src/containers/FlightDirector/MacroButtons/macroConfig.js
+++ b/src/containers/FlightDirector/MacroButtons/macroConfig.js
@@ -106,7 +106,7 @@ const ActionList = ({
           )}
         </Mutation>
       </Label>
-      {/* SORTABLE ACTION LIST by Sam Hill */}
+      {/* SORTABLE ACTION LIST */}
       <Mutation
         mutation={gql`
           mutation ReorderActions(

--- a/src/containers/FlightDirector/MacroButtons/macroConfig.js
+++ b/src/containers/FlightDirector/MacroButtons/macroConfig.js
@@ -19,6 +19,7 @@ import {capitalCase} from "change-case";
 import {FaBan} from "react-icons/fa";
 import {ActionConfig} from "../Macros/macroConfig";
 import SortableActionList from "./sortableActionList";
+import SortableButtonList from "./sortableMacroButtonList";
 
 const colors = [
   "primary",
@@ -201,6 +202,7 @@ const MacroConfig = ({macros}) => {
               </ListGroupItem>
             ))}
           </ListGroup>
+
           <Mutation
             mutation={gql`
               mutation AddMacro($name: String!) {
@@ -294,6 +296,48 @@ const MacroConfig = ({macros}) => {
           {macro && (
             <>
               <h3>Buttons</h3>
+              {/* SORTABLE BUTTON LIST */}
+              <Mutation
+                mutation={gql`
+                  mutation ReorderButtons(
+                    $configId: ID!
+                    $oldIndex: Int!
+                    $newIndex: Int!
+                  ) {
+                    reorderMacroButton(
+                      configId: $configId
+                      oldIndex: $oldIndex
+                      newIndex: $newIndex
+                    )
+                  }
+                `}
+              >
+                {action => (
+                  <SortableButtonList
+                    css={css`
+                      flex: 1;
+                      overflow-y: auto;
+                    `}
+                    distance={20}
+                    buttons={macro.buttons}
+                    selectedButton={selectedButton}
+                    setSelectedButton={setSelectedButton}
+                    onSortEnd={({oldIndex, newIndex}) => {
+                      let configId = macro.id;
+                      action({
+                        variables: {
+                          configId,
+                          selectedButton,
+                          oldIndex,
+                          newIndex,
+                        },
+                      });
+                    }}
+                  />
+                )}
+              </Mutation>
+
+              {/* OLD MACRO BUTTON LIST
               <ListGroup style={{maxHeight: "60vh", overflowY: "auto"}}>
                 {macro.buttons.map(m => (
                   <ListGroupItem
@@ -309,7 +353,7 @@ const MacroConfig = ({macros}) => {
                     <small>{m.category}</small>
                   </ListGroupItem>
                 ))}
-              </ListGroup>
+                  </ListGroup> */}
               <Mutation
                 mutation={gql`
                   mutation AddButton($configId: ID!, $name: String!) {

--- a/src/containers/FlightDirector/MacroButtons/macroConfig.js
+++ b/src/containers/FlightDirector/MacroButtons/macroConfig.js
@@ -20,8 +20,6 @@ import {FaBan} from "react-icons/fa";
 import {ActionConfig} from "../Macros/macroConfig";
 import SortableActionList from "./sortableActionList";
 
-//import { useTaskFlowReorderStepMutation } from "generated/graphql";
-
 const colors = [
   "primary",
   "secondary",
@@ -44,8 +42,6 @@ const ActionList = ({
   addAction,
   removeAction,
 }) => {
-  //const [reorder] = useTaskFlowReorderStepMutation();
-
   return (
     <Fragment>
       <h3>Actions</h3>
@@ -110,6 +106,46 @@ const ActionList = ({
           )}
         </Mutation>
       </Label>
+      {/* SORTABLE ACTION LIST by Sam Hill */}
+      <Mutation
+        mutation={gql`
+          mutation ReorderActions(
+            $configId: ID!
+            $id: ID!
+            $oldIndex: Int!
+            $newIndex: Int!
+          ) {
+            reorderMacroAction(
+              configId: $configId
+              id: $id
+              oldIndex: $oldIndex
+              newIndex: $newIndex
+            )
+          }
+        `}
+      >
+        {action => (
+          <SortableActionList
+            css={css`
+              flex: 1;
+              overflow-y: auto;
+            `}
+            distance={20}
+            actions={actions}
+            id={id}
+            selectedAction={selectedAction}
+            setSelectedAction={setSelectedAction}
+            removeAction={removeAction}
+            onSortEnd={({oldIndex, newIndex}) =>
+              action({
+                variables: {configId, id, oldIndex, newIndex},
+              })
+            }
+          />
+        )}
+      </Mutation>
+
+      {/* Old macro action list
       <ListGroup style={{maxHeight: "60vh", overflowY: "auto"}}>
         {actions.map(e => (
           <ListGroupItem
@@ -124,40 +160,11 @@ const ActionList = ({
             />
           </ListGroupItem>
         ))}
-      </ListGroup>
+        </ListGroup> */}
       <EventPicker
         className={"btn btn-sm btn-success"}
         handleChange={e => addAction(e.target.value)}
       />
-      {console.log(actions)}
-
-      {/* TESTING SORTABLE ACTION LIST */}
-      <br />
-      <SortableActionList
-        css={css`
-          flex: 1;
-          overflow-y: auto;
-        `}
-        distance={20}
-        actions={actions}
-        id={id}
-        selectedAction={selectedAction}
-        setSelectedAction={setSelectedAction}
-        removeAction={removeAction}
-      />
-      {/**/}
-
-      {/*
-      onSortEnd={({oldIndex, newIndex}) =>
-            reorder({
-              variables: {
-                id: id,
-                stepId: selectedAction,
-                order: newIndex,
-              },
-            })
-          }
-      */}
     </Fragment>
   );
 };

--- a/src/containers/FlightDirector/MacroButtons/sortableActionList.tsx
+++ b/src/containers/FlightDirector/MacroButtons/sortableActionList.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import {SortableContainer, SortableElement} from "react-sortable-hoc";
+import {ListGroup, ListGroupItem} from "reactstrap";
+import EventName from "../MissionConfig/EventName";
+import {FaBan} from "react-icons/fa";
+
+const SortableAction = SortableElement(
+  ({
+    id,
+    event,
+    selectedAction,
+    setSelectedAction,
+    removeAction,
+  }: {
+    id: string;
+    event: {id: string; event: string};
+    selectedAction?: string | null;
+    setSelectedAction: (id: string) => void;
+    removeAction: (id: string) => void;
+  }) => (
+    <ListGroupItem
+        key={`${id}-${event.id}`}
+        onClick={() => setSelectedAction(event.id)}
+        active={event.id === selectedAction}
+    >
+        <EventName id={event.event} />{" "}
+        <FaBan
+            className="text-danger pull-right"
+            onClick={() => removeAction(event.id)}
+        />
+    </ListGroupItem>
+  ),
+);
+
+const SortableActionList = SortableContainer(
+  ({
+    id,
+    selectedAction,
+    setSelectedAction,
+    removeAction,
+    actions,
+    ...props
+  }: {
+    id: string;
+    selectedAction?: string | null;
+    setSelectedAction: (id: string) => void;
+    removeAction: (id: string) => void;
+    actions: {id: string; event: string}[];
+  }) => {
+    return (
+        <ListGroup style={{maxHeight: "60vh", overflowY: "auto"}} {...props}>
+            {actions.map((e, index) => (
+                <SortableAction
+                    key={e.id}
+                    index={index}
+                    id={id}
+                    event={e}
+                    selectedAction={selectedAction}
+                    setSelectedAction={() => setSelectedAction(e.id)}
+                    removeAction={() => removeAction(e.id)}
+                />
+            ))}
+        </ListGroup>
+    );
+  },
+);
+
+export default SortableActionList;

--- a/src/containers/FlightDirector/MacroButtons/sortableActionList.tsx
+++ b/src/containers/FlightDirector/MacroButtons/sortableActionList.tsx
@@ -19,15 +19,15 @@ const SortableAction = SortableElement(
     removeAction: (id: string) => void;
   }) => (
     <ListGroupItem
-        key={`${id}-${event.id}`}
-        onClick={() => setSelectedAction(event.id)}
-        active={event.id === selectedAction}
+      key={`${id}-${event.id}`}
+      onClick={() => setSelectedAction(event.id)}
+      active={event.id === selectedAction}
     >
-        <EventName id={event.event} />{" "}
-        <FaBan
-            className="text-danger pull-right"
-            onClick={() => removeAction(event.id)}
-        />
+      <EventName id={event.event} />{" "}
+      <FaBan
+        className="text-danger pull-right"
+        onClick={() => removeAction(event.id)}
+      />
     </ListGroupItem>
   ),
 );
@@ -39,6 +39,7 @@ const SortableActionList = SortableContainer(
     setSelectedAction,
     removeAction,
     actions,
+    onSortEnd,
     ...props
   }: {
     id: string;
@@ -46,21 +47,22 @@ const SortableActionList = SortableContainer(
     setSelectedAction: (id: string) => void;
     removeAction: (id: string) => void;
     actions: {id: string; event: string}[];
+    onSortEnd: (newIndex: number) => void;
   }) => {
     return (
-        <ListGroup style={{maxHeight: "60vh", overflowY: "auto"}} {...props}>
-            {actions.map((e, index) => (
-                <SortableAction
-                    key={e.id}
-                    index={index}
-                    id={id}
-                    event={e}
-                    selectedAction={selectedAction}
-                    setSelectedAction={() => setSelectedAction(e.id)}
-                    removeAction={() => removeAction(e.id)}
-                />
-            ))}
-        </ListGroup>
+      <ListGroup style={{maxHeight: "60vh", overflowY: "auto"}} {...props}>
+        {actions.map((e, index) => (
+          <SortableAction
+            key={e.id}
+            index={index}
+            id={id}
+            event={e}
+            selectedAction={selectedAction}
+            setSelectedAction={() => setSelectedAction(e.id)}
+            removeAction={() => removeAction(e.id)}
+          />
+        ))}
+      </ListGroup>
     );
   },
 );

--- a/src/containers/FlightDirector/MacroButtons/sortableMacroButtonList.tsx
+++ b/src/containers/FlightDirector/MacroButtons/sortableMacroButtonList.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import {SortableContainer, SortableElement} from "react-sortable-hoc";
+import {ListGroup, ListGroupItem} from "reactstrap";
+
+const SortableButton = SortableElement(
+  ({
+    button,
+    selectedButton,
+    setSelectedButton,
+  }: {
+    button: {id: string; name: string; category: string};
+    selectedButton?: string | null;
+    setSelectedButton: (id: string) => void;
+  }) => (
+    <ListGroupItem
+      key={`${button.id}`}
+      onClick={() => setSelectedButton(button.id)}
+      active={button.id === selectedButton}
+    >
+      {button.name}
+      <br />
+      <small>{button.category}</small>
+    </ListGroupItem>
+  ),
+);
+
+const SortableButtonList = SortableContainer(
+  ({
+    id,
+    selectedButton,
+    setSelectedButton,
+    buttons,
+    onSortEnd,
+    ...props
+  }: {
+    id: string;
+    selectedButton?: string | null;
+    setSelectedButton: (id: string) => void;
+    buttons: {id: string; name: string; category: string}[];
+    onSortEnd: (newIndex: number) => void;
+  }) => {
+    return (
+      <ListGroup style={{maxHeight: "60vh", overflowY: "auto"}} {...props}>
+        {buttons.map((b, index) => (
+          <SortableButton
+            key={b.id}
+            index={index}
+            button={b}
+            selectedButton={selectedButton}
+            setSelectedButton={() => setSelectedButton(b.id)}
+          />
+        ))}
+      </ListGroup>
+    );
+  },
+);
+
+export default SortableButtonList;

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -1050,6 +1050,8 @@ export type Mutation = {
   setMacroButtonCategory?: Maybe<Scalars['String']>;
   setMacroButtonColor?: Maybe<Scalars['String']>;
   updateMacroButtonActions?: Maybe<Scalars['String']>;
+  /** Reorder Macros (by Sam Hill) */
+  reorderMacroAction?: Maybe<Scalars['String']>;
   triggerMacroButton?: Maybe<Scalars['String']>;
   toggleStationMessageGroup?: Maybe<Scalars['String']>;
   /**
@@ -3311,6 +3313,14 @@ export type MutationUpdateMacroButtonActionsArgs = {
   configId: Scalars['ID'];
   id: Scalars['ID'];
   actions?: Maybe<Array<Maybe<ActionInput>>>;
+};
+
+
+export type MutationReorderMacroActionArgs = {
+  configId: Scalars['ID'];
+  id: Scalars['ID'];
+  oldIndex: Scalars['Int'];
+  newIndex: Scalars['Int'];
 };
 
 
@@ -8725,9 +8735,11 @@ export type ScienceProbeEvent = {
 };
 
 export type ProbeInput = {
+  id?: Maybe<Scalars['ID']>;
   name?: Maybe<Scalars['String']>;
   type?: Maybe<Scalars['ID']>;
   equipment?: Maybe<Array<Maybe<EquipmentInput>>>;
+  launched?: Maybe<Scalars['Boolean']>;
 };
 
 export type EquipmentInput = {

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -1051,6 +1051,7 @@ export type Mutation = {
   setMacroButtonColor?: Maybe<Scalars['String']>;
   updateMacroButtonActions?: Maybe<Scalars['String']>;
   /** Reorder Macros */
+  reorderMacroButton?: Maybe<Scalars['String']>;
   reorderMacroAction?: Maybe<Scalars['String']>;
   triggerMacroButton?: Maybe<Scalars['String']>;
   toggleStationMessageGroup?: Maybe<Scalars['String']>;
@@ -3313,6 +3314,13 @@ export type MutationUpdateMacroButtonActionsArgs = {
   configId: Scalars['ID'];
   id: Scalars['ID'];
   actions?: Maybe<Array<Maybe<ActionInput>>>;
+};
+
+
+export type MutationReorderMacroButtonArgs = {
+  configId: Scalars['ID'];
+  oldIndex: Scalars['Int'];
+  newIndex: Scalars['Int'];
 };
 
 

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -1050,7 +1050,7 @@ export type Mutation = {
   setMacroButtonCategory?: Maybe<Scalars['String']>;
   setMacroButtonColor?: Maybe<Scalars['String']>;
   updateMacroButtonActions?: Maybe<Scalars['String']>;
-  /** Reorder Macros (by Sam Hill) */
+  /** Reorder Macros */
   reorderMacroAction?: Maybe<Scalars['String']>;
   triggerMacroButton?: Maybe<Scalars['String']>;
   toggleStationMessageGroup?: Maybe<Scalars['String']>;

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -549,7 +549,7 @@ type Mutation {
   setMacroButtonColor(configId: ID!, id: ID!, color: NotifyColors!): String
   updateMacroButtonActions(configId: ID!, id: ID!, actions: [ActionInput]): String
 
-  """Reorder Macros (by Sam Hill)"""
+  """Reorder Macros"""
   reorderMacroAction(configId: ID!, id: ID!, oldIndex: Int!, newIndex: Int!): String
   triggerMacroButton(simulatorId: ID!, configId: ID!, buttonId: ID!): String
   toggleStationMessageGroup(stationSetId: ID!, station: String!, group: String!, state: Boolean!): String

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -548,6 +548,9 @@ type Mutation {
   setMacroButtonCategory(configId: ID!, id: ID!, category: String!): String
   setMacroButtonColor(configId: ID!, id: ID!, color: NotifyColors!): String
   updateMacroButtonActions(configId: ID!, id: ID!, actions: [ActionInput]): String
+
+  """Reorder Macros (by Sam Hill)"""
+  reorderMacroAction(configId: ID!, id: ID!, oldIndex: Int!, newIndex: Int!): String
   triggerMacroButton(simulatorId: ID!, configId: ID!, buttonId: ID!): String
   toggleStationMessageGroup(stationSetId: ID!, station: String!, group: String!, state: Boolean!): String
 

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -550,6 +550,7 @@ type Mutation {
   updateMacroButtonActions(configId: ID!, id: ID!, actions: [ActionInput]): String
 
   """Reorder Macros"""
+  reorderMacroButton(configId: ID!, oldIndex: Int!, newIndex: Int!): String
   reorderMacroAction(configId: ID!, id: ID!, oldIndex: Int!, newIndex: Int!): String
   triggerMacroButton(simulatorId: ID!, configId: ID!, buttonId: ID!): String
   toggleStationMessageGroup(stationSetId: ID!, station: String!, group: String!, state: Boolean!): String


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Added functionality to rearrange the order in which a macro executes its assigned actions. Create a macro button with more than one action, then click and drag the actions to rearrange them.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes https://github.com/Thorium-Sim/thorium/issues/3201

## Screenshots (if appropriate):

- [ ] I submitted a pull request or created an issue for documenting this
      feature on the [Thorium Docs](https://github.com/Thorium-Sim/thorium-docs)
      repo. (Include the issue or pull request url below.)
