### PR TITLE
fix(Movie): Removed overriding transform css

### DIFF
--- a/src/components/client/client.scss
+++ b/src/components/client/client.scss
@@ -129,7 +129,6 @@ p.offline-message {
 }
 .card-transition-entered {
   opacity: 1;
-  transform: perspective(200px) translateZ(0px);
 }
 .card-transition-exiting {
   opacity: 0;


### PR DESCRIPTION
## Description

I removed a css transform definition that was overriding the position: fixed property of the movie element, thus causing it to not take up the whole fixed area. 

## Related Issue

https://github.com/Thorium-Sim/thorium/issues/3333

## Screenshots (if appropriate):

<img width="1680" alt="Screen Shot 2023-10-04 at 3 41 51 PM" src="https://github.com/Thorium-Sim/thorium/assets/21268331/70e85ce0-734f-403c-abe2-78c6d276e42e">

(When full screen-ed it looks much better)

- [ ] I submitted a pull request or created an issue for documenting this
      feature on the [Thorium Docs](https://github.com/Thorium-Sim/thorium-docs)
      repo. (Include the issue or pull request url below.)
