### PR TITLE
Allow core users to select task text descriptions

### DIFF
--- a/src/components/views/Tasks/core/TasksManager.jsx
+++ b/src/components/views/Tasks/core/TasksManager.jsx
@@ -128,7 +128,7 @@ class TasksManager extends Component {
                 <p>
                   <strong>Instructions:</strong>
                 </p>
-                <Card style={{whiteSpace: "pre-wrap"}}>
+                <Card style={{whiteSpace: "pre-wrap", userSelect: "text"}}>
                   {task.instructions}
                 </Card>
                 {!task.verified && (


### PR DESCRIPTION
## Description

Enable text selection for task descriptions on core.

This is a simple override due to its one-off nature. The default of disabling selecting text except within input fields handles most cases where this behavior would be desired.
A user facing config solution was also considered, but there isn't scaffolding in place for individual core cards, and that may not be the place for configuration to live.

## Related Issue
https://github.com/Thorium-Sim/thorium/issues/3483

## Screenshots (if appropriate):
<img width="463" height="879" alt="image" src="https://github.com/user-attachments/assets/213a7072-5f9a-4eca-9a9a-90677d4fb914" />


- [ ] I submitted a pull request or created an issue for documenting this
      feature on the [Thorium Docs](https://github.com/Thorium-Sim/thorium-docs)
      repo. (Include the issue or pull request url below.)
