### PR TITLE
fix: Correct computer core macro ignoring hacker name

### DIFF
--- a/server/events/computerCore.js
+++ b/server/events/computerCore.js
@@ -68,13 +68,13 @@ const hackerNames = [
 
 App.on(
   "computerCoreAddHacker",
-  ({id, simulatorId, level = Math.round(Math.random() * 9 + 1), cb}) => {
+  ({id, simulatorId, name, level = Math.round(Math.random() * 9 + 1), cb}) => {
     const computerCore = App.systems.find(
       s => s.class === "ComputerCore" && s.simulatorId === simulatorId,
     );
     if (!computerCore) return;
     computerCore.addUser({
-      name: randomFromList(hackerNames),
+      name: name || randomFromList(hackerNames),
       level,
       hacker: true,
     });

--- a/src/components/macros/computerCore.tsx
+++ b/src/components/macros/computerCore.tsx
@@ -11,7 +11,7 @@ const ComputerCoreAddHacker: React.FC<MacroConfigProps> = ({
       <Label>
         Name
         <Input
-          defaultValue={args.name}
+          value={args.name || ""}
           onChange={e => updateArgs("name", e.target.value)}
         />
         <small>Leave blank for random hacker name</small>


### PR DESCRIPTION
## Description

Fixes the computer core macro ignoring the provided hacker name.

## Related Issue

No related issue. 

## Screenshots (if appropriate)

Not applicable.

- [ ] I submitted a pull request or created an issue for documenting this
      feature on the [Thorium Docs](https://github.com/Thorium-Sim/thorium-docs)
      repo. (Include the issue or pull request url below.)
