### PR TITLE
Added null check on internal messaging

### DIFF
--- a/src/components/views/Messaging/index.js
+++ b/src/components/views/Messaging/index.js
@@ -147,8 +147,10 @@ const Messaging = ({simulator, station, flight: {id: flightId}}) => {
     },
   });
   const sendMessage = () => {
-    sendMessageMutation();
-    setMessageInput("");
+    if (messageInput !== "") {
+      sendMessageMutation();
+      setMessageInput("");
+    }
   };
   const scrollElement = () => {
     const el = messageHolder.current;


### PR DESCRIPTION
## Description

Add a null check on `messageInput` to prevent sending empty messages

## Related Issue

https://github.com/Thorium-Sim/thorium/issues/3243

## Screenshots (if appropriate):

![Empty Messages Fixed](https://user-images.githubusercontent.com/31600957/181855411-d31b761d-8b4c-4811-a1aa-8a17908f6e38.gif)

- [X] I submitted a pull request or created an issue for documenting this
      feature on the [Thorium Docs](https://github.com/Thorium-Sim/thorium-docs)
      repo. (Include the issue or pull request url below.)
https://github.com/Thorium-Sim/thorium/issues/3243
