### PR TITLE
Fix/hacking preset deep clone

### DIFF
--- a/server/typeDefs/computerCore.ts
+++ b/server/typeDefs/computerCore.ts
@@ -2,6 +2,7 @@ import App from "../app";
 import {gql, withFilter} from "apollo-server-express";
 import {pubsub} from "../helpers/subscriptionManager";
 import {ComputerCore, HackingPreset} from "../classes";
+import {cloneDeep} from "lodash";
 import uuid from "uuid";
 // We define a schema that encompasses all of the types
 // necessary for the functionality in this file.
@@ -219,7 +220,8 @@ const resolver = {
       performAction(id, sys => {
         const preset = App.hackingPresets.find(i => i.id === presetId);
         if (preset) {
-          sys.activeHackingPreset = preset;
+          // Create a deep copy for this computer core instance to prevent global modifications
+          sys.activeHackingPreset = cloneDeep(preset);
           sys.hackingPorts = {
             logs: preset.logs ? Math.round(Math.random() * 16385 + 1000) : null,
             longRange: preset.longRange


### PR DESCRIPTION
## Description

This change adds a deepClone function around the hacking presets area. This makes sure that any file or log changes don't need to be re-entered after each flight after crews make changes.

Pass by reference strikes again!

## Related Issue

https://github.com/Thorium-Sim/thorium/issues/3409  Thankfully, this fix was _very_ easy. :) 

## Screenshots (if appropriate):

- [ ] I submitted a pull request or created an issue for documenting this
      feature on the [Thorium Docs](https://github.com/Thorium-Sim/thorium-docs)
      repo. (Include the issue or pull request url below.)
