### PR TITLE
feat: Added requested caution tape css fixes

### DIFF
--- a/src/components/layouts/LayoutCautionTape/style.scss
+++ b/src/components/layouts/LayoutCautionTape/style.scss
@@ -38,7 +38,7 @@ $alertp: #7a24cf;
 
 @mixin card-variant($background) {
   $background: lighten(desaturate($background, 20%), 10%);
-  background: rgba($background, 0.1);
+  background: rgba($background, 0.15);
   border: solid 1px $background;
   box-shadow: inset 0px 0px 20px -5px rgba(saturate($background, 10%), 0.5),
     0px 0px 15px -2px rgba(saturate($background, 10%), 1);
@@ -47,7 +47,7 @@ $alertp: #7a24cf;
 @mixin input-variant($background) {
   color: white;
   $background: lighten(desaturate($background, 20%), 10%);
-  background: rgba(desaturate($background, 20%), 0.1);
+  background: rgba(desaturate($background, 20%), 0.15);
   border: solid 1px desaturate($background, 20%);
   box-shadow: inset 0px 0px 20px -5px rgba(desaturate($background, 20%), 0.5),
     0px 0px 15px -2px rgba(desaturate($background, 20%), 1);
@@ -110,6 +110,7 @@ $alertp: #7a24cf;
 .layout-cautiontape {
   background-color: black;
   color: white;
+  font-family: "Saira", sans-serif;
 
   .card-switcher-holder {
     z-index: 100;
@@ -255,11 +256,11 @@ $alertp: #7a24cf;
     height: 100%;
   }
   .card-area {
-    top: 84px;
-    left: 100px;
-    right: 40px;
-    width: calc(100% - 110px);
-    height: calc(100% - 180px);
+    top: 100px;
+    left: 108px;
+    right: 48px;
+    width: calc(100% - 126px);
+    height: calc(100% - 196px);
     position: relative;
   }
   &.viewscreen {

--- a/src/components/macros/removeLibraryEntry.jsx
+++ b/src/components/macros/removeLibraryEntry.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import {FormGroup, Label, Input} from "helpers/reactstrap";
 
-export default ({updateArgs, args: {entry = {}}, client}) => {
+export default ({updateArgs, args: {slug = ""}}) => {
   return (
     <FormGroup className="macro-addLibraryEntry">
       <Label>
@@ -9,11 +9,11 @@ export default ({updateArgs, args: {entry = {}}, client}) => {
       </Label>
       <Input
         type="text"
-        defaultValue={entry.slug}
+        defaultValue={slug}
         onBlur={evt =>
           updateArgs(
-            "entry",
-            Object.assign({}, entry, {slug: evt.target.value}),
+            "slug",
+            evt.target.value ? evt.target.value : "",
           )
         }
       />


### PR DESCRIPTION
Also fixed an issue with the remove library entry macro

## Description

The Magellan staff reached out for some small css fixes to their caution tape layout, they included the following. 

1. Fixing the font to the same one used in buttons and the title area, instead of the bootstrap default. 
2. Fixing an issue where text overlap was occurring with the borders of the card (particularly in the coolant tank card)
3. Making the backgrounds on input fields 5% more opaque. 
4. An issue with the remove library entry macro was preventing them from implementing a new repair system. This bug has been included. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Screenshots (if appropriate):
Before:
<img width="1454" height="864" alt="Screenshot 2025-11-28 at 5 02 43 PM" src="https://github.com/user-attachments/assets/fff0eaae-cc77-4b6e-8109-32bef318bd49" />

<img width="1454" height="864" alt="Screenshot 2025-11-28 at 5 05 25 PM" src="https://github.com/user-attachments/assets/7c4859ae-a072-4a97-b8b3-0d0dc51e196b" />

After:
<img width="1454" height="864" alt="Screenshot 2025-11-28 at 5 01 47 PM" src="https://github.com/user-attachments/assets/833b7463-f7ba-4f85-bb26-99f99a64aab3" />

<img width="1454" height="864" alt="Screenshot 2025-11-28 at 5 05 43 PM" src="https://github.com/user-attachments/assets/2d274d6e-c9ac-460c-9b8e-62ae89c8f487" />



- [ ] I submitted a pull request or created an issue for documenting this
      feature on the [Thorium Docs](https://github.com/Thorium-Sim/thorium-docs)
      repo. (Include the issue or pull request url below.)