### PR TITLE
fix: update firebase manager to give display name instead of id

### DIFF
--- a/server/classes/FirebaseManager.ts
+++ b/server/classes/FirebaseManager.ts
@@ -214,7 +214,7 @@ export class FirebaseManager {
             FlightHours: this.selectedMission.FlightHours,
             ClassHours: this.selectedMission.ClassHours,
             Simulator: this.selectedSimulator.id,
-            Mission: this.selectedMission.id,
+            Mission: this.selectedMission.Name,
             Awards: this.awards,
             OfficerLogs: officerLogMap
         };


### PR DESCRIPTION
## Description

Switch out id for name when creating an event in firebase

## Related Issue



## Screenshots (if appropriate):

- [ ] I submitted a pull request or created an issue for documenting this
      feature on the [Thorium Docs](https://github.com/Thorium-Sim/thorium-docs)
      repo. (Include the issue or pull request url below.)
