### PR TITLE
fix: set font-family to a font that has casing for the edventures app…

### DIFF
--- a/src/components/views/EdVenturesApp/index.tsx
+++ b/src/components/views/EdVenturesApp/index.tsx
@@ -192,7 +192,7 @@ const EdVenturesAppComp: React.FC<any> = (props) => {
                         <div>
                             <h2 className='heading-text-area'>{Heading}</h2>
                         </div>
-                        <h1 className='event-id-text' style={{ textTransform: 'none'}}>{getCurrentFirebaseSelections.EventId}</h1>
+                        <h1 className='event-id-text' style={{ textTransform: 'none', fontFamily: "Saira", fontWeight: "normal"}}>{getCurrentFirebaseSelections.EventId}</h1>
                         <h6>
                             {Subheading}
                         </h6>


### PR DESCRIPTION
… code

## Description

Some of the font families in the layouts don't have lower case letters, which makes things difficult for lower case codes. This sets the font family directly on the element, so that it's the same font across all layouts.

## Screenshots (if appropriate):

Before:
<img width="831" height="678" alt="Screenshot 2025-10-20 at 9 14 25 PM" src="https://github.com/user-attachments/assets/dd105fad-ce6f-4fe2-8485-a35b6ea9d012" />

After:
<img width="831" height="678" alt="Screenshot 2025-10-20 at 9 13 52 PM" src="https://github.com/user-attachments/assets/afae9371-0fb1-4594-a9b1-8efb740614a7" />


- [ ] I submitted a pull request or created an issue for documenting this
      feature on the [Thorium Docs](https://github.com/Thorium-Sim/thorium-docs)
      repo. (Include the issue or pull request url below.)
