### PR TITLE
Feat/updated training

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -216,6 +216,7 @@ class Events extends EventEmitter {
     events = null,
     flights = [],
     motus = [],
+    advancedTrainingProgress = [],
     ...snapshot
   }: Events) {
     const newFlights = flights.map(({timeouts, ...f}) => f);

--- a/server/app.ts
+++ b/server/app.ts
@@ -78,6 +78,7 @@ class Events extends EventEmitter {
   dmxConfigs: ClassesImport.DMXConfig[] = [];
   dmxSets: ClassesImport.DMXSet[] = [];
   hackingPresets: ClassesImport.HackingPreset[] = [];
+  advancedTrainingProgress: any[] = [];
   printQueue: {
     id: string;
     asset: string;

--- a/server/classes/advancedTraining.ts
+++ b/server/classes/advancedTraining.ts
@@ -154,6 +154,7 @@ export interface AdvancedTrainingConfigParams {
   chapters?: ChapterParams[];
   loginChapter?: ChapterParams | null;
   completionChapter?: ChapterParams | null;
+  stripPosition?: "top" | "bottom";
 }
 
 export class AdvancedTrainingConfig {
@@ -162,6 +163,7 @@ export class AdvancedTrainingConfig {
   chapters: Chapter[];
   loginChapter: Chapter | null;
   completionChapter: Chapter | null;
+  stripPosition: "top" | "bottom";
 
   constructor(params: AdvancedTrainingConfigParams = {}) {
     this.enabled = params.enabled ?? false;
@@ -169,6 +171,7 @@ export class AdvancedTrainingConfig {
     this.chapters = (params.chapters || []).map(c => new Chapter(c));
     this.loginChapter = params.loginChapter ? new Chapter(params.loginChapter) : null;
     this.completionChapter = params.completionChapter ? new Chapter(params.completionChapter) : null;
+    this.stripPosition = params.stripPosition || "bottom";
   }
 
   setEnabled(enabled: boolean) {

--- a/server/classes/advancedTraining.ts
+++ b/server/classes/advancedTraining.ts
@@ -61,6 +61,7 @@ export interface ChapterParams {
   mediaAsset?: string | null;
   autoOpenMedia?: boolean;
   autoAdvance?: boolean;
+  autoLogin?: "none" | "immediate" | "on-complete" | boolean;
   cardSwitchBehavior?: "auto" | "manual";
   mediaSize?: "small" | "medium" | "large";
   mediaPosition?: string;
@@ -74,6 +75,7 @@ export class Chapter {
   mediaAsset: string | null;
   autoOpenMedia: boolean;
   autoAdvance: boolean;
+  autoLogin: "none" | "immediate" | "on-complete";
   cardSwitchBehavior: "auto" | "manual";
   mediaSize: "small" | "medium" | "large";
   mediaPosition: string;
@@ -86,6 +88,14 @@ export class Chapter {
     this.mediaAsset = params.mediaAsset || null;
     this.autoOpenMedia = params.autoOpenMedia ?? false;
     this.autoAdvance = params.autoAdvance ?? false;
+    // Handle migration from boolean (false → "none", true → "immediate")
+    const rawLogin = params.autoLogin;
+    this.autoLogin =
+      rawLogin === true
+        ? "immediate"
+        : rawLogin === "immediate" || rawLogin === "on-complete"
+          ? rawLogin
+          : "none";
     this.cardSwitchBehavior = params.cardSwitchBehavior || "manual";
     this.mediaSize = params.mediaSize || "small";
     this.mediaPosition = params.mediaPosition || "bottom-right";
@@ -112,6 +122,10 @@ export class Chapter {
 
   setAutoAdvance(auto: boolean) {
     this.autoAdvance = auto;
+  }
+
+  setAutoLogin(value: "none" | "immediate" | "on-complete") {
+    this.autoLogin = value;
   }
 
   setCardSwitchBehavior(behavior: "auto" | "manual") {

--- a/server/classes/advancedTraining.ts
+++ b/server/classes/advancedTraining.ts
@@ -94,14 +94,12 @@ export class Chapter {
       rawLogin === true
         ? "immediate"
         : rawLogin === "immediate" || rawLogin === "on-complete"
-          ? rawLogin
-          : "none";
+        ? rawLogin
+        : "none";
     this.cardSwitchBehavior = params.cardSwitchBehavior || "manual";
     this.mediaSize = params.mediaSize || "small";
     this.mediaPosition = params.mediaPosition || "bottom-right";
-    this.subChapters = (params.subChapters || []).map(
-      s => new SubChapter(s),
-    );
+    this.subChapters = (params.subChapters || []).map(s => new SubChapter(s));
   }
 
   setName(name: string) {
@@ -152,7 +150,9 @@ export class Chapter {
 
   reorderSubChapters(subChapterId: string, newIndex: number) {
     const idx = this.subChapters.findIndex(s => s.id === subChapterId);
-    if (idx === -1) return;
+    if (idx === -1) {
+      return;
+    }
     const [item] = this.subChapters.splice(idx, 1);
     this.subChapters.splice(newIndex, 0, item);
   }
@@ -166,6 +166,7 @@ export interface AdvancedTrainingConfigParams {
   enabled?: boolean;
   sequentialChapters?: boolean;
   chapters?: ChapterParams[];
+  inFlightChapters?: ChapterParams[];
   loginChapter?: ChapterParams | null;
   completionChapter?: ChapterParams | null;
   stripPosition?: "top" | "bottom";
@@ -175,6 +176,9 @@ export class AdvancedTrainingConfig {
   enabled: boolean;
   sequentialChapters: boolean;
   chapters: Chapter[];
+  // Ad-hoc help chapters reachable mid-flight via the question-mark widget.
+  // Tied to a card component; kept out of the normal sequential progression.
+  inFlightChapters: Chapter[];
   loginChapter: Chapter | null;
   completionChapter: Chapter | null;
   stripPosition: "top" | "bottom";
@@ -183,8 +187,15 @@ export class AdvancedTrainingConfig {
     this.enabled = params.enabled ?? false;
     this.sequentialChapters = params.sequentialChapters ?? false;
     this.chapters = (params.chapters || []).map(c => new Chapter(c));
-    this.loginChapter = params.loginChapter ? new Chapter(params.loginChapter) : null;
-    this.completionChapter = params.completionChapter ? new Chapter(params.completionChapter) : null;
+    this.inFlightChapters = (params.inFlightChapters || []).map(
+      c => new Chapter(c),
+    );
+    this.loginChapter = params.loginChapter
+      ? new Chapter(params.loginChapter)
+      : null;
+    this.completionChapter = params.completionChapter
+      ? new Chapter(params.completionChapter)
+      : null;
     this.stripPosition = params.stripPosition || "bottom";
   }
 
@@ -216,7 +227,9 @@ export class AdvancedTrainingConfig {
 
   reorderChapters(chapterId: string, newIndex: number) {
     const idx = this.chapters.findIndex(c => c.id === chapterId);
-    if (idx === -1) return;
+    if (idx === -1) {
+      return;
+    }
     const [item] = this.chapters.splice(idx, 1);
     this.chapters.splice(newIndex, 0, item);
   }
@@ -225,10 +238,52 @@ export class AdvancedTrainingConfig {
     return this.chapters.find(c => c.id === chapterId);
   }
 
-  /** Find any chapter by ID, including loginChapter and completionChapter. */
+  addInFlightChapter(chapter?: ChapterParams) {
+    const ch = new Chapter(chapter);
+    this.inFlightChapters.push(ch);
+    return ch;
+  }
+
+  removeInFlightChapter(chapterId: string) {
+    this.inFlightChapters = this.inFlightChapters.filter(
+      c => c.id !== chapterId,
+    );
+  }
+
+  getInFlightChapter(chapterId: string): Chapter | undefined {
+    return this.inFlightChapters.find(c => c.id === chapterId);
+  }
+
+  /**
+   * Find the in-flight help chapter authored for a given card component, if any.
+   * Used when the crew presses the help widget while on that card.
+   */
+  findInFlightChapterByCard(cardComponent: string): Chapter | undefined {
+    if (!cardComponent) {
+      return undefined;
+    }
+    return this.inFlightChapters.find(c => c.cardComponent === cardComponent);
+  }
+
+  /** True if the given chapter ID belongs to the in-flight help chapters. */
+  isInFlightChapter(chapterId: string): boolean {
+    return this.inFlightChapters.some(c => c.id === chapterId);
+  }
+
+  /**
+   * Find any chapter by ID, including loginChapter, completionChapter, and
+   * in-flight help chapters.
+   */
   findChapter(chapterId: string): Chapter | undefined {
-    if (this.loginChapter?.id === chapterId) return this.loginChapter;
-    if (this.completionChapter?.id === chapterId) return this.completionChapter;
-    return this.chapters.find(c => c.id === chapterId);
+    if (this.loginChapter?.id === chapterId) {
+      return this.loginChapter;
+    }
+    if (this.completionChapter?.id === chapterId) {
+      return this.completionChapter;
+    }
+    return (
+      this.chapters.find(c => c.id === chapterId) ||
+      this.inFlightChapters.find(c => c.id === chapterId)
+    );
   }
 }

--- a/server/classes/advancedTraining.ts
+++ b/server/classes/advancedTraining.ts
@@ -1,0 +1,217 @@
+import uuid from "uuid";
+
+export interface RequiredActionParams {
+  id?: string;
+  eventName?: string;
+  args?: Record<string, any> | null;
+}
+
+export class RequiredAction {
+  id: string;
+  eventName: string;
+  args: Record<string, any> | null;
+
+  constructor(params: RequiredActionParams = {}) {
+    this.id = params.id || uuid.v4();
+    this.eventName = params.eventName || "";
+    this.args = params.args || null;
+  }
+}
+
+export interface SubChapterParams {
+  id?: string;
+  name?: string;
+  requiredActions?: RequiredActionParams[];
+}
+
+export class SubChapter {
+  id: string;
+  name: string;
+  requiredActions: RequiredAction[];
+
+  constructor(params: SubChapterParams = {}) {
+    this.id = params.id || uuid.v4();
+    this.name = params.name || "New Sub-Chapter";
+    this.requiredActions = (params.requiredActions || []).map(
+      a => new RequiredAction(a),
+    );
+  }
+
+  setName(name: string) {
+    this.name = name;
+  }
+
+  setRequiredActions(actions: RequiredActionParams[]) {
+    this.requiredActions = actions.map(a => new RequiredAction(a));
+  }
+
+  addRequiredAction(action: RequiredActionParams) {
+    this.requiredActions.push(new RequiredAction(action));
+  }
+
+  removeRequiredAction(actionId: string) {
+    this.requiredActions = this.requiredActions.filter(a => a.id !== actionId);
+  }
+}
+
+export interface ChapterParams {
+  id?: string;
+  name?: string;
+  cardComponent?: string;
+  mediaAsset?: string | null;
+  autoOpenMedia?: boolean;
+  autoAdvance?: boolean;
+  cardSwitchBehavior?: "auto" | "manual";
+  mediaSize?: "small" | "medium" | "large";
+  mediaPosition?: string;
+  subChapters?: SubChapterParams[];
+}
+
+export class Chapter {
+  id: string;
+  name: string;
+  cardComponent: string;
+  mediaAsset: string | null;
+  autoOpenMedia: boolean;
+  autoAdvance: boolean;
+  cardSwitchBehavior: "auto" | "manual";
+  mediaSize: "small" | "medium" | "large";
+  mediaPosition: string;
+  subChapters: SubChapter[];
+
+  constructor(params: ChapterParams = {}) {
+    this.id = params.id || uuid.v4();
+    this.name = params.name || "New Chapter";
+    this.cardComponent = params.cardComponent || "";
+    this.mediaAsset = params.mediaAsset || null;
+    this.autoOpenMedia = params.autoOpenMedia ?? false;
+    this.autoAdvance = params.autoAdvance ?? false;
+    this.cardSwitchBehavior = params.cardSwitchBehavior || "manual";
+    this.mediaSize = params.mediaSize || "small";
+    this.mediaPosition = params.mediaPosition || "bottom-right";
+    this.subChapters = (params.subChapters || []).map(
+      s => new SubChapter(s),
+    );
+  }
+
+  setName(name: string) {
+    this.name = name;
+  }
+
+  setCardComponent(component: string) {
+    this.cardComponent = component;
+  }
+
+  setMediaAsset(asset: string | null) {
+    this.mediaAsset = asset;
+  }
+
+  setAutoOpenMedia(auto: boolean) {
+    this.autoOpenMedia = auto;
+  }
+
+  setAutoAdvance(auto: boolean) {
+    this.autoAdvance = auto;
+  }
+
+  setCardSwitchBehavior(behavior: "auto" | "manual") {
+    this.cardSwitchBehavior = behavior;
+  }
+
+  setMediaSize(size: "small" | "medium" | "large") {
+    this.mediaSize = size;
+  }
+
+  setMediaPosition(position: string) {
+    this.mediaPosition = position;
+  }
+
+  addSubChapter(subChapter?: SubChapterParams) {
+    const sc = new SubChapter(subChapter);
+    this.subChapters.push(sc);
+    return sc;
+  }
+
+  removeSubChapter(subChapterId: string) {
+    this.subChapters = this.subChapters.filter(s => s.id !== subChapterId);
+  }
+
+  reorderSubChapters(subChapterId: string, newIndex: number) {
+    const idx = this.subChapters.findIndex(s => s.id === subChapterId);
+    if (idx === -1) return;
+    const [item] = this.subChapters.splice(idx, 1);
+    this.subChapters.splice(newIndex, 0, item);
+  }
+
+  getSubChapter(subChapterId: string): SubChapter | undefined {
+    return this.subChapters.find(s => s.id === subChapterId);
+  }
+}
+
+export interface AdvancedTrainingConfigParams {
+  enabled?: boolean;
+  sequentialChapters?: boolean;
+  chapters?: ChapterParams[];
+  loginChapter?: ChapterParams | null;
+  completionChapter?: ChapterParams | null;
+}
+
+export class AdvancedTrainingConfig {
+  enabled: boolean;
+  sequentialChapters: boolean;
+  chapters: Chapter[];
+  loginChapter: Chapter | null;
+  completionChapter: Chapter | null;
+
+  constructor(params: AdvancedTrainingConfigParams = {}) {
+    this.enabled = params.enabled ?? false;
+    this.sequentialChapters = params.sequentialChapters ?? false;
+    this.chapters = (params.chapters || []).map(c => new Chapter(c));
+    this.loginChapter = params.loginChapter ? new Chapter(params.loginChapter) : null;
+    this.completionChapter = params.completionChapter ? new Chapter(params.completionChapter) : null;
+  }
+
+  setEnabled(enabled: boolean) {
+    this.enabled = enabled;
+  }
+
+  setSequentialChapters(sequential: boolean) {
+    this.sequentialChapters = sequential;
+  }
+
+  setLoginChapter(params: ChapterParams | null) {
+    this.loginChapter = params ? new Chapter(params) : null;
+  }
+
+  setCompletionChapter(params: ChapterParams | null) {
+    this.completionChapter = params ? new Chapter(params) : null;
+  }
+
+  addChapter(chapter?: ChapterParams) {
+    const ch = new Chapter(chapter);
+    this.chapters.push(ch);
+    return ch;
+  }
+
+  removeChapter(chapterId: string) {
+    this.chapters = this.chapters.filter(c => c.id !== chapterId);
+  }
+
+  reorderChapters(chapterId: string, newIndex: number) {
+    const idx = this.chapters.findIndex(c => c.id === chapterId);
+    if (idx === -1) return;
+    const [item] = this.chapters.splice(idx, 1);
+    this.chapters.splice(newIndex, 0, item);
+  }
+
+  getChapter(chapterId: string): Chapter | undefined {
+    return this.chapters.find(c => c.id === chapterId);
+  }
+
+  /** Find any chapter by ID, including loginChapter and completionChapter. */
+  findChapter(chapterId: string): Chapter | undefined {
+    if (this.loginChapter?.id === chapterId) return this.loginChapter;
+    if (this.completionChapter?.id === chapterId) return this.completionChapter;
+    return this.chapters.find(c => c.id === chapterId);
+  }
+}

--- a/server/classes/advancedTrainingProgress.ts
+++ b/server/classes/advancedTrainingProgress.ts
@@ -13,6 +13,8 @@ export interface AdvancedTrainingProgressParams {
   globalObservedEvents?: string[];
   mediaViewerOpen?: boolean;
   chapterListOpen?: boolean;
+  inFlightHelp?: boolean;
+  inFlightHelpCard?: string | null;
 }
 
 export class AdvancedTrainingProgress {
@@ -28,6 +30,15 @@ export class AdvancedTrainingProgress {
   globalObservedEvents: string[];
   mediaViewerOpen: boolean;
   chapterListOpen: boolean;
+  // True when this session was launched as ad-hoc in-flight help (the crew
+  // clicked the help button mid-flight) rather than as a full training run.
+  // In-flight help never auto-advances into the main sequence and never
+  // auto-closes on chapter completion — it stays until the crew dismisses it.
+  inFlightHelp: boolean;
+  // When set, the card component this in-flight help was launched on. Used for
+  // help shown on a card without a dedicated in-flight chapter: navigating to a
+  // different card auto-closes the help. Null means no card binding.
+  inFlightHelpCard: string | null;
 
   constructor(params: AdvancedTrainingProgressParams = {}) {
     this.id = params.id || uuid.v4();
@@ -42,6 +53,8 @@ export class AdvancedTrainingProgress {
     this.globalObservedEvents = params.globalObservedEvents || [];
     this.mediaViewerOpen = params.mediaViewerOpen ?? false;
     this.chapterListOpen = params.chapterListOpen ?? false;
+    this.inFlightHelp = params.inFlightHelp ?? false;
+    this.inFlightHelpCard = params.inFlightHelpCard ?? null;
   }
 
   setActiveChapter(chapterId: string | null) {
@@ -105,5 +118,7 @@ export class AdvancedTrainingProgress {
     this.globalObservedEvents = [];
     this.mediaViewerOpen = false;
     this.chapterListOpen = false;
+    this.inFlightHelp = false;
+    this.inFlightHelpCard = null;
   }
 }

--- a/server/classes/advancedTrainingProgress.ts
+++ b/server/classes/advancedTrainingProgress.ts
@@ -10,6 +10,7 @@ export interface AdvancedTrainingProgressParams {
   completedChapterIds?: string[];
   completedSubChapterIds?: string[];
   observedActions?: Record<string, string[]>;
+  globalObservedEvents?: string[];
   mediaViewerOpen?: boolean;
   chapterListOpen?: boolean;
 }
@@ -24,6 +25,7 @@ export class AdvancedTrainingProgress {
   completedChapterIds: string[];
   completedSubChapterIds: string[];
   observedActions: Record<string, string[]>;
+  globalObservedEvents: string[];
   mediaViewerOpen: boolean;
   chapterListOpen: boolean;
 
@@ -37,6 +39,7 @@ export class AdvancedTrainingProgress {
     this.completedChapterIds = params.completedChapterIds || [];
     this.completedSubChapterIds = params.completedSubChapterIds || [];
     this.observedActions = params.observedActions || {};
+    this.globalObservedEvents = params.globalObservedEvents || [];
     this.mediaViewerOpen = params.mediaViewerOpen ?? false;
     this.chapterListOpen = params.chapterListOpen ?? false;
   }
@@ -56,6 +59,12 @@ export class AdvancedTrainingProgress {
     }
     if (!this.observedActions[subChapterId].includes(eventName)) {
       this.observedActions[subChapterId].push(eventName);
+    }
+  }
+
+  observeEvent(eventName: string) {
+    if (!this.globalObservedEvents.includes(eventName)) {
+      this.globalObservedEvents.push(eventName);
     }
   }
 
@@ -93,6 +102,7 @@ export class AdvancedTrainingProgress {
     this.completedChapterIds = [];
     this.completedSubChapterIds = [];
     this.observedActions = {};
+    this.globalObservedEvents = [];
     this.mediaViewerOpen = false;
     this.chapterListOpen = false;
   }

--- a/server/classes/advancedTrainingProgress.ts
+++ b/server/classes/advancedTrainingProgress.ts
@@ -1,0 +1,99 @@
+import uuid from "uuid";
+
+export interface AdvancedTrainingProgressParams {
+  id?: string;
+  clientId?: string;
+  simulatorId?: string;
+  stationName?: string;
+  activeChapterId?: string | null;
+  activeSubChapterId?: string | null;
+  completedChapterIds?: string[];
+  completedSubChapterIds?: string[];
+  observedActions?: Record<string, string[]>;
+  mediaViewerOpen?: boolean;
+  chapterListOpen?: boolean;
+}
+
+export class AdvancedTrainingProgress {
+  id: string;
+  clientId: string;
+  simulatorId: string;
+  stationName: string;
+  activeChapterId: string | null;
+  activeSubChapterId: string | null;
+  completedChapterIds: string[];
+  completedSubChapterIds: string[];
+  observedActions: Record<string, string[]>;
+  mediaViewerOpen: boolean;
+  chapterListOpen: boolean;
+
+  constructor(params: AdvancedTrainingProgressParams = {}) {
+    this.id = params.id || uuid.v4();
+    this.clientId = params.clientId || "";
+    this.simulatorId = params.simulatorId || "";
+    this.stationName = params.stationName || "";
+    this.activeChapterId = params.activeChapterId || null;
+    this.activeSubChapterId = params.activeSubChapterId || null;
+    this.completedChapterIds = params.completedChapterIds || [];
+    this.completedSubChapterIds = params.completedSubChapterIds || [];
+    this.observedActions = params.observedActions || {};
+    this.mediaViewerOpen = params.mediaViewerOpen ?? false;
+    this.chapterListOpen = params.chapterListOpen ?? false;
+  }
+
+  setActiveChapter(chapterId: string | null) {
+    this.activeChapterId = chapterId;
+    this.activeSubChapterId = null;
+  }
+
+  setActiveSubChapter(subChapterId: string | null) {
+    this.activeSubChapterId = subChapterId;
+  }
+
+  recordAction(subChapterId: string, eventName: string) {
+    if (!this.observedActions[subChapterId]) {
+      this.observedActions[subChapterId] = [];
+    }
+    if (!this.observedActions[subChapterId].includes(eventName)) {
+      this.observedActions[subChapterId].push(eventName);
+    }
+  }
+
+  completeSubChapter(subChapterId: string) {
+    if (!this.completedSubChapterIds.includes(subChapterId)) {
+      this.completedSubChapterIds.push(subChapterId);
+    }
+  }
+
+  completeChapter(chapterId: string) {
+    if (!this.completedChapterIds.includes(chapterId)) {
+      this.completedChapterIds.push(chapterId);
+    }
+  }
+
+  isSubChapterComplete(subChapterId: string): boolean {
+    return this.completedSubChapterIds.includes(subChapterId);
+  }
+
+  isChapterComplete(chapterId: string): boolean {
+    return this.completedChapterIds.includes(chapterId);
+  }
+
+  setMediaViewerOpen(open: boolean) {
+    this.mediaViewerOpen = open;
+  }
+
+  setChapterListOpen(open: boolean) {
+    this.chapterListOpen = open;
+  }
+
+  reset() {
+    this.activeChapterId = null;
+    this.activeSubChapterId = null;
+    this.completedChapterIds = [];
+    this.completedSubChapterIds = [];
+    this.observedActions = {};
+    this.mediaViewerOpen = false;
+    this.chapterListOpen = false;
+  }
+}

--- a/server/classes/stationSet.ts
+++ b/server/classes/stationSet.ts
@@ -1,6 +1,7 @@
 import uuid from "uuid";
 import App from "../app";
 import {pascalCase} from "change-case";
+import {AdvancedTrainingConfig, AdvancedTrainingConfigParams} from "./advancedTraining";
 
 export class StationSet {
   id: string;
@@ -115,6 +116,7 @@ export class Station {
   training: string;
   ambiance: string;
   layout: string;
+  advancedTraining: AdvancedTrainingConfig | null;
   constructor({
     name,
     cards = [],
@@ -127,7 +129,8 @@ export class Station {
     training,
     ambiance,
     layout,
-  }: Partial<Station>) {
+    advancedTraining,
+  }: Partial<Station> & {advancedTraining?: AdvancedTrainingConfigParams | AdvancedTrainingConfig | null}) {
     this.class = "Station";
     this.name = name || "Station";
     this.description = description || "";
@@ -139,6 +142,9 @@ export class Station {
     this.messageGroups = messageGroups;
     this.widgets = widgets;
     this.layout = layout || null;
+    this.advancedTraining = advancedTraining
+      ? new AdvancedTrainingConfig(advancedTraining)
+      : null;
     this.cards = [];
     cards.forEach(card => {
       this.addCard(card);
@@ -162,6 +168,9 @@ export class Station {
   }
   setTraining(training: string) {
     this.training = training;
+  }
+  setAdvancedTraining(config: AdvancedTrainingConfigParams | null) {
+    this.advancedTraining = config ? new AdvancedTrainingConfig(config) : null;
   }
   setTags(tags: string[]) {
     this.tags = tags.map(t => t.trim());

--- a/server/classes/stationSet.ts
+++ b/server/classes/stationSet.ts
@@ -1,7 +1,10 @@
 import uuid from "uuid";
 import App from "../app";
 import {pascalCase} from "change-case";
-import {AdvancedTrainingConfig, AdvancedTrainingConfigParams} from "./advancedTraining";
+import {
+  AdvancedTrainingConfig,
+  AdvancedTrainingConfigParams,
+} from "./advancedTraining";
 
 export class StationSet {
   id: string;
@@ -130,7 +133,12 @@ export class Station {
     ambiance,
     layout,
     advancedTraining,
-  }: Partial<Station> & {advancedTraining?: AdvancedTrainingConfigParams | AdvancedTrainingConfig | null}) {
+  }: Partial<Station> & {
+    advancedTraining?:
+      | AdvancedTrainingConfigParams
+      | AdvancedTrainingConfig
+      | null;
+  }) {
     this.class = "Station";
     this.name = name || "Station";
     this.description = description || "";

--- a/server/classes/trainingPrerequisites.ts
+++ b/server/classes/trainingPrerequisites.ts
@@ -1,0 +1,18 @@
+/**
+ * System-level prerequisites for advanced training chapters.
+ *
+ * Maps cardComponent names to the mutation/event names that must be observed
+ * (by any client, including the FD) before that chapter becomes available to
+ * navigate to during an active training session.
+ *
+ * Add entries here when a system only becomes relevant after a specific FD
+ * action fires mid-flight. Example:
+ *
+ *   "NavigationAdvanced": ["activateAdvancedNavigation"],
+ *
+ * The server watches for these event names globally and marks them in each
+ * active training session's globalObservedEvents when they fire.
+ */
+export const CARD_PREREQUISITES: Record<string, string[]> = {
+  // Add entries as needed for your mission systems.
+};

--- a/server/events/advancedTraining.ts
+++ b/server/events/advancedTraining.ts
@@ -1,0 +1,375 @@
+import App from "../app";
+import {pubsub} from "../helpers/subscriptionManager";
+import {AdvancedTrainingConfig} from "../classes/advancedTraining";
+import {AdvancedTrainingProgress} from "../classes/advancedTrainingProgress";
+
+// Ensure the array exists on App
+if (!App.advancedTrainingProgress) {
+  App.advancedTrainingProgress = [];
+}
+
+// Helper to find a station's advanced training config
+function getStationConfig(stationSetID: string, stationName: string) {
+  const stationSet = App.stationSets.find(
+    (s: any) => s.id === stationSetID,
+  );
+  if (!stationSet) return null;
+  const station = stationSet.stations.find(
+    (s: any) => s.name === stationName,
+  );
+  return station;
+}
+
+// Helper to get a client's training config from their station
+function getClientTrainingConfig(clientId: string) {
+  const client = App.clients.find((c: any) => c.id === clientId);
+  if (!client || !client.simulatorId || !client.station) return null;
+
+  // Look up the station directly on the simulator (not the station set template,
+  // which has a different simulatorId — the template's, not the flight instance's)
+  const simulator = App.simulators.find(
+    (s: any) => s.id === client.simulatorId,
+  );
+  if (!simulator) return null;
+
+  const station = simulator.stations?.find(
+    (s: any) => s.name === client.station,
+  );
+  if (!station || !station.advancedTraining?.enabled) return null;
+
+  return station.advancedTraining;
+}
+
+function publishProgress() {
+  pubsub.publish(
+    "advancedTrainingProgressUpdate",
+    App.advancedTrainingProgress || [],
+  );
+}
+
+function publishClientChanged() {
+  pubsub.publish("clientChanged", App.clients);
+}
+
+// --- Configuration events ---
+// These are handled by explicit mutation resolvers in the typeDef.
+// The event handlers here are no-ops; they exist so App.emit doesn't
+// throw an "unhandled event" warning.
+
+App.on("setStationAdvancedTraining", () => {});
+App.on("toggleAdvancedTrainingMode", () => {});
+
+// --- Client training session events ---
+
+App.on("clientStartAdvancedTraining", ({clientId}: any) => {
+  const client = App.clients.find((c: any) => c.id === clientId);
+  if (!client) return;
+
+  const config = getClientTrainingConfig(clientId);
+  if (!config) return;
+
+  // Remove any existing progress for this client
+  App.advancedTrainingProgress = (App.advancedTrainingProgress || []).filter(
+    (p: any) => p.clientId !== clientId,
+  );
+
+  // Create new progress — start at login chapter if configured, else first regular chapter
+  const startChapter = config.loginChapter || config.chapters[0];
+  const firstSubChapter = startChapter?.subChapters?.[0];
+  const progress = new AdvancedTrainingProgress({
+    clientId: client.id,
+    simulatorId: client.simulatorId,
+    stationName: client.station,
+    activeChapterId: startChapter?.id || null,
+    activeSubChapterId: firstSubChapter?.id || null,
+    mediaViewerOpen: startChapter?.autoOpenMedia ?? false,
+  });
+
+  App.advancedTrainingProgress.push(progress);
+
+  // Also set the legacy training flag so the system knows
+  client.setTraining(true);
+
+  publishProgress();
+  publishClientChanged();
+});
+
+App.on("clientStopAdvancedTraining", ({clientId}: any) => {
+  const client = App.clients.find((c: any) => c.id === clientId);
+  if (!client) return;
+
+  App.advancedTrainingProgress = (App.advancedTrainingProgress || []).filter(
+    (p: any) => p.clientId !== clientId,
+  );
+
+  client.setTraining(false);
+
+  publishProgress();
+  publishClientChanged();
+});
+
+// --- Action tracking ---
+
+App.on("clientAdvancedTrainingAction", ({clientId, eventName, args}: any) => {
+  const progress = (App.advancedTrainingProgress || []).find(
+    (p: any) => p.clientId === clientId,
+  );
+  if (!progress || !progress.activeChapterId) return;
+
+  const config = getClientTrainingConfig(clientId);
+  if (!config) return;
+
+  const chapter = config.findChapter(progress.activeChapterId);
+  if (!chapter) return;
+
+  // Find the active sub-chapter, or check all incomplete sub-chapters in order
+  const subChaptersToCheck = progress.activeSubChapterId
+    ? [chapter.getSubChapter(progress.activeSubChapterId)].filter(Boolean)
+    : chapter.subChapters.filter(
+        (sc: any) => !progress.isSubChapterComplete(sc.id),
+      );
+
+  for (const subChapter of subChaptersToCheck) {
+    if (!subChapter) continue;
+
+    // Check if this action matches any required action in this sub-chapter.
+    // Match on eventName alone — args like simulatorId, clientId, etc. will
+    // always differ between the recording session and a live flight, so
+    // strict arg comparison would never match.
+    const matchingAction = subChapter.requiredActions.find(
+      (ra: any) => ra.eventName === eventName,
+    );
+
+    if (matchingAction) {
+      progress.recordAction(subChapter.id, eventName);
+
+      // Check if all required actions for this sub-chapter are now done
+      const allDone = subChapter.requiredActions.every((ra: any) =>
+        (progress.observedActions[subChapter.id] || []).includes(ra.eventName),
+      );
+
+      if (allDone) {
+        progress.completeSubChapter(subChapter.id);
+
+        // Move to next incomplete sub-chapter
+        const nextSubChapter = chapter.subChapters.find(
+          (sc: any) => !progress.isSubChapterComplete(sc.id),
+        );
+        progress.setActiveSubChapter(nextSubChapter?.id || null);
+
+        // Check if all sub-chapters for this chapter are complete
+        const chapterDone = chapter.subChapters.every((sc: any) =>
+          progress.isSubChapterComplete(sc.id),
+        );
+
+        if (chapterDone) {
+          progress.completeChapter(chapter.id);
+
+          // Auto-advance to next chapter if configured
+          if (chapter.autoAdvance) {
+            let nextChapter: any = null;
+
+            if (config.loginChapter?.id === chapter.id) {
+              // Login chapter complete → go to first regular chapter
+              nextChapter = config.chapters[0] || null;
+            } else if (config.completionChapter?.id === chapter.id) {
+              // Completion chapter is terminal, no further advance
+              nextChapter = null;
+            } else {
+              // Regular chapter — find the next one
+              const chapterIdx = config.chapters.findIndex(
+                (c: any) => c.id === chapter.id,
+              );
+              nextChapter = config.chapters[chapterIdx + 1] || null;
+              // If no next regular chapter, go to completion chapter if configured
+              if (!nextChapter && config.completionChapter) {
+                nextChapter = config.completionChapter;
+              }
+            }
+
+            if (nextChapter) {
+              progress.setActiveChapter(nextChapter.id);
+              const firstSub = nextChapter.subChapters[0];
+              progress.setActiveSubChapter(firstSub?.id || null);
+
+              // Auto-open media if configured
+              if (nextChapter.autoOpenMedia && nextChapter.mediaAsset) {
+                progress.setMediaViewerOpen(true);
+              }
+
+              // Handle card switching (only for regular chapters with a cardComponent)
+              if (nextChapter.cardSwitchBehavior === "auto" && nextChapter.cardComponent) {
+                const client = App.clients.find(
+                  (c: any) => c.id === clientId,
+                );
+                if (client) {
+                  // Find the card on the station that matches the next chapter's component
+                  const simulator = App.simulators.find(
+                    (s: any) => s.id === client.simulatorId,
+                  );
+                  if (simulator) {
+                    const station = simulator.stations?.find(
+                      (s: any) => s.name === client.station,
+                    );
+                    const targetCard = station?.cards?.find(
+                      (c: any) => c.component === nextChapter.cardComponent,
+                    );
+                    if (targetCard) {
+                      App.handleEvent(
+                        {id: clientId, card: targetCard.name},
+                        "clientSetCard",
+                        {clientId},
+                      );
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      // Only process the first matching sub-chapter
+      break;
+    }
+  }
+
+  publishProgress();
+});
+
+// --- Navigation events ---
+
+App.on("advancedTrainingSetActiveChapter", ({clientId, chapterId}: any) => {
+  const progress = (App.advancedTrainingProgress || []).find(
+    (p: any) => p.clientId === clientId,
+  );
+  if (!progress) return;
+
+  const config = getClientTrainingConfig(clientId);
+  if (!config) return;
+
+  const chapter = config.findChapter(chapterId);
+  if (!chapter) return;
+
+  // Block navigation to locked chapters in sequential mode
+  // (skip for login/completion chapters — those are auto-managed)
+  const isSpecialChapter =
+    config.loginChapter?.id === chapterId ||
+    config.completionChapter?.id === chapterId;
+
+  if (!isSpecialChapter && config.sequentialChapters) {
+    const chapterIdx = config.chapters.findIndex((c: any) => c.id === chapterId);
+    if (chapterIdx > 0) {
+      const prevChapter = config.chapters[chapterIdx - 1];
+      if (!progress.isChapterComplete(prevChapter.id)) return;
+    }
+  }
+
+  progress.setActiveChapter(chapterId);
+  const firstIncompleteSub = chapter.subChapters.find(
+    (sc: any) => !progress.isSubChapterComplete(sc.id),
+  );
+  progress.setActiveSubChapter(
+    firstIncompleteSub?.id || chapter.subChapters[0]?.id || null,
+  );
+
+  // Auto-open media if configured
+  if (chapter.autoOpenMedia && chapter.mediaAsset) {
+    progress.setMediaViewerOpen(true);
+  }
+
+  // Handle card switching
+  if (chapter.cardSwitchBehavior === "auto") {
+    const client = App.clients.find((c: any) => c.id === clientId);
+    if (client) {
+      const simulator = App.simulators.find(
+        (s: any) => s.id === client.simulatorId,
+      );
+      if (simulator) {
+        const station = simulator.stations?.find(
+          (s: any) => s.name === client.station,
+        );
+        const targetCard = station?.cards?.find(
+          (c: any) => c.component === chapter.cardComponent,
+        );
+        if (targetCard) {
+          App.handleEvent(
+            {id: clientId, card: targetCard.name},
+            "clientSetCard",
+            {clientId},
+          );
+        }
+      }
+    }
+  }
+
+  publishProgress();
+});
+
+// --- FD intervention events ---
+
+App.on("fdCompleteTrainingSubChapter", ({clientId, subChapterId}: any) => {
+  const progress = (App.advancedTrainingProgress || []).find(
+    (p: any) => p.clientId === clientId,
+  );
+  if (!progress) return;
+
+  progress.completeSubChapter(subChapterId);
+
+  // Check if this completes the chapter
+  const config = getClientTrainingConfig(clientId);
+  if (config && progress.activeChapterId) {
+    const chapter = config.getChapter(progress.activeChapterId);
+    if (chapter) {
+      const chapterDone = chapter.subChapters.every((sc: any) =>
+        progress.isSubChapterComplete(sc.id),
+      );
+      if (chapterDone) {
+        progress.completeChapter(chapter.id);
+      }
+    }
+  }
+
+  publishProgress();
+});
+
+App.on("fdResetTrainingProgress", ({clientId}: any) => {
+  const progress = (App.advancedTrainingProgress || []).find(
+    (p: any) => p.clientId === clientId,
+  );
+  if (!progress) return;
+
+  const config = getClientTrainingConfig(clientId);
+  progress.reset();
+
+  // Re-activate first chapter (login chapter if configured, else first regular)
+  if (config) {
+    const startChapter = config.loginChapter || config.chapters[0] || null;
+    if (startChapter) {
+      progress.setActiveChapter(startChapter.id);
+      progress.setActiveSubChapter(startChapter.subChapters[0]?.id || null);
+    }
+  }
+
+  publishProgress();
+});
+
+// --- UI state events ---
+
+App.on("advancedTrainingToggleMediaViewer", ({clientId, open}: any) => {
+  const progress = (App.advancedTrainingProgress || []).find(
+    (p: any) => p.clientId === clientId,
+  );
+  if (!progress) return;
+  progress.setMediaViewerOpen(open);
+  publishProgress();
+});
+
+App.on("advancedTrainingToggleChapterList", ({clientId, open}: any) => {
+  const progress = (App.advancedTrainingProgress || []).find(
+    (p: any) => p.clientId === clientId,
+  );
+  if (!progress) return;
+  progress.setChapterListOpen(open);
+  publishProgress();
+});

--- a/server/events/advancedTraining.ts
+++ b/server/events/advancedTraining.ts
@@ -1,55 +1,20 @@
 import App from "../app";
-import {pubsub} from "../helpers/subscriptionManager";
-import {AdvancedTrainingConfig} from "../classes/advancedTraining";
 import {AdvancedTrainingProgress} from "../classes/advancedTrainingProgress";
 import {CARD_PREREQUISITES} from "../classes/trainingPrerequisites";
+import {
+  getClientTrainingConfig,
+  publishProgress,
+  publishClientChanged,
+  autoCompleteIfEmpty,
+  advanceToNextChapter,
+  activateChapter,
+} from "./advancedTrainingHelpers";
+// Registers the FD-intervention and UI-state listeners as a side effect.
+import "./advancedTrainingFdEvents";
 
 // Ensure the array exists on App
 if (!App.advancedTrainingProgress) {
   App.advancedTrainingProgress = [];
-}
-
-// Helper to find a station's advanced training config
-function getStationConfig(stationSetID: string, stationName: string) {
-  const stationSet = App.stationSets.find(
-    (s: any) => s.id === stationSetID,
-  );
-  if (!stationSet) return null;
-  const station = stationSet.stations.find(
-    (s: any) => s.name === stationName,
-  );
-  return station;
-}
-
-// Helper to get a client's training config from their station
-function getClientTrainingConfig(clientId: string) {
-  const client = App.clients.find((c: any) => c.id === clientId);
-  if (!client || !client.simulatorId || !client.station) return null;
-
-  // Look up the station directly on the simulator (not the station set template,
-  // which has a different simulatorId — the template's, not the flight instance's)
-  const simulator = App.simulators.find(
-    (s: any) => s.id === client.simulatorId,
-  );
-  if (!simulator) return null;
-
-  const station = simulator.stations?.find(
-    (s: any) => s.name === client.station,
-  );
-  if (!station || !station.advancedTraining?.enabled) return null;
-
-  return station.advancedTraining;
-}
-
-function publishProgress() {
-  pubsub.publish(
-    "advancedTrainingProgressUpdate",
-    App.advancedTrainingProgress || [],
-  );
-}
-
-function publishClientChanged() {
-  pubsub.publish("clientChanged", App.clients);
 }
 
 // Register global listeners for prerequisite events so FD-fired mutations
@@ -65,98 +30,22 @@ for (const eventName of allPrerequisiteEvents) {
       (args?.clientId
         ? App.clients.find((c: any) => c.id === args.clientId)?.simulatorId
         : null);
-    if (!simulatorId) return;
+    if (!simulatorId) {
+      return;
+    }
 
     const affected = (App.advancedTrainingProgress || []).filter(
       (p: any) => p.simulatorId === simulatorId,
     );
-    if (affected.length === 0) return;
+    if (affected.length === 0) {
+      return;
+    }
 
     for (const prog of affected) {
       prog.observeEvent(eventName);
     }
     publishProgress();
   });
-}
-
-// Auto-complete a chapter that has no subchapters immediately upon activation.
-function autoCompleteIfEmpty(progress: AdvancedTrainingProgress, chapter: any) {
-  if ((chapter.subChapters || []).length === 0) {
-    progress.completeChapter(chapter.id);
-    return true;
-  }
-  return false;
-}
-
-// Advance to the chapter that follows completedChapter, respecting autoAdvance,
-// autoOpenMedia, and cardSwitchBehavior. Resets mediaViewerOpen before opening.
-function advanceToNextChapter(
-  progress: AdvancedTrainingProgress,
-  config: any,
-  completedChapter: any,
-  clientId: string,
-) {
-  if (!completedChapter.autoAdvance) return;
-
-  let nextChapter: any = null;
-
-  if (config.loginChapter?.id === completedChapter.id) {
-    nextChapter = config.chapters[0] || null;
-  } else if (config.completionChapter?.id === completedChapter.id) {
-    nextChapter = null;
-  } else {
-    const chapterIdx = config.chapters.findIndex(
-      (c: any) => c.id === completedChapter.id,
-    );
-    if (chapterIdx === -1) return;
-    nextChapter = config.chapters[chapterIdx + 1] || null;
-    if (!nextChapter && config.completionChapter) {
-      nextChapter = config.completionChapter;
-    }
-  }
-
-  if (!nextChapter) return;
-
-  progress.setMediaViewerOpen(false);
-  progress.setActiveChapter(nextChapter.id);
-
-  if (!autoCompleteIfEmpty(progress, nextChapter)) {
-    const firstSub = nextChapter.subChapters[0];
-    progress.setActiveSubChapter(firstSub?.id || null);
-  } else {
-    // nextChapter had no sub-chapters and was immediately auto-completed.
-    // Chain forward so a sequence of empty autoAdvance chapters doesn't stall.
-    advanceToNextChapter(progress, config, nextChapter, clientId);
-    return;
-  }
-
-  if (nextChapter.autoOpenMedia && nextChapter.mediaAsset) {
-    progress.setMediaViewerOpen(true);
-  }
-
-  if (nextChapter.cardSwitchBehavior === "auto" && nextChapter.cardComponent) {
-    const client = App.clients.find((c: any) => c.id === clientId);
-    if (client) {
-      const simulator = App.simulators.find(
-        (s: any) => s.id === client.simulatorId,
-      );
-      if (simulator) {
-        const station = simulator.stations?.find(
-          (s: any) => s.name === client.station,
-        );
-        const targetCard = station?.cards?.find(
-          (c: any) => c.component === nextChapter.cardComponent,
-        );
-        if (targetCard) {
-          App.handleEvent(
-            {id: clientId, card: targetCard.name},
-            "clientSetCard",
-            {clientId},
-          );
-        }
-      }
-    }
-  }
 }
 
 // --- Configuration events ---
@@ -171,10 +60,14 @@ App.on("toggleAdvancedTrainingMode", () => {});
 
 App.on("clientStartAdvancedTraining", ({clientId}: any) => {
   const client = App.clients.find((c: any) => c.id === clientId);
-  if (!client) return;
+  if (!client) {
+    return;
+  }
 
   const config = getClientTrainingConfig(clientId);
-  if (!config) return;
+  if (!config) {
+    return;
+  }
 
   // Remove any existing progress for this client
   App.advancedTrainingProgress = (App.advancedTrainingProgress || []).filter(
@@ -190,7 +83,9 @@ App.on("clientStartAdvancedTraining", ({clientId}: any) => {
     stationName: client.station,
     activeChapterId: startChapter?.id || null,
     activeSubChapterId: firstSubChapter?.id || null,
-    mediaViewerOpen: !!(startChapter?.autoOpenMedia && startChapter?.mediaAsset),
+    mediaViewerOpen: !!(
+      startChapter?.autoOpenMedia && startChapter?.mediaAsset
+    ),
   });
 
   App.advancedTrainingProgress.push(progress);
@@ -200,7 +95,11 @@ App.on("clientStartAdvancedTraining", ({clientId}: any) => {
   // (If it fired after chaining, it would land on whatever chapter ended up active.)
   if (config.loginChapter?.autoLogin === "immediate") {
     App.emit("clientLogin", {client: clientId, loginName: client.station});
-    App.emit("clientAdvancedTrainingAction", {clientId, eventName: "clientLogin", args: null});
+    App.emit("clientAdvancedTrainingAction", {
+      clientId,
+      eventName: "clientLogin",
+      args: null,
+    });
   }
 
   // Auto-complete the starting chapter if it has no sub-chapters, then chain
@@ -222,7 +121,9 @@ App.on("clientStartAdvancedTraining", ({clientId}: any) => {
 
 App.on("clientStopAdvancedTraining", ({clientId}: any) => {
   const client = App.clients.find((c: any) => c.id === clientId);
-  if (!client) return;
+  if (!client) {
+    return;
+  }
 
   App.advancedTrainingProgress = (App.advancedTrainingProgress || []).filter(
     (p: any) => p.clientId !== clientId,
@@ -240,16 +141,22 @@ App.on("clientAdvancedTrainingAction", ({clientId, eventName, args}: any) => {
   const progress = (App.advancedTrainingProgress || []).find(
     (p: any) => p.clientId === clientId,
   );
-  if (!progress || !progress.activeChapterId) return;
+  if (!progress || !progress.activeChapterId) {
+    return;
+  }
 
   // Track every event globally for prerequisite checking
   progress.observeEvent(eventName);
 
   const config = getClientTrainingConfig(clientId);
-  if (!config) return;
+  if (!config) {
+    return;
+  }
 
   const chapter = config.findChapter(progress.activeChapterId);
-  if (!chapter) return;
+  if (!chapter) {
+    return;
+  }
 
   // Find the active sub-chapter, or check all incomplete sub-chapters in order
   const subChaptersToCheck = progress.activeSubChapterId
@@ -259,7 +166,9 @@ App.on("clientAdvancedTrainingAction", ({clientId, eventName, args}: any) => {
       );
 
   for (const subChapter of subChaptersToCheck) {
-    if (!subChapter) continue;
+    if (!subChapter) {
+      continue;
+    }
 
     // Check if this action matches any required action in this sub-chapter.
     // Match on eventName alone — args like simulatorId, clientId, etc. will
@@ -296,6 +205,13 @@ App.on("clientAdvancedTrainingAction", ({clientId, eventName, args}: any) => {
         if (chapterDone) {
           progress.completeChapter(chapter.id);
 
+          // In-flight help is ad-hoc — once finished it stays on screen until
+          // the crew dismisses it (or navigates away). Never auto-advance into
+          // the main chapter sequence and never auto-close.
+          if (progress.inFlightHelp || config.isInFlightChapter(chapter.id)) {
+            break;
+          }
+
           // Auto-login on login chapter completion if configured
           if (
             config.loginChapter?.id === chapter.id &&
@@ -303,8 +219,15 @@ App.on("clientAdvancedTrainingAction", ({clientId, eventName, args}: any) => {
           ) {
             const clientObj = App.clients.find((c: any) => c.id === clientId);
             if (clientObj) {
-              App.emit("clientLogin", {client: clientId, loginName: clientObj.station});
-              App.emit("clientAdvancedTrainingAction", {clientId, eventName: "clientLogin", args: null});
+              App.emit("clientLogin", {
+                client: clientId,
+                loginName: clientObj.station,
+              });
+              App.emit("clientAdvancedTrainingAction", {
+                clientId,
+                eventName: "clientLogin",
+                args: null,
+              });
             }
           }
 
@@ -326,13 +249,19 @@ App.on("advancedTrainingSetActiveChapter", ({clientId, chapterId}: any) => {
   const progress = (App.advancedTrainingProgress || []).find(
     (p: any) => p.clientId === clientId,
   );
-  if (!progress) return;
+  if (!progress) {
+    return;
+  }
 
   const config = getClientTrainingConfig(clientId);
-  if (!config) return;
+  if (!config) {
+    return;
+  }
 
   const chapter = config.findChapter(chapterId);
-  if (!chapter) return;
+  if (!chapter) {
+    return;
+  }
 
   // Block navigation to locked chapters in sequential mode
   // (skip for login/completion chapters — those are auto-managed)
@@ -341,10 +270,14 @@ App.on("advancedTrainingSetActiveChapter", ({clientId, chapterId}: any) => {
     config.completionChapter?.id === chapterId;
 
   if (!isSpecialChapter && config.sequentialChapters) {
-    const chapterIdx = config.chapters.findIndex((c: any) => c.id === chapterId);
+    const chapterIdx = config.chapters.findIndex(
+      (c: any) => c.id === chapterId,
+    );
     if (chapterIdx > 0) {
       const prevChapter = config.chapters[chapterIdx - 1];
-      if (!progress.isChapterComplete(prevChapter.id)) return;
+      if (!progress.isChapterComplete(prevChapter.id)) {
+        return;
+      }
     }
   }
 
@@ -354,142 +287,130 @@ App.on("advancedTrainingSetActiveChapter", ({clientId, chapterId}: any) => {
     const unmet = prerequisites.filter(
       (evt: string) => !progress.globalObservedEvents.includes(evt),
     );
-    if (unmet.length > 0) return;
-  }
-
-  progress.setActiveChapter(chapterId);
-  // Auto-complete chapter if it has no subchapters; otherwise seek first incomplete
-  if (!autoCompleteIfEmpty(progress, chapter)) {
-    const firstIncompleteSub = chapter.subChapters.find(
-      (sc: any) => !progress.isSubChapterComplete(sc.id),
-    );
-    progress.setActiveSubChapter(
-      firstIncompleteSub?.id || chapter.subChapters[0]?.id || null,
-    );
-  }
-
-  progress.setMediaViewerOpen(!!(chapter.autoOpenMedia && chapter.mediaAsset));
-
-  // Handle card switching
-  if (chapter.cardSwitchBehavior === "auto" && chapter.cardComponent) {
-    const client = App.clients.find((c: any) => c.id === clientId);
-    if (client) {
-      const simulator = App.simulators.find(
-        (s: any) => s.id === client.simulatorId,
-      );
-      if (simulator) {
-        const station = simulator.stations?.find(
-          (s: any) => s.name === client.station,
-        );
-        const targetCard = station?.cards?.find(
-          (c: any) => c.component === chapter.cardComponent,
-        );
-        if (targetCard) {
-          App.handleEvent(
-            {id: clientId, card: targetCard.name},
-            "clientSetCard",
-            {clientId},
-          );
-        }
-      }
+    if (unmet.length > 0) {
+      return;
     }
   }
+
+  activateChapter(progress, config, chapter, clientId);
 
   publishProgress();
 });
 
-// --- FD intervention events ---
+// --- In-flight help events ---
 
-App.on("fdCompleteTrainingSubChapter", ({clientId, subChapterId}: any) => {
-  const progress = (App.advancedTrainingProgress || []).find(
-    (p: any) => p.clientId === clientId,
-  );
-  if (!progress) return;
-
-  progress.completeSubChapter(subChapterId);
+App.on("clientRequestTrainingHelp", ({clientId}: any) => {
+  const client = App.clients.find((c: any) => c.id === clientId);
+  if (!client) {
+    return;
+  }
 
   const config = getClientTrainingConfig(clientId);
-  if (config && progress.activeChapterId) {
-    const chapter = config.findChapter(progress.activeChapterId);
-    if (chapter) {
-      const nextSubChapter = chapter.subChapters.find(
-        (sc: any) => !progress.isSubChapterComplete(sc.id),
-      );
-      progress.setActiveSubChapter(nextSubChapter?.id || null);
 
-      const chapterDone = chapter.subChapters.every((sc: any) =>
-        progress.isSubChapterComplete(sc.id),
-      );
-      if (chapterDone) {
-        progress.completeChapter(chapter.id);
-
-        if (
-          config.loginChapter?.id === chapter.id &&
-          config.loginChapter?.autoLogin === "on-complete"
-        ) {
-          const clientObj = App.clients.find((c: any) => c.id === clientId);
-          if (clientObj) {
-            App.emit("clientLogin", {client: clientId, loginName: clientObj.station});
-          }
-        }
-
-        advanceToNextChapter(progress, config, chapter, clientId);
-      }
-    }
+  // No advanced training enabled for this station — fall back to the default
+  // help/question-mark behavior (legacy tour, handled by clientSetTraining).
+  if (!config) {
+    App.handleEvent({client: clientId, training: true}, "clientSetTraining");
+    return;
   }
 
-  publishProgress();
-});
-
-App.on("fdResetTrainingProgress", ({clientId}: any) => {
-  const progress = (App.advancedTrainingProgress || []).find(
-    (p: any) => p.clientId === clientId,
+  // Resolve the crew's current card component (same source as the currentCard
+  // resolver: the simulator's per-client card assignment).
+  const simulator = App.simulators.find(
+    (s: any) => s.id === client.simulatorId,
   );
-  if (!progress) return;
+  const station = simulator?.stations?.find(
+    (s: any) => s.name === client.station,
+  );
+  const currentCardName = simulator?.clientCards?.[clientId];
+  const currentCard = station?.cards?.find(
+    (c: any) => c.name === currentCardName,
+  );
+  const cardComponent = currentCard?.component || "";
 
-  const config = getClientTrainingConfig(clientId);
-  progress.reset();
+  // Priority: an in-flight help chapter dedicated to this card, else fall back
+  // to a regular chapter associated with it. Skip entirely if we can't resolve
+  // the current card so a chapter with an empty cardComponent is never matched
+  // by accident.
+  const inFlightChapter = cardComponent
+    ? config.findInFlightChapterByCard(cardComponent)
+    : undefined;
+  // Fallback: a regular sequence chapter authored for this card, used when the
+  // card has no dedicated in-flight chapter ("location that doesn't have it
+  // defined").
+  const fallbackChapter =
+    !inFlightChapter && cardComponent
+      ? config.chapters.find((c: any) => c.cardComponent === cardComponent)
+      : undefined;
+  const target = inFlightChapter || fallbackChapter;
 
-  // Re-activate first chapter (login chapter if configured, else first regular)
-  if (config) {
-    const startChapter = config.loginChapter || config.chapters[0] || null;
-    if (startChapter) {
-      progress.setActiveChapter(startChapter.id);
-      if (!autoCompleteIfEmpty(progress, startChapter)) {
-        progress.setActiveSubChapter(startChapter.subChapters[0]?.id || null);
-      } else {
-        advanceToNextChapter(progress, config, startChapter, clientId);
-      }
-    }
-
-    if (config.loginChapter?.autoLogin === "immediate") {
-      const client = App.clients.find((c: any) => c.id === clientId);
-      if (client) {
-        App.emit("clientLogin", {client: clientId, loginName: client.station});
-        App.emit("clientAdvancedTrainingAction", {clientId, eventName: "clientLogin", args: null});
-      }
-    }
+  // No chapter associated with this card — default begin-training behavior
+  // (full advanced training from the start, via clientSetTraining).
+  if (!target) {
+    App.handleEvent({client: clientId, training: true}, "clientSetTraining");
+    return;
   }
 
-  publishProgress();
-});
-
-// --- UI state events ---
-
-App.on("advancedTrainingToggleMediaViewer", ({clientId, open}: any) => {
-  const progress = (App.advancedTrainingProgress || []).find(
+  // Ensure a training session exists without resetting one already in progress.
+  let progress = (App.advancedTrainingProgress || []).find(
     (p: any) => p.clientId === clientId,
   );
-  if (!progress) return;
-  progress.setMediaViewerOpen(open);
+  if (!progress) {
+    progress = new AdvancedTrainingProgress({
+      clientId: client.id,
+      simulatorId: client.simulatorId,
+      stationName: client.station,
+    });
+    App.advancedTrainingProgress.push(progress);
+    client.setTraining(true);
+  }
+
+  // Mark this as an in-flight help session so completion never auto-advances or
+  // auto-closes — it stays until the crew dismisses it. When the help came from
+  // the fallback (a card without a dedicated in-flight chapter), bind it to the
+  // current card so navigating away auto-closes it.
+  progress.inFlightHelp = true;
+  progress.inFlightHelpCard = fallbackChapter ? cardComponent : null;
+
+  // Jump straight to the target chapter, bypassing sequential/prerequisite
+  // locks — this is an explicit help request.
+  activateChapter(progress, config, target, clientId);
+
   publishProgress();
+  publishClientChanged();
 });
 
-App.on("advancedTrainingToggleChapterList", ({clientId, open}: any) => {
+// In-flight help launched on a card without a dedicated in-flight chapter is
+// bound to that card. When the crew navigates to a different card, the ad-hoc
+// help is no longer relevant, so auto-close it. (This listener runs alongside
+// the primary clientSetCard handler in events/clients.ts.)
+App.on("clientSetCard", ({id, card}: any) => {
   const progress = (App.advancedTrainingProgress || []).find(
-    (p: any) => p.clientId === clientId,
+    (p: any) => p.clientId === id,
   );
-  if (!progress) return;
-  progress.setChapterListOpen(open);
-  publishProgress();
+  if (!progress || !progress.inFlightHelpCard) {
+    return;
+  }
+
+  const client = App.clients.find((c: any) => c.id === id);
+  if (!client) {
+    return;
+  }
+
+  const simulator = App.simulators.find(
+    (s: any) => s.id === client.simulatorId,
+  );
+  const station = simulator?.stations?.find(
+    (s: any) => s.name === client.station,
+  );
+  const newCard = station?.cards?.find((c: any) => c.name === card);
+  const newComponent = newCard?.component || "";
+
+  // Still on the bound card (e.g. the help itself switched the crew to it) —
+  // leave the session open.
+  if (newComponent === progress.inFlightHelpCard) {
+    return;
+  }
+
+  App.handleEvent({clientId: id}, "clientStopAdvancedTraining");
 });

--- a/server/events/advancedTraining.ts
+++ b/server/events/advancedTraining.ts
@@ -2,6 +2,7 @@ import App from "../app";
 import {pubsub} from "../helpers/subscriptionManager";
 import {AdvancedTrainingConfig} from "../classes/advancedTraining";
 import {AdvancedTrainingProgress} from "../classes/advancedTrainingProgress";
+import {CARD_PREREQUISITES} from "../classes/trainingPrerequisites";
 
 // Ensure the array exists on App
 if (!App.advancedTrainingProgress) {
@@ -51,6 +52,42 @@ function publishClientChanged() {
   pubsub.publish("clientChanged", App.clients);
 }
 
+// Register global listeners for prerequisite events so FD-fired mutations
+// (not just crew actions) unlock chapters as expected.
+const allPrerequisiteEvents = new Set<string>(
+  Object.values(CARD_PREREQUISITES).flat(),
+);
+
+for (const eventName of allPrerequisiteEvents) {
+  App.on(eventName, (args: any) => {
+    const simulatorId =
+      args?.simulatorId ||
+      (args?.clientId
+        ? App.clients.find((c: any) => c.id === args.clientId)?.simulatorId
+        : null);
+    if (!simulatorId) return;
+
+    const affected = (App.advancedTrainingProgress || []).filter(
+      (p: any) => p.simulatorId === simulatorId,
+    );
+    if (affected.length === 0) return;
+
+    for (const prog of affected) {
+      prog.observeEvent(eventName);
+    }
+    publishProgress();
+  });
+}
+
+// Auto-complete a chapter that has no subchapters immediately upon activation.
+function autoCompleteIfEmpty(progress: AdvancedTrainingProgress, chapter: any) {
+  if ((chapter.subChapters || []).length === 0) {
+    progress.completeChapter(chapter.id);
+    return true;
+  }
+  return false;
+}
+
 // --- Configuration events ---
 // These are handled by explicit mutation resolvers in the typeDef.
 // The event handlers here are no-ops; they exist so App.emit doesn't
@@ -87,6 +124,9 @@ App.on("clientStartAdvancedTraining", ({clientId}: any) => {
 
   App.advancedTrainingProgress.push(progress);
 
+  // Auto-complete the starting chapter if it has no subchapters
+  if (startChapter) autoCompleteIfEmpty(progress, startChapter);
+
   // Also set the legacy training flag so the system knows
   client.setTraining(true);
 
@@ -116,6 +156,9 @@ App.on("clientAdvancedTrainingAction", ({clientId, eventName, args}: any) => {
   );
   if (!progress || !progress.activeChapterId) return;
 
+  // Track every event globally for prerequisite checking
+  progress.observeEvent(eventName);
+
   const config = getClientTrainingConfig(clientId);
   if (!config) return;
 
@@ -136,6 +179,8 @@ App.on("clientAdvancedTrainingAction", ({clientId, eventName, args}: any) => {
     // Match on eventName alone — args like simulatorId, clientId, etc. will
     // always differ between the recording session and a live flight, so
     // strict arg comparison would never match.
+    // __videoComplete__ is a synthetic event fired by the media viewer and
+    // can be added as a required action just like any other event.
     const matchingAction = subChapter.requiredActions.find(
       (ra: any) => ra.eventName === eventName,
     );
@@ -189,8 +234,11 @@ App.on("clientAdvancedTrainingAction", ({clientId, eventName, args}: any) => {
 
             if (nextChapter) {
               progress.setActiveChapter(nextChapter.id);
-              const firstSub = nextChapter.subChapters[0];
-              progress.setActiveSubChapter(firstSub?.id || null);
+              // Auto-complete if the next chapter has no subchapters
+              if (!autoCompleteIfEmpty(progress, nextChapter)) {
+                const firstSub = nextChapter.subChapters[0];
+                progress.setActiveSubChapter(firstSub?.id || null);
+              }
 
               // Auto-open media if configured
               if (nextChapter.autoOpenMedia && nextChapter.mediaAsset) {
@@ -265,13 +313,25 @@ App.on("advancedTrainingSetActiveChapter", ({clientId, chapterId}: any) => {
     }
   }
 
+  // Block navigation to chapters whose system prerequisites haven't fired
+  if (!isSpecialChapter) {
+    const prerequisites = CARD_PREREQUISITES[chapter.cardComponent] || [];
+    const unmet = prerequisites.filter(
+      (evt: string) => !progress.globalObservedEvents.includes(evt),
+    );
+    if (unmet.length > 0) return;
+  }
+
   progress.setActiveChapter(chapterId);
-  const firstIncompleteSub = chapter.subChapters.find(
-    (sc: any) => !progress.isSubChapterComplete(sc.id),
-  );
-  progress.setActiveSubChapter(
-    firstIncompleteSub?.id || chapter.subChapters[0]?.id || null,
-  );
+  // Auto-complete chapter if it has no subchapters; otherwise seek first incomplete
+  if (!autoCompleteIfEmpty(progress, chapter)) {
+    const firstIncompleteSub = chapter.subChapters.find(
+      (sc: any) => !progress.isSubChapterComplete(sc.id),
+    );
+    progress.setActiveSubChapter(
+      firstIncompleteSub?.id || chapter.subChapters[0]?.id || null,
+    );
+  }
 
   // Auto-open media if configured
   if (chapter.autoOpenMedia && chapter.mediaAsset) {

--- a/server/events/advancedTraining.ts
+++ b/server/events/advancedTraining.ts
@@ -88,6 +88,77 @@ function autoCompleteIfEmpty(progress: AdvancedTrainingProgress, chapter: any) {
   return false;
 }
 
+// Advance to the chapter that follows completedChapter, respecting autoAdvance,
+// autoOpenMedia, and cardSwitchBehavior. Resets mediaViewerOpen before opening.
+function advanceToNextChapter(
+  progress: AdvancedTrainingProgress,
+  config: any,
+  completedChapter: any,
+  clientId: string,
+) {
+  if (!completedChapter.autoAdvance) return;
+
+  let nextChapter: any = null;
+
+  if (config.loginChapter?.id === completedChapter.id) {
+    nextChapter = config.chapters[0] || null;
+  } else if (config.completionChapter?.id === completedChapter.id) {
+    nextChapter = null;
+  } else {
+    const chapterIdx = config.chapters.findIndex(
+      (c: any) => c.id === completedChapter.id,
+    );
+    if (chapterIdx === -1) return;
+    nextChapter = config.chapters[chapterIdx + 1] || null;
+    if (!nextChapter && config.completionChapter) {
+      nextChapter = config.completionChapter;
+    }
+  }
+
+  if (!nextChapter) return;
+
+  progress.setMediaViewerOpen(false);
+  progress.setActiveChapter(nextChapter.id);
+
+  if (!autoCompleteIfEmpty(progress, nextChapter)) {
+    const firstSub = nextChapter.subChapters[0];
+    progress.setActiveSubChapter(firstSub?.id || null);
+  } else {
+    // nextChapter had no sub-chapters and was immediately auto-completed.
+    // Chain forward so a sequence of empty autoAdvance chapters doesn't stall.
+    advanceToNextChapter(progress, config, nextChapter, clientId);
+    return;
+  }
+
+  if (nextChapter.autoOpenMedia && nextChapter.mediaAsset) {
+    progress.setMediaViewerOpen(true);
+  }
+
+  if (nextChapter.cardSwitchBehavior === "auto" && nextChapter.cardComponent) {
+    const client = App.clients.find((c: any) => c.id === clientId);
+    if (client) {
+      const simulator = App.simulators.find(
+        (s: any) => s.id === client.simulatorId,
+      );
+      if (simulator) {
+        const station = simulator.stations?.find(
+          (s: any) => s.name === client.station,
+        );
+        const targetCard = station?.cards?.find(
+          (c: any) => c.component === nextChapter.cardComponent,
+        );
+        if (targetCard) {
+          App.handleEvent(
+            {id: clientId, card: targetCard.name},
+            "clientSetCard",
+            {clientId},
+          );
+        }
+      }
+    }
+  }
+}
+
 // --- Configuration events ---
 // These are handled by explicit mutation resolvers in the typeDef.
 // The event handlers here are no-ops; they exist so App.emit doesn't
@@ -119,13 +190,28 @@ App.on("clientStartAdvancedTraining", ({clientId}: any) => {
     stationName: client.station,
     activeChapterId: startChapter?.id || null,
     activeSubChapterId: firstSubChapter?.id || null,
-    mediaViewerOpen: startChapter?.autoOpenMedia ?? false,
+    mediaViewerOpen: !!(startChapter?.autoOpenMedia && startChapter?.mediaAsset),
   });
 
   App.advancedTrainingProgress.push(progress);
 
-  // Auto-complete the starting chapter if it has no subchapters
-  if (startChapter) autoCompleteIfEmpty(progress, startChapter);
+  // Fire immediate auto-login before auto-complete so the clientLogin action is
+  // tracked against the loginChapter while it's still the active chapter.
+  // (If it fired after chaining, it would land on whatever chapter ended up active.)
+  if (config.loginChapter?.autoLogin === "immediate") {
+    App.emit("clientLogin", {client: clientId, loginName: client.station});
+    App.emit("clientAdvancedTrainingAction", {clientId, eventName: "clientLogin", args: null});
+  }
+
+  // Auto-complete the starting chapter if it has no sub-chapters, then chain
+  // forward if it also has autoAdvance. Guard on activeChapterId in case the
+  // clientAdvancedTrainingAction above already advanced the chapter (e.g. a
+  // clientLogin sub-chapter completed it).
+  if (startChapter && progress.activeChapterId === startChapter.id) {
+    if (autoCompleteIfEmpty(progress, startChapter)) {
+      advanceToNextChapter(progress, config, startChapter, clientId);
+    }
+  }
 
   // Also set the legacy training flag so the system knows
   client.setTraining(true);
@@ -210,70 +296,19 @@ App.on("clientAdvancedTrainingAction", ({clientId, eventName, args}: any) => {
         if (chapterDone) {
           progress.completeChapter(chapter.id);
 
-          // Auto-advance to next chapter if configured
-          if (chapter.autoAdvance) {
-            let nextChapter: any = null;
-
-            if (config.loginChapter?.id === chapter.id) {
-              // Login chapter complete → go to first regular chapter
-              nextChapter = config.chapters[0] || null;
-            } else if (config.completionChapter?.id === chapter.id) {
-              // Completion chapter is terminal, no further advance
-              nextChapter = null;
-            } else {
-              // Regular chapter — find the next one
-              const chapterIdx = config.chapters.findIndex(
-                (c: any) => c.id === chapter.id,
-              );
-              nextChapter = config.chapters[chapterIdx + 1] || null;
-              // If no next regular chapter, go to completion chapter if configured
-              if (!nextChapter && config.completionChapter) {
-                nextChapter = config.completionChapter;
-              }
-            }
-
-            if (nextChapter) {
-              progress.setActiveChapter(nextChapter.id);
-              // Auto-complete if the next chapter has no subchapters
-              if (!autoCompleteIfEmpty(progress, nextChapter)) {
-                const firstSub = nextChapter.subChapters[0];
-                progress.setActiveSubChapter(firstSub?.id || null);
-              }
-
-              // Auto-open media if configured
-              if (nextChapter.autoOpenMedia && nextChapter.mediaAsset) {
-                progress.setMediaViewerOpen(true);
-              }
-
-              // Handle card switching (only for regular chapters with a cardComponent)
-              if (nextChapter.cardSwitchBehavior === "auto" && nextChapter.cardComponent) {
-                const client = App.clients.find(
-                  (c: any) => c.id === clientId,
-                );
-                if (client) {
-                  // Find the card on the station that matches the next chapter's component
-                  const simulator = App.simulators.find(
-                    (s: any) => s.id === client.simulatorId,
-                  );
-                  if (simulator) {
-                    const station = simulator.stations?.find(
-                      (s: any) => s.name === client.station,
-                    );
-                    const targetCard = station?.cards?.find(
-                      (c: any) => c.component === nextChapter.cardComponent,
-                    );
-                    if (targetCard) {
-                      App.handleEvent(
-                        {id: clientId, card: targetCard.name},
-                        "clientSetCard",
-                        {clientId},
-                      );
-                    }
-                  }
-                }
-              }
+          // Auto-login on login chapter completion if configured
+          if (
+            config.loginChapter?.id === chapter.id &&
+            config.loginChapter?.autoLogin === "on-complete"
+          ) {
+            const clientObj = App.clients.find((c: any) => c.id === clientId);
+            if (clientObj) {
+              App.emit("clientLogin", {client: clientId, loginName: clientObj.station});
+              App.emit("clientAdvancedTrainingAction", {clientId, eventName: "clientLogin", args: null});
             }
           }
+
+          advanceToNextChapter(progress, config, chapter, clientId);
         }
       }
 
@@ -333,13 +368,10 @@ App.on("advancedTrainingSetActiveChapter", ({clientId, chapterId}: any) => {
     );
   }
 
-  // Auto-open media if configured
-  if (chapter.autoOpenMedia && chapter.mediaAsset) {
-    progress.setMediaViewerOpen(true);
-  }
+  progress.setMediaViewerOpen(!!(chapter.autoOpenMedia && chapter.mediaAsset));
 
   // Handle card switching
-  if (chapter.cardSwitchBehavior === "auto") {
+  if (chapter.cardSwitchBehavior === "auto" && chapter.cardComponent) {
     const client = App.clients.find((c: any) => c.id === clientId);
     if (client) {
       const simulator = App.simulators.find(
@@ -376,16 +408,32 @@ App.on("fdCompleteTrainingSubChapter", ({clientId, subChapterId}: any) => {
 
   progress.completeSubChapter(subChapterId);
 
-  // Check if this completes the chapter
   const config = getClientTrainingConfig(clientId);
   if (config && progress.activeChapterId) {
-    const chapter = config.getChapter(progress.activeChapterId);
+    const chapter = config.findChapter(progress.activeChapterId);
     if (chapter) {
+      const nextSubChapter = chapter.subChapters.find(
+        (sc: any) => !progress.isSubChapterComplete(sc.id),
+      );
+      progress.setActiveSubChapter(nextSubChapter?.id || null);
+
       const chapterDone = chapter.subChapters.every((sc: any) =>
         progress.isSubChapterComplete(sc.id),
       );
       if (chapterDone) {
         progress.completeChapter(chapter.id);
+
+        if (
+          config.loginChapter?.id === chapter.id &&
+          config.loginChapter?.autoLogin === "on-complete"
+        ) {
+          const clientObj = App.clients.find((c: any) => c.id === clientId);
+          if (clientObj) {
+            App.emit("clientLogin", {client: clientId, loginName: clientObj.station});
+          }
+        }
+
+        advanceToNextChapter(progress, config, chapter, clientId);
       }
     }
   }
@@ -407,7 +455,19 @@ App.on("fdResetTrainingProgress", ({clientId}: any) => {
     const startChapter = config.loginChapter || config.chapters[0] || null;
     if (startChapter) {
       progress.setActiveChapter(startChapter.id);
-      progress.setActiveSubChapter(startChapter.subChapters[0]?.id || null);
+      if (!autoCompleteIfEmpty(progress, startChapter)) {
+        progress.setActiveSubChapter(startChapter.subChapters[0]?.id || null);
+      } else {
+        advanceToNextChapter(progress, config, startChapter, clientId);
+      }
+    }
+
+    if (config.loginChapter?.autoLogin === "immediate") {
+      const client = App.clients.find((c: any) => c.id === clientId);
+      if (client) {
+        App.emit("clientLogin", {client: clientId, loginName: client.station});
+        App.emit("clientAdvancedTrainingAction", {clientId, eventName: "clientLogin", args: null});
+      }
     }
   }
 

--- a/server/events/advancedTrainingFdEvents.ts
+++ b/server/events/advancedTrainingFdEvents.ts
@@ -1,0 +1,126 @@
+import App from "../app";
+import {
+  getClientTrainingConfig,
+  publishProgress,
+  autoCompleteIfEmpty,
+  advanceToNextChapter,
+} from "./advancedTrainingHelpers";
+
+// Flight-Director intervention and UI-state listeners for advanced training.
+// Split out from ./advancedTraining (which owns the crew-driven session and
+// action-tracking listeners) to keep each file focused.
+
+// --- FD intervention events ---
+
+App.on("fdCompleteTrainingSubChapter", ({clientId, subChapterId}: any) => {
+  const progress = (App.advancedTrainingProgress || []).find(
+    (p: any) => p.clientId === clientId,
+  );
+  if (!progress) {
+    return;
+  }
+
+  progress.completeSubChapter(subChapterId);
+
+  const config = getClientTrainingConfig(clientId);
+  if (config && progress.activeChapterId) {
+    const chapter = config.findChapter(progress.activeChapterId);
+    if (chapter) {
+      const nextSubChapter = chapter.subChapters.find(
+        (sc: any) => !progress.isSubChapterComplete(sc.id),
+      );
+      progress.setActiveSubChapter(nextSubChapter?.id || null);
+
+      const chapterDone = chapter.subChapters.every((sc: any) =>
+        progress.isSubChapterComplete(sc.id),
+      );
+      if (chapterDone) {
+        progress.completeChapter(chapter.id);
+
+        // In-flight help stays on screen until the crew dismisses it; never
+        // auto-advance into the main chapter sequence.
+        if (!(progress.inFlightHelp || config.isInFlightChapter(chapter.id))) {
+          if (
+            config.loginChapter?.id === chapter.id &&
+            config.loginChapter?.autoLogin === "on-complete"
+          ) {
+            const clientObj = App.clients.find((c: any) => c.id === clientId);
+            if (clientObj) {
+              App.emit("clientLogin", {
+                client: clientId,
+                loginName: clientObj.station,
+              });
+            }
+          }
+
+          advanceToNextChapter(progress, config, chapter, clientId);
+        }
+      }
+    }
+  }
+
+  publishProgress();
+});
+
+App.on("fdResetTrainingProgress", ({clientId}: any) => {
+  const progress = (App.advancedTrainingProgress || []).find(
+    (p: any) => p.clientId === clientId,
+  );
+  if (!progress) {
+    return;
+  }
+
+  const config = getClientTrainingConfig(clientId);
+  progress.reset();
+
+  // Re-activate first chapter (login chapter if configured, else first regular)
+  if (config) {
+    const startChapter = config.loginChapter || config.chapters[0] || null;
+    if (startChapter) {
+      progress.setActiveChapter(startChapter.id);
+      if (!autoCompleteIfEmpty(progress, startChapter)) {
+        progress.setActiveSubChapter(startChapter.subChapters[0]?.id || null);
+      } else {
+        advanceToNextChapter(progress, config, startChapter, clientId);
+      }
+    }
+
+    if (config.loginChapter?.autoLogin === "immediate") {
+      const client = App.clients.find((c: any) => c.id === clientId);
+      if (client) {
+        App.emit("clientLogin", {client: clientId, loginName: client.station});
+        App.emit("clientAdvancedTrainingAction", {
+          clientId,
+          eventName: "clientLogin",
+          args: null,
+        });
+      }
+    }
+  }
+
+  publishProgress();
+});
+
+// --- UI state events ---
+
+App.on("advancedTrainingToggleMediaViewer", ({clientId, open}: any) => {
+  const progress = (App.advancedTrainingProgress || []).find(
+    (p: any) => p.clientId === clientId,
+  );
+  if (!progress) {
+    return;
+  }
+  progress.setMediaViewerOpen(open);
+  publishProgress();
+});
+
+App.on("advancedTrainingToggleChapterList", ({clientId, open}: any) => {
+  const progress = (App.advancedTrainingProgress || []).find(
+    (p: any) => p.clientId === clientId,
+  );
+  if (!progress) {
+    return;
+  }
+  progress.setChapterListOpen(open);
+  publishProgress();
+});

--- a/server/events/advancedTrainingHelpers.ts
+++ b/server/events/advancedTrainingHelpers.ts
@@ -1,0 +1,165 @@
+import App from "../app";
+import {pubsub} from "../helpers/subscriptionManager";
+import {AdvancedTrainingProgress} from "../classes/advancedTrainingProgress";
+
+// Shared helpers for the advanced-training event handlers. Kept separate from
+// the listener registrations in ./advancedTraining so neither file grows
+// unwieldy.
+
+// Resolve a client's training config from the station they're currently on.
+// Returns null unless the station has advanced training explicitly enabled.
+export function getClientTrainingConfig(clientId: string) {
+  const client = App.clients.find((c: any) => c.id === clientId);
+  if (!client || !client.simulatorId || !client.station) {
+    return null;
+  }
+
+  // Look up the station directly on the simulator (not the station set template,
+  // which has a different simulatorId — the template's, not the flight instance's)
+  const simulator = App.simulators.find(
+    (s: any) => s.id === client.simulatorId,
+  );
+  if (!simulator) {
+    return null;
+  }
+
+  const station = simulator.stations?.find(
+    (s: any) => s.name === client.station,
+  );
+  if (!station || !station.advancedTraining?.enabled) {
+    return null;
+  }
+
+  return station.advancedTraining;
+}
+
+export function publishProgress() {
+  pubsub.publish(
+    "advancedTrainingProgressUpdate",
+    App.advancedTrainingProgress || [],
+  );
+}
+
+export function publishClientChanged() {
+  pubsub.publish("clientChanged", App.clients);
+}
+
+// Auto-complete a chapter that has no subchapters immediately upon activation.
+export function autoCompleteIfEmpty(
+  progress: AdvancedTrainingProgress,
+  chapter: any,
+) {
+  if ((chapter.subChapters || []).length === 0) {
+    progress.completeChapter(chapter.id);
+    return true;
+  }
+  return false;
+}
+
+// Switch the crew's card to the one backing a chapter, when that chapter
+// requests automatic card switching. No-ops gracefully if the card isn't on the
+// station (e.g. an in-flight help chapter authored for a card added later).
+function autoSwitchCardForChapter(chapter: any, clientId: string) {
+  if (chapter.cardSwitchBehavior !== "auto" || !chapter.cardComponent) {
+    return;
+  }
+  const client = App.clients.find((c: any) => c.id === clientId);
+  if (!client) {
+    return;
+  }
+  const simulator = App.simulators.find(
+    (s: any) => s.id === client.simulatorId,
+  );
+  const station = simulator?.stations?.find(
+    (s: any) => s.name === client.station,
+  );
+  const targetCard = station?.cards?.find(
+    (c: any) => c.component === chapter.cardComponent,
+  );
+  if (targetCard) {
+    App.handleEvent({id: clientId, card: targetCard.name}, "clientSetCard", {
+      clientId,
+    });
+  }
+}
+
+// Advance to the chapter that follows completedChapter, respecting autoAdvance,
+// autoOpenMedia, and cardSwitchBehavior. Resets mediaViewerOpen before opening.
+export function advanceToNextChapter(
+  progress: AdvancedTrainingProgress,
+  config: any,
+  completedChapter: any,
+  clientId: string,
+) {
+  if (!completedChapter.autoAdvance) {
+    return;
+  }
+
+  let nextChapter: any = null;
+
+  if (config.loginChapter?.id === completedChapter.id) {
+    nextChapter = config.chapters[0] || null;
+  } else if (config.completionChapter?.id === completedChapter.id) {
+    nextChapter = null;
+  } else {
+    const chapterIdx = config.chapters.findIndex(
+      (c: any) => c.id === completedChapter.id,
+    );
+    if (chapterIdx === -1) {
+      return;
+    }
+    nextChapter = config.chapters[chapterIdx + 1] || null;
+    if (!nextChapter && config.completionChapter) {
+      nextChapter = config.completionChapter;
+    }
+  }
+
+  if (!nextChapter) {
+    return;
+  }
+
+  progress.setMediaViewerOpen(false);
+  progress.setActiveChapter(nextChapter.id);
+
+  if (!autoCompleteIfEmpty(progress, nextChapter)) {
+    const firstSub = nextChapter.subChapters[0];
+    progress.setActiveSubChapter(firstSub?.id || null);
+  } else {
+    // nextChapter had no sub-chapters and was immediately auto-completed.
+    // Chain forward so a sequence of empty autoAdvance chapters doesn't stall.
+    advanceToNextChapter(progress, config, nextChapter, clientId);
+    return;
+  }
+
+  if (nextChapter.autoOpenMedia && nextChapter.mediaAsset) {
+    progress.setMediaViewerOpen(true);
+  }
+
+  autoSwitchCardForChapter(nextChapter, clientId);
+}
+
+// Activate a chapter for a client: set it active, seek the first incomplete
+// sub-chapter (or auto-complete it if empty), open media if configured, and
+// switch the crew's card if the chapter requests auto card switching. Does NOT
+// enforce sequential/prerequisite locks — callers gate that themselves.
+export function activateChapter(
+  progress: AdvancedTrainingProgress,
+  config: any,
+  chapter: any,
+  clientId: string,
+) {
+  progress.setActiveChapter(chapter.id);
+
+  if (!autoCompleteIfEmpty(progress, chapter)) {
+    const firstIncompleteSub = chapter.subChapters.find(
+      (sc: any) => !progress.isSubChapterComplete(sc.id),
+    );
+    progress.setActiveSubChapter(
+      firstIncompleteSub?.id || chapter.subChapters[0]?.id || null,
+    );
+  }
+
+  progress.setMediaViewerOpen(!!(chapter.autoOpenMedia && chapter.mediaAsset));
+
+  autoSwitchCardForChapter(chapter, clientId);
+}

--- a/server/events/assets.js
+++ b/server/events/assets.js
@@ -10,6 +10,15 @@ if (process.env.NODE_ENV === "production") {
   assetDir = paths.userData + "/assets";
 }
 
+// Ensure default asset folders exist
+const defaultFolders = ["/Training"];
+for (const folder of defaultFolders) {
+  const folderPath = `${assetDir}${folder}`;
+  if (!fs.existsSync(folderPath)) {
+    fs.mkdirSync(folderPath, {recursive: true});
+  }
+}
+
 function getFolders(dir, folderList = []) {
   const folders = fs
     .readdirSync(dir)

--- a/server/events/clients.ts
+++ b/server/events/clients.ts
@@ -221,6 +221,26 @@ App.on("clientOfflineState", ({client, state}) => {
 });
 App.on("clientSetTraining", ({client, training}) => {
   const clientObj = App.clients.find(c => c.id === client);
+
+  // If the station has advanced training enabled, delegate to that system
+  if (training && clientObj?.simulatorId && clientObj?.station) {
+    const simulator = App.simulators.find(
+      (s: any) => s.id === clientObj.simulatorId,
+    );
+    const station = simulator?.stations?.find(
+      (s: any) => s.name === clientObj.station,
+    );
+    if (station?.advancedTraining?.enabled) {
+      App.handleEvent({clientId: client}, "clientStartAdvancedTraining");
+      return;
+    }
+  }
+
+  // If stopping training, also stop any advanced training session
+  if (!training) {
+    App.handleEvent({clientId: client}, "clientStopAdvancedTraining");
+  }
+
   clientObj.setTraining(training);
   pubsub.publish("clientChanged", App.clients);
 });

--- a/server/events/clients.ts
+++ b/server/events/clients.ts
@@ -221,9 +221,10 @@ App.on("clientOfflineState", ({client, state}) => {
 });
 App.on("clientSetTraining", ({client, training}) => {
   const clientObj = App.clients.find(c => c.id === client);
+  if (!clientObj) return;
 
   // If the station has advanced training enabled, delegate to that system
-  if (training && clientObj?.simulatorId && clientObj?.station) {
+  if (training && clientObj.simulatorId && clientObj.station) {
     const simulator = App.simulators.find(
       (s: any) => s.id === clientObj.simulatorId,
     );
@@ -236,9 +237,10 @@ App.on("clientSetTraining", ({client, training}) => {
     }
   }
 
-  // If stopping training, also stop any advanced training session
+  // clientStopAdvancedTraining handles setTraining(false) + clientChanged publish
   if (!training) {
     App.handleEvent({clientId: client}, "clientStopAdvancedTraining");
+    return;
   }
 
   clientObj.setTraining(training);

--- a/server/events/index.js
+++ b/server/events/index.js
@@ -63,3 +63,4 @@ import "./Countermeasures";
 import "./hullPlating";
 import "./edVenturesApp";
 import "./advancedNavigationAndAstrometrics";
+import "./advancedTraining";

--- a/server/helpers/defaultSnapshot.js
+++ b/server/helpers/defaultSnapshot.js
@@ -13637,6 +13637,7 @@ export function getDefaultSnapshot(){return {
   dmxConfigs: [],
   dmxDevices: [],
   hackingPresets: [],
+  advancedTrainingProgress: [],
   printQueue: [],
   autoUpdate: true,
   thoriumId: randomWords(5).join("-"),

--- a/server/typeDefs/advancedTraining.ts
+++ b/server/typeDefs/advancedTraining.ts
@@ -39,6 +39,7 @@ const schema = gql`
   type AdvancedTrainingConfig {
     enabled: Boolean!
     sequentialChapters: Boolean!
+    stripPosition: String!
     chapters: [AdvancedTrainingChapter!]!
     loginChapter: AdvancedTrainingChapter
     completionChapter: AdvancedTrainingChapter
@@ -54,6 +55,7 @@ const schema = gql`
     completedChapterIds: [ID!]!
     completedSubChapterIds: [ID!]!
     observedActions: JSON
+    globalObservedEvents: [String!]!
     mediaViewerOpen: Boolean!
     chapterListOpen: Boolean!
   }
@@ -86,6 +88,7 @@ const schema = gql`
   input AdvancedTrainingConfigInput {
     enabled: Boolean
     sequentialChapters: Boolean
+    stripPosition: String
     chapters: [AdvancedTrainingChapterInput!]
     loginChapter: AdvancedTrainingChapterInput
     completionChapter: AdvancedTrainingChapterInput
@@ -232,7 +235,7 @@ const resolver = {
       }
       station.advancedTraining.setEnabled(enabled);
       pubsub.publish("stationSetUpdate", App.stationSets);
-      return "";
+      pubsub.publish("advancedTrainingConfigUpdate", App.stationSets);
     },
     clientStartAdvancedTraining(rootValue: any, {clientId}: any) {
       // Handled by event handler

--- a/server/typeDefs/advancedTraining.ts
+++ b/server/typeDefs/advancedTraining.ts
@@ -6,7 +6,9 @@ import {AdvancedTrainingConfig} from "../classes/advancedTraining";
 
 function getStationConfig(stationSetID: string, stationName: string) {
   const stationSet = App.stationSets.find((s: any) => s.id === stationSetID);
-  if (!stationSet) return null;
+  if (!stationSet) {
+    return null;
+  }
   return stationSet.stations.find((s: any) => s.name === stationName);
 }
 
@@ -42,6 +44,7 @@ const schema = gql`
     sequentialChapters: Boolean!
     stripPosition: String!
     chapters: [AdvancedTrainingChapter!]!
+    inFlightChapters: [AdvancedTrainingChapter!]!
     loginChapter: AdvancedTrainingChapter
     completionChapter: AdvancedTrainingChapter
   }
@@ -92,6 +95,7 @@ const schema = gql`
     sequentialChapters: Boolean
     stripPosition: String
     chapters: [AdvancedTrainingChapterInput!]
+    inFlightChapters: [AdvancedTrainingChapterInput!]
     loginChapter: AdvancedTrainingChapterInput
     completionChapter: AdvancedTrainingChapterInput
   }
@@ -142,6 +146,13 @@ const schema = gql`
     clientStopAdvancedTraining(clientId: ID!): String
 
     """
+    Crew pressed the help/question-mark widget. Resolves the crew's current card
+    and jumps to the in-flight help chapter for that card (or the regular chapter
+    for it), falling back to the default begin-training behavior if neither exists.
+    """
+    clientRequestTrainingHelp(clientId: ID!): String
+
+    """
     Record a crew action during advanced training.
     Checks against required actions and may trigger sub-chapter/chapter completion.
     """
@@ -154,18 +165,12 @@ const schema = gql`
     """
     Set the active chapter for a client (crew navigation or FD override).
     """
-    advancedTrainingSetActiveChapter(
-      clientId: ID!
-      chapterId: ID!
-    ): String
+    advancedTrainingSetActiveChapter(clientId: ID!, chapterId: ID!): String
 
     """
     FD force-complete a sub-chapter for a client.
     """
-    fdCompleteTrainingSubChapter(
-      clientId: ID!
-      subChapterId: ID!
-    ): String
+    fdCompleteTrainingSubChapter(clientId: ID!, subChapterId: ID!): String
 
     """
     FD reset all training progress for a client.
@@ -175,22 +180,18 @@ const schema = gql`
     """
     Toggle the media viewer open/close for a client.
     """
-    advancedTrainingToggleMediaViewer(
-      clientId: ID!
-      open: Boolean!
-    ): String
+    advancedTrainingToggleMediaViewer(clientId: ID!, open: Boolean!): String
 
     """
     Toggle the chapter list open/close for a client.
     """
-    advancedTrainingToggleChapterList(
-      clientId: ID!
-      open: Boolean!
-    ): String
+    advancedTrainingToggleChapterList(clientId: ID!, open: Boolean!): String
   }
 
   extend type Subscription {
-    advancedTrainingProgressUpdate(simulatorId: ID): [AdvancedTrainingProgress!]!
+    advancedTrainingProgressUpdate(
+      simulatorId: ID
+    ): [AdvancedTrainingProgress!]!
     advancedTrainingConfigUpdate(stationSetID: ID): [StationSet!]!
   }
 `;
@@ -203,9 +204,11 @@ const resolver = {
   },
   Client: {
     advancedTrainingProgress(client: any) {
-      return App.advancedTrainingProgress?.find(
-        (p: any) => p.clientId === client.id,
-      ) || null;
+      return (
+        App.advancedTrainingProgress?.find(
+          (p: any) => p.clientId === client.id,
+        ) || null
+      );
     },
   },
   Query: {
@@ -221,17 +224,27 @@ const resolver = {
     },
   },
   Mutation: {
-    setStationAdvancedTraining(rootValue: any, {stationSetID, stationName, config}: any) {
+    setStationAdvancedTraining(
+      rootValue: any,
+      {stationSetID, stationName, config}: any,
+    ) {
       const station = getStationConfig(stationSetID, stationName);
-      if (!station) return "";
+      if (!station) {
+        return "";
+      }
       station.setAdvancedTraining(config);
       pubsub.publish("stationSetUpdate", App.stationSets);
       pubsub.publish("advancedTrainingConfigUpdate", App.stationSets);
       return "";
     },
-    toggleAdvancedTrainingMode(rootValue: any, {stationSetID, stationName, enabled}: any) {
+    toggleAdvancedTrainingMode(
+      rootValue: any,
+      {stationSetID, stationName, enabled}: any,
+    ) {
       const station = getStationConfig(stationSetID, stationName);
-      if (!station) return "";
+      if (!station) {
+        return "";
+      }
       if (!station.advancedTraining) {
         station.advancedTraining = new AdvancedTrainingConfig();
       }
@@ -246,13 +259,26 @@ const resolver = {
     clientStopAdvancedTraining(rootValue: any, {clientId}: any) {
       return "";
     },
-    clientAdvancedTrainingAction(rootValue: any, {clientId, eventName, args}: any) {
+    clientRequestTrainingHelp(rootValue: any, {clientId}: any) {
+      // Handled by event handler
       return "";
     },
-    advancedTrainingSetActiveChapter(rootValue: any, {clientId, chapterId}: any) {
+    clientAdvancedTrainingAction(
+      rootValue: any,
+      {clientId, eventName, args}: any,
+    ) {
       return "";
     },
-    fdCompleteTrainingSubChapter(rootValue: any, {clientId, subChapterId}: any) {
+    advancedTrainingSetActiveChapter(
+      rootValue: any,
+      {clientId, chapterId}: any,
+    ) {
+      return "";
+    },
+    fdCompleteTrainingSubChapter(
+      rootValue: any,
+      {clientId, subChapterId}: any,
+    ) {
       return "";
     },
     fdResetTrainingProgress(rootValue: any, {clientId}: any) {

--- a/server/typeDefs/advancedTraining.ts
+++ b/server/typeDefs/advancedTraining.ts
@@ -30,6 +30,7 @@ const schema = gql`
     mediaAsset: String
     autoOpenMedia: Boolean!
     autoAdvance: Boolean!
+    autoLogin: String!
     cardSwitchBehavior: String!
     mediaSize: String!
     mediaPosition: String!
@@ -79,6 +80,7 @@ const schema = gql`
     mediaAsset: String
     autoOpenMedia: Boolean
     autoAdvance: Boolean
+    autoLogin: String
     cardSwitchBehavior: String
     mediaSize: String
     mediaPosition: String

--- a/server/typeDefs/advancedTraining.ts
+++ b/server/typeDefs/advancedTraining.ts
@@ -1,0 +1,300 @@
+import App from "../app";
+import {gql, withFilter} from "apollo-server-express";
+import {pubsub} from "../helpers/subscriptionManager";
+import uuid from "uuid";
+import {AdvancedTrainingConfig} from "../classes/advancedTraining";
+
+function getStationConfig(stationSetID: string, stationName: string) {
+  const stationSet = App.stationSets.find((s: any) => s.id === stationSetID);
+  if (!stationSet) return null;
+  return stationSet.stations.find((s: any) => s.name === stationName);
+}
+
+const schema = gql`
+  type AdvancedTrainingRequiredAction {
+    id: ID!
+    eventName: String!
+    args: JSON
+  }
+
+  type AdvancedTrainingSubChapter {
+    id: ID!
+    name: String!
+    requiredActions: [AdvancedTrainingRequiredAction!]!
+  }
+
+  type AdvancedTrainingChapter {
+    id: ID!
+    name: String!
+    cardComponent: String!
+    mediaAsset: String
+    autoOpenMedia: Boolean!
+    autoAdvance: Boolean!
+    cardSwitchBehavior: String!
+    mediaSize: String!
+    mediaPosition: String!
+    subChapters: [AdvancedTrainingSubChapter!]!
+  }
+
+  type AdvancedTrainingConfig {
+    enabled: Boolean!
+    sequentialChapters: Boolean!
+    chapters: [AdvancedTrainingChapter!]!
+    loginChapter: AdvancedTrainingChapter
+    completionChapter: AdvancedTrainingChapter
+  }
+
+  type AdvancedTrainingProgress {
+    id: ID!
+    clientId: ID!
+    simulatorId: ID!
+    stationName: String!
+    activeChapterId: ID
+    activeSubChapterId: ID
+    completedChapterIds: [ID!]!
+    completedSubChapterIds: [ID!]!
+    observedActions: JSON
+    mediaViewerOpen: Boolean!
+    chapterListOpen: Boolean!
+  }
+
+  input AdvancedTrainingRequiredActionInput {
+    id: ID
+    eventName: String!
+    args: JSON
+  }
+
+  input AdvancedTrainingSubChapterInput {
+    id: ID
+    name: String!
+    requiredActions: [AdvancedTrainingRequiredActionInput!]
+  }
+
+  input AdvancedTrainingChapterInput {
+    id: ID
+    name: String!
+    cardComponent: String!
+    mediaAsset: String
+    autoOpenMedia: Boolean
+    autoAdvance: Boolean
+    cardSwitchBehavior: String
+    mediaSize: String
+    mediaPosition: String
+    subChapters: [AdvancedTrainingSubChapterInput!]
+  }
+
+  input AdvancedTrainingConfigInput {
+    enabled: Boolean
+    sequentialChapters: Boolean
+    chapters: [AdvancedTrainingChapterInput!]
+    loginChapter: AdvancedTrainingChapterInput
+    completionChapter: AdvancedTrainingChapterInput
+  }
+
+  extend type Station {
+    advancedTraining: AdvancedTrainingConfig
+  }
+
+  extend type Client {
+    advancedTrainingProgress: AdvancedTrainingProgress
+  }
+
+  extend type Query {
+    advancedTrainingProgress(
+      clientId: ID
+      simulatorId: ID
+    ): [AdvancedTrainingProgress!]!
+  }
+
+  extend type Mutation {
+    """
+    Save the full advanced training configuration for a station.
+    """
+    setStationAdvancedTraining(
+      stationSetID: ID!
+      stationName: String!
+      config: AdvancedTrainingConfigInput!
+    ): String
+
+    """
+    Toggle advanced training mode on a station set.
+    """
+    toggleAdvancedTrainingMode(
+      stationSetID: ID!
+      stationName: String!
+      enabled: Boolean!
+    ): String
+
+    """
+    Start an advanced training session for a client.
+    Sets up progress tracking and activates the first chapter.
+    """
+    clientStartAdvancedTraining(clientId: ID!): String
+
+    """
+    Stop advanced training for a client.
+    """
+    clientStopAdvancedTraining(clientId: ID!): String
+
+    """
+    Record a crew action during advanced training.
+    Checks against required actions and may trigger sub-chapter/chapter completion.
+    """
+    clientAdvancedTrainingAction(
+      clientId: ID!
+      eventName: String!
+      args: JSON
+    ): String
+
+    """
+    Set the active chapter for a client (crew navigation or FD override).
+    """
+    advancedTrainingSetActiveChapter(
+      clientId: ID!
+      chapterId: ID!
+    ): String
+
+    """
+    FD force-complete a sub-chapter for a client.
+    """
+    fdCompleteTrainingSubChapter(
+      clientId: ID!
+      subChapterId: ID!
+    ): String
+
+    """
+    FD reset all training progress for a client.
+    """
+    fdResetTrainingProgress(clientId: ID!): String
+
+    """
+    Toggle the media viewer open/close for a client.
+    """
+    advancedTrainingToggleMediaViewer(
+      clientId: ID!
+      open: Boolean!
+    ): String
+
+    """
+    Toggle the chapter list open/close for a client.
+    """
+    advancedTrainingToggleChapterList(
+      clientId: ID!
+      open: Boolean!
+    ): String
+  }
+
+  extend type Subscription {
+    advancedTrainingProgressUpdate(simulatorId: ID): [AdvancedTrainingProgress!]!
+    advancedTrainingConfigUpdate(stationSetID: ID): [StationSet!]!
+  }
+`;
+
+const resolver = {
+  Station: {
+    advancedTraining(station: any) {
+      return station.advancedTraining || null;
+    },
+  },
+  Client: {
+    advancedTrainingProgress(client: any) {
+      return App.advancedTrainingProgress?.find(
+        (p: any) => p.clientId === client.id,
+      ) || null;
+    },
+  },
+  Query: {
+    advancedTrainingProgress(_root: any, {clientId, simulatorId}: any) {
+      let progress = App.advancedTrainingProgress || [];
+      if (clientId) {
+        progress = progress.filter((p: any) => p.clientId === clientId);
+      }
+      if (simulatorId) {
+        progress = progress.filter((p: any) => p.simulatorId === simulatorId);
+      }
+      return progress;
+    },
+  },
+  Mutation: {
+    setStationAdvancedTraining(rootValue: any, {stationSetID, stationName, config}: any) {
+      const station = getStationConfig(stationSetID, stationName);
+      if (!station) return "";
+      station.setAdvancedTraining(config);
+      pubsub.publish("stationSetUpdate", App.stationSets);
+      pubsub.publish("advancedTrainingConfigUpdate", App.stationSets);
+      return "";
+    },
+    toggleAdvancedTrainingMode(rootValue: any, {stationSetID, stationName, enabled}: any) {
+      const station = getStationConfig(stationSetID, stationName);
+      if (!station) return "";
+      if (!station.advancedTraining) {
+        station.advancedTraining = new AdvancedTrainingConfig();
+      }
+      station.advancedTraining.setEnabled(enabled);
+      pubsub.publish("stationSetUpdate", App.stationSets);
+      return "";
+    },
+    clientStartAdvancedTraining(rootValue: any, {clientId}: any) {
+      // Handled by event handler
+      return "";
+    },
+    clientStopAdvancedTraining(rootValue: any, {clientId}: any) {
+      return "";
+    },
+    clientAdvancedTrainingAction(rootValue: any, {clientId, eventName, args}: any) {
+      return "";
+    },
+    advancedTrainingSetActiveChapter(rootValue: any, {clientId, chapterId}: any) {
+      return "";
+    },
+    fdCompleteTrainingSubChapter(rootValue: any, {clientId, subChapterId}: any) {
+      return "";
+    },
+    fdResetTrainingProgress(rootValue: any, {clientId}: any) {
+      return "";
+    },
+    advancedTrainingToggleMediaViewer(rootValue: any, {clientId, open}: any) {
+      return "";
+    },
+    advancedTrainingToggleChapterList(rootValue: any, {clientId, open}: any) {
+      return "";
+    },
+  },
+  Subscription: {
+    advancedTrainingProgressUpdate: {
+      resolve(rootValue: any, {simulatorId}: any) {
+        if (simulatorId) {
+          return rootValue.filter((p: any) => p.simulatorId === simulatorId);
+        }
+        return rootValue;
+      },
+      subscribe: withFilter(
+        () => {
+          const id = uuid.v4();
+          process.nextTick(() => {
+            pubsub.publish(id, App.advancedTrainingProgress || []);
+          });
+          return pubsub.asyncIterator([id, "advancedTrainingProgressUpdate"]);
+        },
+        (rootValue: any) => !!(rootValue && rootValue.length >= 0),
+      ),
+    },
+    advancedTrainingConfigUpdate: {
+      resolve(rootValue: any, {stationSetID}: any) {
+        if (stationSetID) {
+          return rootValue.filter((s: any) => s.id === stationSetID);
+        }
+        return rootValue;
+      },
+      subscribe: () => {
+        const id = uuid.v4();
+        process.nextTick(() => {
+          pubsub.publish(id, App.stationSets);
+        });
+        return pubsub.asyncIterator([id, "advancedTrainingConfigUpdate"]);
+      },
+    },
+  },
+};
+
+export default {schema, resolver};

--- a/server/typeDefs/flight.ts
+++ b/server/typeDefs/flight.ts
@@ -124,10 +124,13 @@ export function addAspects(
         // Override the system ID
         newAspect.id = uuid.v4();
         if (isochip) {
-          isochip.id = uuid.v4();
-          isochip.system = newAspect.id;
-          isochip.simulatorId = sim.id;
-          data.isochips.push(new Classes.Isochip(isochip));
+          // Clone the isochip rather than mutating the original — the template's
+          // isochip must remain intact so future flights can copy it correctly.
+          const isochipCopy = cloneDeep(isochip);
+          isochipCopy.id = uuid.v4();
+          isochipCopy.system = newAspect.id;
+          isochipCopy.simulatorId = sim.id;
+          data.isochips.push(new Classes.Isochip(isochipCopy));
         }
         if (!isImport) {
           if (newAspect.power && newAspect.power.powerLevels.length) {
@@ -417,8 +420,11 @@ const resolver = {
     startFlight(rootQuery, {id = uuid.v4(), name, simulators, flightType}) {
       const simIds = simulators.map(
         (s: {simulatorId: string; missionId?: string; stationSet: string}) => {
-          // Create a snapshot restore before the flight is created
-          App.saveRestore();
+          // Save a restore snapshot before creating the flight, but not for
+          // sandbox/preview flights used during training configuration.
+          if (!name?.startsWith("__sandbox_")) {
+            App.saveRestore();
+          }
           const template = cloneDeep(
             App.simulators.find(sim => sim.id === s.simulatorId),
           );

--- a/server/typeDefs/index.ts
+++ b/server/typeDefs/index.ts
@@ -79,6 +79,7 @@ import dmxTypeDefs from "./dmx";
 import taskFlowTypeDefs from "./taskFlow";
 import firebaseConnectionTypeDefs from './firebase'
 import flightSetsTypeDefs from "./flightSets";
+import advancedTrainingTypeDefs from "./advancedTraining";
 export * from "./universe/components";
 
 export const actions = actionsTypeDefs;
@@ -162,3 +163,4 @@ export const countermeasures = countermeasuresTypeDefs;
 export const universe = universeTypeDefs;
 export const dmx = dmxTypeDefs;
 export const taskFlow = taskFlowTypeDefs;
+export const advancedTraining = advancedTrainingTypeDefs;

--- a/src/components/client/Card.tsx
+++ b/src/components/client/Card.tsx
@@ -15,6 +15,7 @@ import {playSound} from "../generic/SoundPlayer";
 import {randomFromList} from "helpers/randomFromList";
 import styled from "styled-components";
 import {Simulator, Station, Flight, Client} from "generated/graphql";
+import AdvancedTrainingBorder from "components/training/AdvancedTrainingBorder";
 
 const Blackout = styled.div`
   width: 100vw;
@@ -186,6 +187,24 @@ const CardFrame: React.FC<CardFrameProps> = props => {
       training: false,
     },
   });
+  const advancedTrainingConfig = (station as any).advancedTraining;
+
+  const cardContent = (
+    <CardRenderer
+      {...props}
+      card={client?.currentCard?.name || ""}
+      changeCard={changeCard}
+      client={{
+        ...client,
+        training:
+          advancedTrainingConfig?.enabled ||
+          (simTraining && stationTraining && isMedia(stationTraining))
+            ? false
+            : client.training,
+      }}
+    />
+  );
+
   return (
     <div
       className={`client-container ${caps ? "all-caps" : ""} ${
@@ -194,20 +213,20 @@ const CardFrame: React.FC<CardFrameProps> = props => {
     >
       <ActionsMixin {...props} changeCard={changeCard} />
       {client.cracked && <div className="cracked-screen" />}
-      <CardRenderer
-        {...props}
-        card={client?.currentCard?.name || ""}
-        changeCard={changeCard}
-        client={{
-          ...client,
-          training:
-            simTraining && stationTraining && isMedia(stationTraining)
-              ? false
-              : client.training,
-        }}
-      />
+      {advancedTrainingConfig?.enabled ? (
+        <AdvancedTrainingBorder
+          clientId={client.id}
+          simulatorId={simulator.id}
+          advancedTrainingConfig={advancedTrainingConfig}
+        >
+          {cardContent}
+        </AdvancedTrainingBorder>
+      ) : (
+        cardContent
+      )}
       {client && <Reset station={station} clientId={client.id} />}
-      {simTraining &&
+      {!advancedTrainingConfig?.enabled &&
+        simTraining &&
         stationTraining &&
         client.training &&
         isMedia(stationTraining) && (

--- a/src/components/client/queries/simulatorDataFragment.graphql
+++ b/src/components/client/queries/simulatorDataFragment.graphql
@@ -35,5 +35,69 @@ fragment SimulatorData on Simulator {
       assigned
       newStation
     }
+    advancedTraining {
+      enabled
+      sequentialChapters
+      chapters {
+        id
+        name
+        cardComponent
+        mediaAsset
+        autoOpenMedia
+        autoAdvance
+        cardSwitchBehavior
+        mediaSize
+        mediaPosition
+        subChapters {
+          id
+          name
+          requiredActions {
+            id
+            eventName
+            args
+          }
+        }
+      }
+      loginChapter {
+        id
+        name
+        cardComponent
+        mediaAsset
+        autoOpenMedia
+        autoAdvance
+        cardSwitchBehavior
+        mediaSize
+        mediaPosition
+        subChapters {
+          id
+          name
+          requiredActions {
+            id
+            eventName
+            args
+          }
+        }
+      }
+      completionChapter {
+        id
+        name
+        cardComponent
+        mediaAsset
+        autoOpenMedia
+        autoAdvance
+        cardSwitchBehavior
+        mediaSize
+        mediaPosition
+        subChapters {
+          id
+          name
+          requiredActions {
+            id
+            eventName
+            args
+          }
+        }
+      }
+    }
   }
 }

--- a/src/components/client/queries/simulatorDataFragment.graphql
+++ b/src/components/client/queries/simulatorDataFragment.graphql
@@ -60,6 +60,27 @@ fragment SimulatorData on Simulator {
           }
         }
       }
+      inFlightChapters {
+        id
+        name
+        cardComponent
+        mediaAsset
+        autoOpenMedia
+        autoAdvance
+        autoLogin
+        cardSwitchBehavior
+        mediaSize
+        mediaPosition
+        subChapters {
+          id
+          name
+          requiredActions {
+            id
+            eventName
+            args
+          }
+        }
+      }
       loginChapter {
         id
         name

--- a/src/components/client/queries/simulatorDataFragment.graphql
+++ b/src/components/client/queries/simulatorDataFragment.graphql
@@ -38,6 +38,7 @@ fragment SimulatorData on Simulator {
     advancedTraining {
       enabled
       sequentialChapters
+      stripPosition
       chapters {
         id
         name

--- a/src/components/client/queries/simulatorDataFragment.graphql
+++ b/src/components/client/queries/simulatorDataFragment.graphql
@@ -46,6 +46,7 @@ fragment SimulatorData on Simulator {
         mediaAsset
         autoOpenMedia
         autoAdvance
+        autoLogin
         cardSwitchBehavior
         mediaSize
         mediaPosition
@@ -66,6 +67,7 @@ fragment SimulatorData on Simulator {
         mediaAsset
         autoOpenMedia
         autoAdvance
+        autoLogin
         cardSwitchBehavior
         mediaSize
         mediaPosition
@@ -86,6 +88,7 @@ fragment SimulatorData on Simulator {
         mediaAsset
         autoOpenMedia
         autoAdvance
+        autoLogin
         cardSwitchBehavior
         mediaSize
         mediaPosition

--- a/src/components/layouts/LayoutCorners/settings.jsx
+++ b/src/components/layouts/LayoutCorners/settings.jsx
@@ -18,19 +18,17 @@ const Settings = props => {
     });
   };
   const startTraining = () => {
-    const client = props.clientObj.id;
-    const variables = {
-      client,
-      training: true,
-    };
+    // Card-aware help: jumps to the in-flight (or regular) chapter for the
+    // crew's current card, falling back to begin-training. Resolved server-side.
+    const clientId = props.clientObj.id;
     const mutation = gql`
-      mutation ClientSetTraining($client: ID!, $training: Boolean!) {
-        clientSetTraining(client: $client, training: $training)
+      mutation ClientRequestTrainingHelp($clientId: ID!) {
+        clientRequestTrainingHelp(clientId: $clientId)
       }
     `;
     props.client.mutate({
       mutation,
-      variables,
+      variables: {clientId},
     });
   };
   return (

--- a/src/components/layouts/LayoutOdyssey/widgets.jsx
+++ b/src/components/layouts/LayoutOdyssey/widgets.jsx
@@ -50,19 +50,17 @@ class WidgetsContainer extends Component {
     });
   };
   startTraining = () => {
-    const client = this.props.clientObj.id;
-    const variables = {
-      client,
-      training: true,
-    };
+    // Card-aware help: jumps to the in-flight (or regular) chapter for the
+    // crew's current card, falling back to begin-training. Resolved server-side.
+    const clientId = this.props.clientObj.id;
     const mutation = gql`
-      mutation ClientSetTraining($client: ID!, $training: Boolean!) {
-        clientSetTraining(client: $client, training: $training)
+      mutation ClientRequestTrainingHelp($clientId: ID!) {
+        clientRequestTrainingHelp(clientId: $clientId)
       }
     `;
     this.props.client.mutate({
       mutation,
-      variables,
+      variables: {clientId},
     });
   };
   logout = () => {

--- a/src/components/training/AdvancedTrainingBorder.scss
+++ b/src/components/training/AdvancedTrainingBorder.scss
@@ -239,6 +239,30 @@
   }
 }
 
+.training-strip__btn--next {
+  width: auto;
+  padding: 0 12px;
+  gap: 6px;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.3px;
+  background: var(--training-accent-soft);
+  border-color: var(--training-accent);
+  color: var(--training-accent-strong);
+  animation: nextChapterPulse 2s ease-in-out infinite;
+
+  &:hover:not(:disabled) {
+    background: var(--training-accent);
+    color: #1a1300;
+    animation: none;
+  }
+}
+
+@keyframes nextChapterPulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(255, 183, 77, 0); }
+  50% { box-shadow: 0 0 0 5px rgba(255, 183, 77, 0.22); }
+}
+
 .training-strip__btn--exit {
   margin-left: 4px;
   border-color: rgba(244, 67, 54, 0.4);

--- a/src/components/training/AdvancedTrainingBorder.scss
+++ b/src/components/training/AdvancedTrainingBorder.scss
@@ -10,69 +10,227 @@
   pointer-events: none;
   isolation: isolate;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-  font-size: 14px;
+  font-size: 16px;
   line-height: 1.4;
-  color: #e0f7fa;
+  color: #f5f5f5;
   box-sizing: border-box;
+
+  // Amber instructor-layer accent so training reads as a layer, not bridge UI
+  --training-accent: #ffb74d;
+  --training-accent-strong: #ffa726;
+  --training-accent-soft: rgba(255, 183, 77, 0.18);
+  --training-accent-edge: rgba(255, 183, 77, 0.45);
+  --training-surface: rgba(12, 14, 18, 0.88);
+  --training-text-dim: #b0bec5;
 
   *, *::before, *::after {
     box-sizing: border-box;
   }
 }
 
-.advanced-training-overlay {
-  position: relative;
+// ── Outside-click catcher for popovers (transparent, dismiss-only) ──
+.training-popover-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 64px; // exclude the bottom strip so strip buttons don't flicker on toggle
+  pointer-events: all;
+  background: transparent;
+  z-index: 1;
+
+  &--top {
+    top: 64px; // exclude the top strip instead
+    bottom: 0;
+  }
+}
+
+// ── Generic popover ──
+.training-popover {
+  position: fixed;
+  background: var(--training-surface);
+  border: 1px solid var(--training-accent-edge);
+  border-radius: 6px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+  pointer-events: all;
+  z-index: 2;
+  backdrop-filter: blur(8px);
+  animation: trainingPopoverIn 0.18s ease-out;
+}
+
+.training-popover--chapters {
+  bottom: 80px;
+  left: 16px;
+  width: 340px;
+  max-height: 60vh;
+  overflow: hidden;
   display: flex;
   flex-direction: column;
-  width: 100%;
-  height: 100%;
-  border: 2px solid rgba(0, 188, 212, 0.5);
-  border-radius: 2px;
-  box-shadow: 0 0 10px rgba(0, 188, 212, 0.3), inset 0 0 10px rgba(0, 188, 212, 0.05);
+
+  &-top {
+    bottom: auto;
+    top: 80px;
+  }
 }
 
-// ── Top bar ──
-.advanced-training-top-bar {
+@keyframes trainingPopoverIn {
+  0% {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+// ── Bottom strip (always visible during training) ──
+.training-strip {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 64px;
+  display: flex;
+  align-items: stretch;
+  background: var(--training-surface);
+  border-top: 1px solid var(--training-accent-edge);
+  box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.45);
+  pointer-events: all;
+  z-index: 3;
+  backdrop-filter: blur(8px);
+}
+
+.training-strip--top {
+  bottom: auto;
+  top: 0;
+  border-top: none;
+  border-bottom: 1px solid var(--training-accent-edge);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.45);
+
+  .training-strip__progress {
+    bottom: auto;
+    top: 0; // progress bar sits at the top edge of the top strip
+  }
+
+  .training-strip__main {
+    padding: 3px 16px 0 20px; // flip padding so it's above the progress bar
+  }
+}
+
+.training-strip__main {
+  flex: 1;
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  flex-shrink: 0;
-  height: 36px;
-  background: linear-gradient(180deg, rgba(0, 188, 212, 0.85), rgba(0, 188, 212, 0.4));
-  border-bottom: 1px solid rgba(0, 188, 212, 0.6);
-  padding: 0 8px;
-  pointer-events: all;
+  gap: 16px;
+  padding: 0 16px 3px 20px; // bottom 3px reserves space for the progress bar
+  min-width: 0;
 }
 
-.advanced-training-controls {
+.training-strip__text {
   display: flex;
-  gap: 4px;
+  flex-direction: column;
+  justify-content: center;
+  min-width: 0;
+  flex-shrink: 0;
+  max-width: 40%;
 }
 
-.advanced-training-btn {
+.training-strip__eyebrow {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1.2px;
+  color: var(--training-text-dim);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.training-strip__task {
+  font-size: 19px;
+  font-weight: 600;
+  color: #ffffff;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  letter-spacing: 0.2px;
+}
+
+.training-strip__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+  flex: 1;
+  min-width: 0;
+}
+
+.training-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 13px;
+  padding: 3px 9px;
+  border-radius: 12px;
+  white-space: nowrap;
+  font-family: inherit;
+
+  svg {
+    flex-shrink: 0;
+  }
+
+  &.pending {
+    color: #fff3e0;
+    background: var(--training-accent-soft);
+    border: 1px solid var(--training-accent-edge);
+
+    svg {
+      color: var(--training-accent);
+    }
+  }
+
+  &.done {
+    color: #a5d6a7;
+    background: rgba(76, 175, 80, 0.12);
+    border: 1px solid rgba(76, 175, 80, 0.3);
+    text-decoration: line-through;
+    opacity: 0.75;
+  }
+}
+
+.training-strip__controls {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0 12px 3px 8px;
+  flex-shrink: 0;
+}
+
+.training-strip__btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: rgba(0, 188, 212, 0.15);
-  border: 1px solid rgba(0, 188, 212, 0.4);
-  border-radius: 4px;
-  color: #b2ebf2;
+  background: transparent;
+  border: 1px solid var(--training-accent-edge);
+  border-radius: 6px;
+  color: var(--training-accent);
   cursor: pointer;
-  padding: 4px 8px;
+  width: 36px;
+  height: 36px;
+  padding: 0;
   font-family: inherit;
-  font-size: inherit;
-  line-height: inherit;
-  transition: all 0.2s;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
 
-  &:hover {
-    background: rgba(0, 188, 212, 0.3);
-    color: #e0f7fa;
+  &:hover:not(:disabled) {
+    background: var(--training-accent-soft);
+    color: #fff3e0;
   }
 
   &.active {
-    background: rgba(0, 188, 212, 0.4);
-    color: #ffffff;
-    border-color: #00bcd4;
+    background: var(--training-accent-soft);
+    color: #fff3e0;
+    border-color: var(--training-accent);
   }
 
   &:disabled {
@@ -81,53 +239,31 @@
   }
 }
 
-.advanced-training-close {
-  margin-left: auto;
-  background: rgba(244, 67, 54, 0.15);
+.training-strip__btn--exit {
+  margin-left: 4px;
   border-color: rgba(244, 67, 54, 0.4);
   color: #ef9a9a;
 
-  &:hover {
-    background: rgba(244, 67, 54, 0.3);
+  &:hover:not(:disabled) {
+    background: rgba(244, 67, 54, 0.18);
     color: #ffcdd2;
   }
 }
 
-// ── Status area (chapter name + progress bar) ──
-.advanced-training-status {
-  flex: 1;
-  text-align: center;
-  color: #b2ebf2;
-  font-size: 13px;
-  font-weight: 500;
-  letter-spacing: 0.5px;
-  text-transform: uppercase;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 2px;
-  padding: 0 12px;
-}
-
-.advanced-training-chapter-name {
-  color: #e0f7fa;
-}
-
-// ── Feature 4: Progress bar ──
-.advanced-training-progress-bar {
-  width: 100%;
-  max-width: 200px;
-  height: 4px;
-  background: rgba(0, 0, 0, 0.3);
-  border-radius: 2px;
+// ── Progress bar (bottom edge of strip) ──
+.training-strip__progress {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: rgba(0, 0, 0, 0.45);
   overflow: hidden;
 }
 
-.advanced-training-progress-fill {
+.training-strip__progress-fill {
   height: 100%;
-  background: #b2ebf2;
-  border-radius: 2px;
+  background: var(--training-accent);
   transition: width 0.4s ease;
 
   &.complete {
@@ -135,107 +271,18 @@
   }
 }
 
-// ── Feature 1: Hint bar ──
-.advanced-training-hint-bar {
-  flex-shrink: 0;
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 5px 12px;
-  background: rgba(0, 0, 0, 0.6);
-  border-bottom: 1px solid rgba(0, 188, 212, 0.2);
-  pointer-events: all;
-  min-height: 28px;
-
-  .hint-task-name {
-    font-size: 12px;
-    font-weight: 600;
-    color: #80deea;
-    white-space: nowrap;
-    flex-shrink: 0;
-
-    &::after {
-      content: "—";
-      margin-left: 10px;
-      color: rgba(0, 188, 212, 0.3);
-    }
-  }
-
-  .hint-actions {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-    align-items: center;
-  }
-
-  .hint-action {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    font-size: 12px;
-    padding: 1px 6px;
-    border-radius: 3px;
-
-    svg {
-      flex-shrink: 0;
-    }
-
-    &.pending {
-      color: #e0f7fa;
-      background: rgba(0, 188, 212, 0.1);
-      border: 1px solid rgba(0, 188, 212, 0.25);
-
-      svg {
-        color: rgba(0, 188, 212, 0.5);
-      }
-    }
-
-    &.done {
-      color: #81c784;
-      background: rgba(76, 175, 80, 0.1);
-      border: 1px solid rgba(76, 175, 80, 0.2);
-      text-decoration: line-through;
-      opacity: 0.7;
-    }
-  }
-}
-
-// ── Body ──
-.advanced-training-overlay-body {
-  display: flex;
-  flex: 1;
-  overflow: hidden;
-}
-
-.advanced-training-sidebar {
-  width: 0;
-  overflow: hidden;
-  flex-shrink: 0;
-  transition: width 0.25s ease;
-  pointer-events: all;
-
-  &.open {
-    width: 300px;
-  }
-}
-
-.advanced-training-passthrough {
-  flex: 1;
-  pointer-events: none;
-}
-
-// ── Features 2 & 3: Toast notifications ──
+// ── Toast notifications (moved to top to avoid colliding with strip) ──
 .advanced-training-toasts {
-  position: absolute;
-  bottom: 24px;
+  position: fixed;
+  top: 24px;
   left: 50%;
   transform: translateX(-50%);
   display: flex;
-  flex-direction: column-reverse;
+  flex-direction: column;
   align-items: center;
   gap: 8px;
   pointer-events: none;
-  z-index: 4000;
+  z-index: 4;
 }
 
 .training-toast {
@@ -250,7 +297,6 @@
   animation: toastIn 0.3s ease-out;
   pointer-events: none;
 
-  // Action confirmed (small, subtle)
   &.action {
     background: rgba(76, 175, 80, 0.85);
     color: #fff;
@@ -259,22 +305,21 @@
     box-shadow: 0 2px 12px rgba(76, 175, 80, 0.4);
   }
 
-  // Sub-chapter complete (medium)
   &.subChapter {
-    background: rgba(0, 188, 212, 0.9);
-    color: #fff;
+    background: var(--training-accent-strong);
+    color: #1a1300;
     font-size: 14px;
-    box-shadow: 0 2px 16px rgba(0, 188, 212, 0.5);
+    font-weight: 600;
+    box-shadow: 0 2px 16px rgba(255, 167, 38, 0.5);
   }
 
-  // Chapter complete (large, celebratory)
   &.chapter {
-    background: linear-gradient(135deg, rgba(255, 193, 7, 0.95), rgba(255, 152, 0, 0.95));
-    color: #fff;
+    background: linear-gradient(135deg, var(--training-accent), var(--training-accent-strong));
+    color: #1a1300;
     font-size: 16px;
-    font-weight: 600;
+    font-weight: 700;
     padding: 10px 20px;
-    box-shadow: 0 4px 24px rgba(255, 152, 0, 0.5);
+    box-shadow: 0 4px 24px rgba(255, 152, 0, 0.55);
     letter-spacing: 0.5px;
   }
 }
@@ -282,7 +327,7 @@
 @keyframes toastIn {
   0% {
     opacity: 0;
-    transform: translateY(16px) scale(0.95);
+    transform: translateY(-12px) scale(0.95);
   }
   100% {
     opacity: 1;

--- a/src/components/training/AdvancedTrainingBorder.scss
+++ b/src/components/training/AdvancedTrainingBorder.scss
@@ -1,0 +1,291 @@
+// ── Isolation boundary (portal into document.body) ──
+.advanced-training-isolation {
+  all: initial;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 10000001;
+  pointer-events: none;
+  isolation: isolate;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-size: 14px;
+  line-height: 1.4;
+  color: #e0f7fa;
+  box-sizing: border-box;
+
+  *, *::before, *::after {
+    box-sizing: border-box;
+  }
+}
+
+.advanced-training-overlay {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  border: 2px solid rgba(0, 188, 212, 0.5);
+  border-radius: 2px;
+  box-shadow: 0 0 10px rgba(0, 188, 212, 0.3), inset 0 0 10px rgba(0, 188, 212, 0.05);
+}
+
+// ── Top bar ──
+.advanced-training-top-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-shrink: 0;
+  height: 36px;
+  background: linear-gradient(180deg, rgba(0, 188, 212, 0.85), rgba(0, 188, 212, 0.4));
+  border-bottom: 1px solid rgba(0, 188, 212, 0.6);
+  padding: 0 8px;
+  pointer-events: all;
+}
+
+.advanced-training-controls {
+  display: flex;
+  gap: 4px;
+}
+
+.advanced-training-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 188, 212, 0.15);
+  border: 1px solid rgba(0, 188, 212, 0.4);
+  border-radius: 4px;
+  color: #b2ebf2;
+  cursor: pointer;
+  padding: 4px 8px;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+  transition: all 0.2s;
+
+  &:hover {
+    background: rgba(0, 188, 212, 0.3);
+    color: #e0f7fa;
+  }
+
+  &.active {
+    background: rgba(0, 188, 212, 0.4);
+    color: #ffffff;
+    border-color: #00bcd4;
+  }
+
+  &:disabled {
+    opacity: 0.3;
+    cursor: not-allowed;
+  }
+}
+
+.advanced-training-close {
+  margin-left: auto;
+  background: rgba(244, 67, 54, 0.15);
+  border-color: rgba(244, 67, 54, 0.4);
+  color: #ef9a9a;
+
+  &:hover {
+    background: rgba(244, 67, 54, 0.3);
+    color: #ffcdd2;
+  }
+}
+
+// ── Status area (chapter name + progress bar) ──
+.advanced-training-status {
+  flex: 1;
+  text-align: center;
+  color: #b2ebf2;
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  padding: 0 12px;
+}
+
+.advanced-training-chapter-name {
+  color: #e0f7fa;
+}
+
+// ── Feature 4: Progress bar ──
+.advanced-training-progress-bar {
+  width: 100%;
+  max-width: 200px;
+  height: 4px;
+  background: rgba(0, 0, 0, 0.3);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.advanced-training-progress-fill {
+  height: 100%;
+  background: #b2ebf2;
+  border-radius: 2px;
+  transition: width 0.4s ease;
+
+  &.complete {
+    background: #4caf50;
+  }
+}
+
+// ── Feature 1: Hint bar ──
+.advanced-training-hint-bar {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 5px 12px;
+  background: rgba(0, 0, 0, 0.6);
+  border-bottom: 1px solid rgba(0, 188, 212, 0.2);
+  pointer-events: all;
+  min-height: 28px;
+
+  .hint-task-name {
+    font-size: 12px;
+    font-weight: 600;
+    color: #80deea;
+    white-space: nowrap;
+    flex-shrink: 0;
+
+    &::after {
+      content: "—";
+      margin-left: 10px;
+      color: rgba(0, 188, 212, 0.3);
+    }
+  }
+
+  .hint-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+  }
+
+  .hint-action {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    padding: 1px 6px;
+    border-radius: 3px;
+
+    svg {
+      flex-shrink: 0;
+    }
+
+    &.pending {
+      color: #e0f7fa;
+      background: rgba(0, 188, 212, 0.1);
+      border: 1px solid rgba(0, 188, 212, 0.25);
+
+      svg {
+        color: rgba(0, 188, 212, 0.5);
+      }
+    }
+
+    &.done {
+      color: #81c784;
+      background: rgba(76, 175, 80, 0.1);
+      border: 1px solid rgba(76, 175, 80, 0.2);
+      text-decoration: line-through;
+      opacity: 0.7;
+    }
+  }
+}
+
+// ── Body ──
+.advanced-training-overlay-body {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+}
+
+.advanced-training-sidebar {
+  width: 0;
+  overflow: hidden;
+  flex-shrink: 0;
+  transition: width 0.25s ease;
+  pointer-events: all;
+
+  &.open {
+    width: 300px;
+  }
+}
+
+.advanced-training-passthrough {
+  flex: 1;
+  pointer-events: none;
+}
+
+// ── Features 2 & 3: Toast notifications ──
+.advanced-training-toasts {
+  position: absolute;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column-reverse;
+  align-items: center;
+  gap: 8px;
+  pointer-events: none;
+  z-index: 4000;
+}
+
+.training-toast {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  white-space: nowrap;
+  animation: toastIn 0.3s ease-out;
+  pointer-events: none;
+
+  // Action confirmed (small, subtle)
+  &.action {
+    background: rgba(76, 175, 80, 0.85);
+    color: #fff;
+    padding: 6px 12px;
+    font-size: 12px;
+    box-shadow: 0 2px 12px rgba(76, 175, 80, 0.4);
+  }
+
+  // Sub-chapter complete (medium)
+  &.subChapter {
+    background: rgba(0, 188, 212, 0.9);
+    color: #fff;
+    font-size: 14px;
+    box-shadow: 0 2px 16px rgba(0, 188, 212, 0.5);
+  }
+
+  // Chapter complete (large, celebratory)
+  &.chapter {
+    background: linear-gradient(135deg, rgba(255, 193, 7, 0.95), rgba(255, 152, 0, 0.95));
+    color: #fff;
+    font-size: 16px;
+    font-weight: 600;
+    padding: 10px 20px;
+    box-shadow: 0 4px 24px rgba(255, 152, 0, 0.5);
+    letter-spacing: 0.5px;
+  }
+}
+
+@keyframes toastIn {
+  0% {
+    opacity: 0;
+    transform: translateY(16px) scale(0.95);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}

--- a/src/components/training/AdvancedTrainingBorder.tsx
+++ b/src/components/training/AdvancedTrainingBorder.tsx
@@ -13,8 +13,13 @@ interface AdvancedTrainingBorderProps {
   children: React.ReactNode;
 }
 
-function getNextChapter(config: any, activeChapterId: string | null): any | null {
-  if (!activeChapterId) return null;
+function getNextChapter(
+  config: any,
+  activeChapterId: string | null,
+): any | null {
+  if (!activeChapterId) {
+    return null;
+  }
   if (config.loginChapter?.id === activeChapterId) {
     return config.chapters[0] || config.completionChapter || null;
   }
@@ -22,7 +27,9 @@ function getNextChapter(config: any, activeChapterId: string | null): any | null
     return null;
   }
   const idx = config.chapters.findIndex((c: any) => c.id === activeChapterId);
-  if (idx === -1) return null;
+  if (idx === -1) {
+    return null;
+  }
   return config.chapters[idx + 1] || config.completionChapter || null;
 }
 
@@ -33,7 +40,9 @@ function getAllSubChapters(config: any): any[] {
     subs.push(...config.loginChapter.subChapters);
   }
   for (const ch of config.chapters || []) {
-    if (ch.subChapters) subs.push(...ch.subChapters);
+    if (ch.subChapters) {
+      subs.push(...ch.subChapters);
+    }
   }
   if (config.completionChapter?.subChapters) {
     subs.push(...config.completionChapter.subChapters);
@@ -81,13 +90,19 @@ const AdvancedTrainingBorder: React.FC<AdvancedTrainingBorderProps> = ({
   // Capture clicks on card elements via the document (capture phase). Clicks
   // on training UI itself are skipped via TRAINING_UI_SELECTOR.
   useEffect(() => {
-    if (!isInAdvancedTraining) return;
+    if (!isInAdvancedTraining) {
+      return;
+    }
 
     const handleDocumentClick = (e: MouseEvent) => {
-      if (!isActiveRef.current) return;
+      if (!isActiveRef.current) {
+        return;
+      }
       const target = e.target as HTMLElement;
 
-      if (target.closest(TRAINING_UI_SELECTOR)) return;
+      if (target.closest(TRAINING_UI_SELECTOR)) {
+        return;
+      }
 
       const interactive = target.closest(
         "button, a, [role='button'], input, select, .btn",
@@ -108,21 +123,27 @@ const AdvancedTrainingBorder: React.FC<AdvancedTrainingBorderProps> = ({
         el.getAttribute("title") ||
         "";
 
-      if (!text) return;
+      if (!text) {
+        return;
+      }
 
       recordActionRef.current(`click:${text}`, {
         text,
         tag,
         className: el.className
-          ? String(el.className).split(" ").filter(Boolean).slice(0, 3).join(" ")
+          ? String(el.className)
+              .split(" ")
+              .filter(Boolean)
+              .slice(0, 3)
+              .join(" ")
           : null,
       });
     };
 
     document.addEventListener("click", handleDocumentClick, true);
-    return () => document.removeEventListener("click", handleDocumentClick, true);
+    return () =>
+      document.removeEventListener("click", handleDocumentClick, true);
   }, [isInAdvancedTraining]);
-
 
   if (!isInAdvancedTraining || !config || !progress) {
     return <>{children}</>;
@@ -130,6 +151,9 @@ const AdvancedTrainingBorder: React.FC<AdvancedTrainingBorderProps> = ({
 
   const activeChapter =
     config.chapters.find((c: any) => c.id === progress.activeChapterId) ||
+    (config.inFlightChapters || []).find(
+      (c: any) => c.id === progress.activeChapterId,
+    ) ||
     (config.loginChapter?.id === progress.activeChapterId
       ? config.loginChapter
       : null) ||
@@ -181,14 +205,24 @@ const AdvancedTrainingBorder: React.FC<AdvancedTrainingBorderProps> = ({
               The media viewer is a draggable floating window and does not need a backdrop. */}
           {progress.chapterListOpen && (
             <div
-              className={`training-popover-backdrop${config.stripPosition === "top" ? " training-popover-backdrop--top" : ""}`}
+              className={`training-popover-backdrop${
+                config.stripPosition === "top"
+                  ? " training-popover-backdrop--top"
+                  : ""
+              }`}
               onClick={() => toggleChapterList(false)}
             />
           )}
 
           {/* Chapter list popover */}
           {progress.chapterListOpen && (
-            <div className={`training-popover training-popover--chapters${config.stripPosition === "top" ? " training-popover--chapters-top" : ""}`}>
+            <div
+              className={`training-popover training-popover--chapters${
+                config.stripPosition === "top"
+                  ? " training-popover--chapters-top"
+                  : ""
+              }`}
+            >
               <AdvancedTrainingChapterList
                 config={config}
                 progress={progress}
@@ -206,12 +240,18 @@ const AdvancedTrainingBorder: React.FC<AdvancedTrainingBorderProps> = ({
               onVideoEnd={onVideoEnd}
               size={activeChapter.mediaSize || "small"}
               position={activeChapter.mediaPosition || "bottom-right"}
-              stripPosition={(config.stripPosition || "bottom") as "top" | "bottom"}
+              stripPosition={
+                (config.stripPosition || "bottom") as "top" | "bottom"
+              }
             />
           )}
 
           {/* Training strip — position driven by config */}
-          <div className={`training-strip${config.stripPosition === "top" ? " training-strip--top" : ""}`}>
+          <div
+            className={`training-strip${
+              config.stripPosition === "top" ? " training-strip--top" : ""
+            }`}
+          >
             <div className="training-strip__main">
               <div className="training-strip__text">
                 {activeChapter && (
@@ -234,7 +274,10 @@ const AdvancedTrainingBorder: React.FC<AdvancedTrainingBorderProps> = ({
                       >
                         <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z" />
                       </svg>
-                      {getActionLabel(ra.eventName, activeChapter?.cardComponent)}
+                      {getActionLabel(
+                        ra.eventName,
+                        activeChapter?.cardComponent,
+                      )}
                     </span>
                   ))}
                   {pendingActions.map((ra: any) => (
@@ -247,7 +290,10 @@ const AdvancedTrainingBorder: React.FC<AdvancedTrainingBorderProps> = ({
                       >
                         <circle cx="12" cy="12" r="5" />
                       </svg>
-                      {getActionLabel(ra.eventName, activeChapter?.cardComponent)}
+                      {getActionLabel(
+                        ra.eventName,
+                        activeChapter?.cardComponent,
+                      )}
                     </span>
                   ))}
                 </div>
@@ -262,7 +308,12 @@ const AdvancedTrainingBorder: React.FC<AdvancedTrainingBorderProps> = ({
                   title={`Next: ${nextChapter.name}`}
                 >
                   Next
-                  <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor">
+                  <svg
+                    viewBox="0 0 24 24"
+                    width="16"
+                    height="16"
+                    fill="currentColor"
+                  >
                     <path d="M8 5v14l11-7z" />
                   </svg>
                 </button>
@@ -325,7 +376,6 @@ const AdvancedTrainingBorder: React.FC<AdvancedTrainingBorderProps> = ({
               />
             </div>
           </div>
-
         </div>,
         document.body,
       )}

--- a/src/components/training/AdvancedTrainingBorder.tsx
+++ b/src/components/training/AdvancedTrainingBorder.tsx
@@ -13,6 +13,19 @@ interface AdvancedTrainingBorderProps {
   children: React.ReactNode;
 }
 
+function getNextChapter(config: any, activeChapterId: string | null): any | null {
+  if (!activeChapterId) return null;
+  if (config.loginChapter?.id === activeChapterId) {
+    return config.chapters[0] || config.completionChapter || null;
+  }
+  if (config.completionChapter?.id === activeChapterId) {
+    return null;
+  }
+  const idx = config.chapters.findIndex((c: any) => c.id === activeChapterId);
+  if (idx === -1) return null;
+  return config.chapters[idx + 1] || config.completionChapter || null;
+}
+
 // Collect every sub-chapter across all chapter types for progress calculation
 function getAllSubChapters(config: any): any[] {
   const subs: any[] = [];
@@ -142,9 +155,22 @@ const AdvancedTrainingBorder: React.FC<AdvancedTrainingBorderProps> = ({
   const progressPercent =
     totalSubs > 0 ? Math.round((completedSubs / totalSubs) * 100) : 0;
 
+  const chapterIsComplete = activeChapter
+    ? progress.completedChapterIds.includes(activeChapter.id)
+    : false;
+  const nextChapter = chapterIsComplete
+    ? getNextChapter(config, progress.activeChapterId)
+    : null;
+
   const heroTaskName =
     activeSubChapter?.name ??
-    (activeChapter ? "Chapter overview" : "Training complete");
+    (chapterIsComplete
+      ? nextChapter
+        ? "Chapter complete!"
+        : "All done — great work!"
+      : activeChapter
+      ? "Chapter overview"
+      : "Training complete");
   return (
     <>
       {children}
@@ -229,6 +255,18 @@ const AdvancedTrainingBorder: React.FC<AdvancedTrainingBorderProps> = ({
             </div>
 
             <div className="training-strip__controls">
+              {chapterIsComplete && nextChapter && (
+                <button
+                  className="training-strip__btn training-strip__btn--next"
+                  onClick={() => setActiveChapter(nextChapter.id)}
+                  title={`Next: ${nextChapter.name}`}
+                >
+                  Next
+                  <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor">
+                    <path d="M8 5v14l11-7z" />
+                  </svg>
+                </button>
+              )}
               <button
                 className={`training-strip__btn ${
                   progress.chapterListOpen ? "active" : ""

--- a/src/components/training/AdvancedTrainingBorder.tsx
+++ b/src/components/training/AdvancedTrainingBorder.tsx
@@ -40,6 +40,11 @@ const TOAST_DURATION: Record<Toast["type"], number> = {
   chapter: 3500,
 };
 
+// Selector matching every training-UI element so the document click capture
+// records crew interactions with the card, not clicks on training chrome.
+const TRAINING_UI_SELECTOR =
+  ".training-strip, .training-popover, .training-popover-backdrop, .advanced-training-toasts, .advanced-training-media-viewer";
+
 const AdvancedTrainingBorder: React.FC<AdvancedTrainingBorderProps> = ({
   clientId,
   simulatorId,
@@ -77,9 +82,8 @@ const AdvancedTrainingBorder: React.FC<AdvancedTrainingBorderProps> = ({
   const isActiveRef = useRef(isInAdvancedTraining);
   isActiveRef.current = isInAdvancedTraining;
 
-  // Capture clicks on card elements via the document (capture phase) so the
-  // overlay's pointer-events:none doesn't prevent recording. Clicks on training
-  // UI itself are skipped by checking the overlay root class.
+  // Capture clicks on card elements via the document (capture phase). Clicks
+  // on training UI itself are skipped via TRAINING_UI_SELECTOR.
   useEffect(() => {
     if (!isInAdvancedTraining) return;
 
@@ -87,8 +91,7 @@ const AdvancedTrainingBorder: React.FC<AdvancedTrainingBorderProps> = ({
       if (!isActiveRef.current) return;
       const target = e.target as HTMLElement;
 
-      // Skip clicks on training UI elements
-      if (target.closest(".advanced-training-overlay")) return;
+      if (target.closest(TRAINING_UI_SELECTOR)) return;
 
       const interactive = target.closest(
         "button, a, [role='button'], input, select, .btn",
@@ -124,22 +127,29 @@ const AdvancedTrainingBorder: React.FC<AdvancedTrainingBorderProps> = ({
     return () => document.removeEventListener("click", handleDocumentClick, true);
   }, [isInAdvancedTraining]);
 
-  // Auto-open chapter list briefly when the active chapter changes
+  // Toast briefly when the active chapter changes (replaces the old auto-open
+  // chapter list — strip already shows the chapter name).
   const prevChapterIdRef = useRef<string | null>(null);
   useEffect(() => {
-    if (!progress) return;
+    if (!progress || !config) return;
     const prevId = prevChapterIdRef.current;
     const currentId = progress.activeChapterId;
     prevChapterIdRef.current = currentId;
 
-    if (prevId && currentId && prevId !== currentId && !progress.chapterListOpen) {
-      toggleChapterList(true);
-      const timeout = setTimeout(() => toggleChapterList(false), 4000);
-      return () => clearTimeout(timeout);
+    if (prevId && currentId && prevId !== currentId) {
+      const ch =
+        config.chapters?.find((c: any) => c.id === currentId) ||
+        (config.loginChapter?.id === currentId ? config.loginChapter : null) ||
+        (config.completionChapter?.id === currentId
+          ? config.completionChapter
+          : null);
+      if (ch) {
+        addToast(`Chapter: ${ch.name}`, "subChapter");
+      }
     }
   }, [progress?.activeChapterId]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // ── Feature 3: Detect new observed actions → toast ──
+  // Toast on each newly observed action
   const prevObservedRef = useRef<Record<string, string[]>>({});
   useEffect(() => {
     if (!progress) return;
@@ -159,18 +169,16 @@ const AdvancedTrainingBorder: React.FC<AdvancedTrainingBorderProps> = ({
     prevObservedRef.current = current;
   }, [progress?.observedActions]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // ── Feature 2: Detect sub-chapter & chapter completions → toast ──
+  // Toast on sub-chapter and chapter completions
   const prevCompletedSubsRef = useRef<string[]>([]);
   const prevCompletedChaptersRef = useRef<string[]>([]);
   useEffect(() => {
     if (!progress || !config) return;
 
-    // Sub-chapter completions
     const prevSubs = prevCompletedSubsRef.current;
     const currentSubs = progress.completedSubChapterIds || [];
     for (const subId of currentSubs) {
       if (!prevSubs.includes(subId)) {
-        // Find sub-chapter name
         const allSubs = getAllSubChapters(config);
         const sub = allSubs.find((s: any) => s.id === subId);
         if (sub) {
@@ -180,7 +188,6 @@ const AdvancedTrainingBorder: React.FC<AdvancedTrainingBorderProps> = ({
     }
     prevCompletedSubsRef.current = currentSubs;
 
-    // Chapter completions
     const prevChapters = prevCompletedChaptersRef.current;
     const currentChapters = progress.completedChapterIds || [];
     for (const chId of currentChapters) {
@@ -212,7 +219,6 @@ const AdvancedTrainingBorder: React.FC<AdvancedTrainingBorderProps> = ({
       ? config.completionChapter
       : null);
 
-  // ── Feature 1: Hints — pending actions for the active sub-chapter ──
   const activeSubChapter = activeChapter?.subChapters?.find(
     (sc: any) => sc.id === progress.activeSubChapterId,
   );
@@ -225,11 +231,18 @@ const AdvancedTrainingBorder: React.FC<AdvancedTrainingBorderProps> = ({
     (ra: any) => observedForSub.includes(ra.eventName),
   );
 
-  // ── Feature 4: Overall progress ──
   const allSubChapters = getAllSubChapters(config);
   const totalSubs = allSubChapters.length;
   const completedSubs = (progress.completedSubChapterIds || []).length;
-  const progressPercent = totalSubs > 0 ? Math.round((completedSubs / totalSubs) * 100) : 0;
+  const progressPercent =
+    totalSubs > 0 ? Math.round((completedSubs / totalSubs) * 100) : 0;
+
+  const heroTaskName =
+    activeSubChapter?.name ??
+    (activeChapter ? "Chapter overview" : "Training complete");
+  const anyPopoverOpen =
+    progress.chapterListOpen ||
+    (progress.mediaViewerOpen && !!activeChapter?.mediaAsset);
 
   return (
     <>
@@ -237,149 +250,182 @@ const AdvancedTrainingBorder: React.FC<AdvancedTrainingBorderProps> = ({
 
       {createPortal(
         <div className="advanced-training-isolation">
-          <div className="advanced-training-overlay">
-            {/* ── Top bar ── */}
-            <div className="advanced-training-top-bar">
-              <div className="advanced-training-controls">
-                <button
-                  className={`advanced-training-btn ${
-                    progress.chapterListOpen ? "active" : ""
-                  }`}
-                  onClick={() => toggleChapterList(!progress.chapterListOpen)}
-                  title="Training Chapters"
-                >
-                  <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
-                    <path d="M3 13h2v-2H3v2zm0 4h2v-2H3v2zm0-8h2V7H3v2zm4 4h14v-2H7v2zm0 4h14v-2H7v2zM7 7v2h14V7H7z" />
-                  </svg>
-                </button>
-                <button
-                  className={`advanced-training-btn ${
-                    progress.mediaViewerOpen ? "active" : ""
-                  }`}
-                  onClick={() => toggleMediaViewer(!progress.mediaViewerOpen)}
-                  title="Media Viewer"
-                  disabled={!activeChapter?.mediaAsset}
-                >
-                  <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
-                    <path d="M8 5v14l11-7z" />
-                  </svg>
-                </button>
-              </div>
+          {/* Outside-click catcher — only rendered when a popover is open */}
+          {anyPopoverOpen && (
+            <div
+              className={`training-popover-backdrop${config.stripPosition === "top" ? " training-popover-backdrop--top" : ""}`}
+              onClick={() => {
+                if (progress.chapterListOpen) toggleChapterList(false);
+              }}
+            />
+          )}
 
-              {/* Chapter name + progress bar */}
-              <div className="advanced-training-status">
-                {activeChapter ? (
-                  <span className="advanced-training-chapter-name">
+          {/* Chapter list popover */}
+          {progress.chapterListOpen && (
+            <div className={`training-popover training-popover--chapters${config.stripPosition === "top" ? " training-popover--chapters-top" : ""}`}>
+              <AdvancedTrainingChapterList
+                config={config}
+                progress={progress}
+                onSelectChapter={setActiveChapter}
+              />
+            </div>
+          )}
+
+          {/* Media viewer popover */}
+          {progress.mediaViewerOpen && activeChapter?.mediaAsset && (
+            <AdvancedTrainingMediaViewer
+              key={progress.activeChapterId || "media"}
+              src={`/assets${activeChapter.mediaAsset}`}
+              onClose={() => toggleMediaViewer(false)}
+              onVideoEnd={() => recordAction("__videoComplete__")}
+              size={activeChapter.mediaSize || "small"}
+              position={activeChapter.mediaPosition || "bottom-right"}
+            />
+          )}
+
+          {/* Training strip — position driven by config */}
+          <div className={`training-strip${config.stripPosition === "top" ? " training-strip--top" : ""}`}>
+            <div className="training-strip__main">
+              <div className="training-strip__text">
+                {activeChapter && (
+                  <span className="training-strip__eyebrow">
                     {activeChapter.name}
                   </span>
-                ) : (
-                  <span>Training Complete</span>
                 )}
-                {totalSubs > 0 && (
-                  <div className="advanced-training-progress-bar">
-                    <div
-                      className={`advanced-training-progress-fill${
-                        progressPercent >= 100 ? " complete" : ""
-                      }`}
-                      style={{width: `${progressPercent}%`}}
-                    />
-                  </div>
-                )}
+                <span className="training-strip__task">{heroTaskName}</span>
               </div>
 
-              <button
-                className="advanced-training-btn advanced-training-close"
-                onClick={stopTraining}
-                title="Exit Training"
-              >
-                <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor">
-                  <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
-                </svg>
-              </button>
-            </div>
-
-            {/* ── Hint bar — shows pending actions for the active sub-chapter ── */}
-            {activeSubChapter && (activeSubChapter.requiredActions?.length > 0) && (
-              <div className="advanced-training-hint-bar">
-                {activeSubChapter.name && (
-                  <span className="hint-task-name">{activeSubChapter.name}</span>
-                )}
-                <div className="hint-actions">
+              {(pendingActions.length > 0 || completedActions.length > 0) && (
+                <div className="training-strip__chips">
                   {completedActions.map((ra: any) => (
-                    <span key={ra.id} className="hint-action done">
-                      <svg viewBox="0 0 24 24" width="12" height="12" fill="currentColor">
+                    <span key={ra.id} className="training-chip done">
+                      <svg
+                        viewBox="0 0 24 24"
+                        width="12"
+                        height="12"
+                        fill="currentColor"
+                      >
                         <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z" />
                       </svg>
                       {getActionLabel(ra.eventName, activeChapter?.cardComponent)}
                     </span>
                   ))}
                   {pendingActions.map((ra: any) => (
-                    <span key={ra.id} className="hint-action pending">
-                      <svg viewBox="0 0 24 24" width="12" height="12" fill="currentColor">
+                    <span key={ra.id} className="training-chip pending">
+                      <svg
+                        viewBox="0 0 24 24"
+                        width="12"
+                        height="12"
+                        fill="currentColor"
+                      >
                         <circle cx="12" cy="12" r="5" />
                       </svg>
                       {getActionLabel(ra.eventName, activeChapter?.cardComponent)}
                     </span>
                   ))}
                 </div>
-              </div>
-            )}
-
-            {/* ── Body: sidebar + passthrough ── */}
-            <div className="advanced-training-overlay-body">
-              <div
-                className={`advanced-training-sidebar${
-                  progress.chapterListOpen ? " open" : ""
-                }`}
-              >
-                <AdvancedTrainingChapterList
-                  config={config}
-                  progress={progress}
-                  onSelectChapter={setActiveChapter}
-                  onClose={() => toggleChapterList(false)}
-                />
-              </div>
-
-              <div className="advanced-training-passthrough" />
+              )}
             </div>
 
-            {/* ── Media viewer ── */}
-            {progress.mediaViewerOpen && activeChapter?.mediaAsset && (
-              <AdvancedTrainingMediaViewer
-                key={progress.activeChapterId || "media"}
-                src={`/assets${activeChapter.mediaAsset}`}
-                onClose={() => toggleMediaViewer(false)}
-                size={activeChapter.mediaSize || "small"}
-                position={activeChapter.mediaPosition || "bottom-right"}
-              />
-            )}
+            <div className="training-strip__controls">
+              <button
+                className={`training-strip__btn ${
+                  progress.chapterListOpen ? "active" : ""
+                }`}
+                onClick={() => toggleChapterList(!progress.chapterListOpen)}
+                title="Training Chapters"
+              >
+                <svg
+                  viewBox="0 0 24 24"
+                  width="20"
+                  height="20"
+                  fill="currentColor"
+                >
+                  <path d="M3 13h2v-2H3v2zm0 4h2v-2H3v2zm0-8h2V7H3v2zm4 4h14v-2H7v2zm0 4h14v-2H7v2zM7 7v2h14V7H7z" />
+                </svg>
+              </button>
+              <button
+                className={`training-strip__btn ${
+                  progress.mediaViewerOpen ? "active" : ""
+                }`}
+                onClick={() => toggleMediaViewer(!progress.mediaViewerOpen)}
+                title="Media Viewer"
+                disabled={!activeChapter?.mediaAsset}
+              >
+                <svg
+                  viewBox="0 0 24 24"
+                  width="20"
+                  height="20"
+                  fill="currentColor"
+                >
+                  <path d="M8 5v14l11-7z" />
+                </svg>
+              </button>
+              <button
+                className="training-strip__btn training-strip__btn--exit"
+                onClick={stopTraining}
+                title="Exit Training"
+              >
+                <svg
+                  viewBox="0 0 24 24"
+                  width="18"
+                  height="18"
+                  fill="currentColor"
+                >
+                  <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
+                </svg>
+              </button>
+            </div>
 
-            {/* ── Toast notifications ── */}
-            {toasts.length > 0 && (
-              <div className="advanced-training-toasts">
-                {toasts.map(toast => (
-                  <div key={toast.id} className={`training-toast ${toast.type}`}>
-                    {toast.type === "action" && (
-                      <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor">
-                        <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z" />
-                      </svg>
-                    )}
-                    {toast.type === "subChapter" && (
-                      <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor">
-                        <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z" />
-                      </svg>
-                    )}
-                    {toast.type === "chapter" && (
-                      <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
-                        <path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zm3.23 15.39L12 15.45l-3.22 1.94.85-3.66-2.83-2.45 3.74-.32L12 7.82l1.46 3.14 3.74.32-2.83 2.45.85 3.66z" />
-                      </svg>
-                    )}
-                    <span>{toast.message}</span>
-                  </div>
-                ))}
-              </div>
-            )}
+            <div className="training-strip__progress">
+              <div
+                className={`training-strip__progress-fill${
+                  progressPercent >= 100 ? " complete" : ""
+                }`}
+                style={{width: `${progressPercent}%`}}
+              />
+            </div>
           </div>
+
+          {toasts.length > 0 && (
+            <div className="advanced-training-toasts">
+              {toasts.map(toast => (
+                <div key={toast.id} className={`training-toast ${toast.type}`}>
+                  {toast.type === "action" && (
+                    <svg
+                      viewBox="0 0 24 24"
+                      width="16"
+                      height="16"
+                      fill="currentColor"
+                    >
+                      <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z" />
+                    </svg>
+                  )}
+                  {toast.type === "subChapter" && (
+                    <svg
+                      viewBox="0 0 24 24"
+                      width="18"
+                      height="18"
+                      fill="currentColor"
+                    >
+                      <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z" />
+                    </svg>
+                  )}
+                  {toast.type === "chapter" && (
+                    <svg
+                      viewBox="0 0 24 24"
+                      width="20"
+                      height="20"
+                      fill="currentColor"
+                    >
+                      <path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zm3.23 15.39L12 15.45l-3.22 1.94.85-3.66-2.83-2.45 3.74-.32L12 7.82l1.46 3.14 3.74.32-2.83 2.45.85 3.66z" />
+                    </svg>
+                  )}
+                  <span>{toast.message}</span>
+                </div>
+              ))}
+            </div>
+          )}
         </div>,
         document.body,
       )}

--- a/src/components/training/AdvancedTrainingBorder.tsx
+++ b/src/components/training/AdvancedTrainingBorder.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef, useState} from "react";
+import React, {useCallback, useEffect, useRef} from "react";
 import {createPortal} from "react-dom";
 import {useAdvancedTraining} from "./useAdvancedTraining";
 import AdvancedTrainingChapterList from "./AdvancedTrainingChapterList";
@@ -28,18 +28,6 @@ function getAllSubChapters(config: any): any[] {
   return subs;
 }
 
-interface Toast {
-  id: string;
-  message: string;
-  type: "action" | "subChapter" | "chapter";
-}
-
-const TOAST_DURATION: Record<Toast["type"], number> = {
-  action: 1500,
-  subChapter: 2500,
-  chapter: 3500,
-};
-
 // Selector matching every training-UI element so the document click capture
 // records crew interactions with the card, not clicks on training chrome.
 const TRAINING_UI_SELECTOR =
@@ -66,15 +54,10 @@ const AdvancedTrainingBorder: React.FC<AdvancedTrainingBorderProps> = ({
     advancedTrainingConfig,
   });
 
-  // ── Toast notification state ──
-  const [toasts, setToasts] = useState<Toast[]>([]);
-  const addToast = (message: string, type: Toast["type"]) => {
-    const id = `${Date.now()}-${Math.random()}`;
-    setToasts(prev => [...prev, {id, message, type}]);
-    setTimeout(() => {
-      setToasts(prev => prev.filter(t => t.id !== id));
-    }, TOAST_DURATION[type]);
-  };
+  const onVideoEnd = useCallback(
+    () => recordAction("__videoComplete__"),
+    [recordAction],
+  );
 
   // Stable refs so the document listener never needs to re-register
   const recordActionRef = useRef(recordAction);
@@ -127,84 +110,6 @@ const AdvancedTrainingBorder: React.FC<AdvancedTrainingBorderProps> = ({
     return () => document.removeEventListener("click", handleDocumentClick, true);
   }, [isInAdvancedTraining]);
 
-  // Toast briefly when the active chapter changes (replaces the old auto-open
-  // chapter list — strip already shows the chapter name).
-  const prevChapterIdRef = useRef<string | null>(null);
-  useEffect(() => {
-    if (!progress || !config) return;
-    const prevId = prevChapterIdRef.current;
-    const currentId = progress.activeChapterId;
-    prevChapterIdRef.current = currentId;
-
-    if (prevId && currentId && prevId !== currentId) {
-      const ch =
-        config.chapters?.find((c: any) => c.id === currentId) ||
-        (config.loginChapter?.id === currentId ? config.loginChapter : null) ||
-        (config.completionChapter?.id === currentId
-          ? config.completionChapter
-          : null);
-      if (ch) {
-        addToast(`Chapter: ${ch.name}`, "subChapter");
-      }
-    }
-  }, [progress?.activeChapterId]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  // Toast on each newly observed action
-  const prevObservedRef = useRef<Record<string, string[]>>({});
-  useEffect(() => {
-    if (!progress) return;
-    const prev = prevObservedRef.current;
-    const current = progress.observedActions || {};
-
-    for (const subId of Object.keys(current)) {
-      const prevActions = prev[subId] || [];
-      const currentActions = current[subId] || [];
-      for (const action of currentActions) {
-        if (!prevActions.includes(action)) {
-          addToast(getActionLabel(action), "action");
-        }
-      }
-    }
-
-    prevObservedRef.current = current;
-  }, [progress?.observedActions]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  // Toast on sub-chapter and chapter completions
-  const prevCompletedSubsRef = useRef<string[]>([]);
-  const prevCompletedChaptersRef = useRef<string[]>([]);
-  useEffect(() => {
-    if (!progress || !config) return;
-
-    const prevSubs = prevCompletedSubsRef.current;
-    const currentSubs = progress.completedSubChapterIds || [];
-    for (const subId of currentSubs) {
-      if (!prevSubs.includes(subId)) {
-        const allSubs = getAllSubChapters(config);
-        const sub = allSubs.find((s: any) => s.id === subId);
-        if (sub) {
-          addToast(`${sub.name}`, "subChapter");
-        }
-      }
-    }
-    prevCompletedSubsRef.current = currentSubs;
-
-    const prevChapters = prevCompletedChaptersRef.current;
-    const currentChapters = progress.completedChapterIds || [];
-    for (const chId of currentChapters) {
-      if (!prevChapters.includes(chId)) {
-        const ch =
-          config.chapters?.find((c: any) => c.id === chId) ||
-          (config.loginChapter?.id === chId ? config.loginChapter : null) ||
-          (config.completionChapter?.id === chId
-            ? config.completionChapter
-            : null);
-        if (ch) {
-          addToast(`Chapter Complete: ${ch.name}`, "chapter");
-        }
-      }
-    }
-    prevCompletedChaptersRef.current = currentChapters;
-  }, [progress?.completedSubChapterIds, progress?.completedChapterIds]); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (!isInAdvancedTraining || !config || !progress) {
     return <>{children}</>;
@@ -240,23 +145,18 @@ const AdvancedTrainingBorder: React.FC<AdvancedTrainingBorderProps> = ({
   const heroTaskName =
     activeSubChapter?.name ??
     (activeChapter ? "Chapter overview" : "Training complete");
-  const anyPopoverOpen =
-    progress.chapterListOpen ||
-    (progress.mediaViewerOpen && !!activeChapter?.mediaAsset);
-
   return (
     <>
       {children}
 
       {createPortal(
         <div className="advanced-training-isolation">
-          {/* Outside-click catcher — only rendered when a popover is open */}
-          {anyPopoverOpen && (
+          {/* Outside-click catcher — only rendered when the chapter list is open.
+              The media viewer is a draggable floating window and does not need a backdrop. */}
+          {progress.chapterListOpen && (
             <div
               className={`training-popover-backdrop${config.stripPosition === "top" ? " training-popover-backdrop--top" : ""}`}
-              onClick={() => {
-                if (progress.chapterListOpen) toggleChapterList(false);
-              }}
+              onClick={() => toggleChapterList(false)}
             />
           )}
 
@@ -277,9 +177,10 @@ const AdvancedTrainingBorder: React.FC<AdvancedTrainingBorderProps> = ({
               key={progress.activeChapterId || "media"}
               src={`/assets${activeChapter.mediaAsset}`}
               onClose={() => toggleMediaViewer(false)}
-              onVideoEnd={() => recordAction("__videoComplete__")}
+              onVideoEnd={onVideoEnd}
               size={activeChapter.mediaSize || "small"}
               position={activeChapter.mediaPosition || "bottom-right"}
+              stripPosition={(config.stripPosition || "bottom") as "top" | "bottom"}
             />
           )}
 
@@ -387,45 +288,6 @@ const AdvancedTrainingBorder: React.FC<AdvancedTrainingBorderProps> = ({
             </div>
           </div>
 
-          {toasts.length > 0 && (
-            <div className="advanced-training-toasts">
-              {toasts.map(toast => (
-                <div key={toast.id} className={`training-toast ${toast.type}`}>
-                  {toast.type === "action" && (
-                    <svg
-                      viewBox="0 0 24 24"
-                      width="16"
-                      height="16"
-                      fill="currentColor"
-                    >
-                      <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z" />
-                    </svg>
-                  )}
-                  {toast.type === "subChapter" && (
-                    <svg
-                      viewBox="0 0 24 24"
-                      width="18"
-                      height="18"
-                      fill="currentColor"
-                    >
-                      <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z" />
-                    </svg>
-                  )}
-                  {toast.type === "chapter" && (
-                    <svg
-                      viewBox="0 0 24 24"
-                      width="20"
-                      height="20"
-                      fill="currentColor"
-                    >
-                      <path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zm3.23 15.39L12 15.45l-3.22 1.94.85-3.66-2.83-2.45 3.74-.32L12 7.82l1.46 3.14 3.74.32-2.83 2.45.85 3.66z" />
-                    </svg>
-                  )}
-                  <span>{toast.message}</span>
-                </div>
-              ))}
-            </div>
-          )}
         </div>,
         document.body,
       )}

--- a/src/components/training/AdvancedTrainingBorder.tsx
+++ b/src/components/training/AdvancedTrainingBorder.tsx
@@ -1,0 +1,390 @@
+import React, {useEffect, useRef, useState} from "react";
+import {createPortal} from "react-dom";
+import {useAdvancedTraining} from "./useAdvancedTraining";
+import AdvancedTrainingChapterList from "./AdvancedTrainingChapterList";
+import AdvancedTrainingMediaViewer from "./AdvancedTrainingMediaViewer";
+import {getActionLabel} from "./actionRegistry";
+import "./AdvancedTrainingBorder.scss";
+
+interface AdvancedTrainingBorderProps {
+  clientId: string;
+  simulatorId: string;
+  advancedTrainingConfig: any;
+  children: React.ReactNode;
+}
+
+// Collect every sub-chapter across all chapter types for progress calculation
+function getAllSubChapters(config: any): any[] {
+  const subs: any[] = [];
+  if (config.loginChapter?.subChapters) {
+    subs.push(...config.loginChapter.subChapters);
+  }
+  for (const ch of config.chapters || []) {
+    if (ch.subChapters) subs.push(...ch.subChapters);
+  }
+  if (config.completionChapter?.subChapters) {
+    subs.push(...config.completionChapter.subChapters);
+  }
+  return subs;
+}
+
+interface Toast {
+  id: string;
+  message: string;
+  type: "action" | "subChapter" | "chapter";
+}
+
+const TOAST_DURATION: Record<Toast["type"], number> = {
+  action: 1500,
+  subChapter: 2500,
+  chapter: 3500,
+};
+
+const AdvancedTrainingBorder: React.FC<AdvancedTrainingBorderProps> = ({
+  clientId,
+  simulatorId,
+  advancedTrainingConfig,
+  children,
+}) => {
+  const {
+    progress,
+    config,
+    isInAdvancedTraining,
+    recordAction,
+    setActiveChapter,
+    toggleMediaViewer,
+    toggleChapterList,
+    stopTraining,
+  } = useAdvancedTraining({
+    clientId,
+    simulatorId,
+    advancedTrainingConfig,
+  });
+
+  // ── Toast notification state ──
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  const addToast = (message: string, type: Toast["type"]) => {
+    const id = `${Date.now()}-${Math.random()}`;
+    setToasts(prev => [...prev, {id, message, type}]);
+    setTimeout(() => {
+      setToasts(prev => prev.filter(t => t.id !== id));
+    }, TOAST_DURATION[type]);
+  };
+
+  // Stable refs so the document listener never needs to re-register
+  const recordActionRef = useRef(recordAction);
+  recordActionRef.current = recordAction;
+  const isActiveRef = useRef(isInAdvancedTraining);
+  isActiveRef.current = isInAdvancedTraining;
+
+  // Capture clicks on card elements via the document (capture phase) so the
+  // overlay's pointer-events:none doesn't prevent recording. Clicks on training
+  // UI itself are skipped by checking the overlay root class.
+  useEffect(() => {
+    if (!isInAdvancedTraining) return;
+
+    const handleDocumentClick = (e: MouseEvent) => {
+      if (!isActiveRef.current) return;
+      const target = e.target as HTMLElement;
+
+      // Skip clicks on training UI elements
+      if (target.closest(".advanced-training-overlay")) return;
+
+      const interactive = target.closest(
+        "button, a, [role='button'], input, select, .btn",
+      ) as HTMLElement | null;
+      const el = interactive || target;
+
+      const tag = el.tagName.toLowerCase();
+      if (
+        ["div", "span", "col", "row", "container", "section"].includes(tag) &&
+        !interactive
+      ) {
+        return;
+      }
+
+      const text =
+        el.textContent?.trim().replace(/\s+/g, " ").substring(0, 60) ||
+        el.getAttribute("aria-label") ||
+        el.getAttribute("title") ||
+        "";
+
+      if (!text) return;
+
+      recordActionRef.current(`click:${text}`, {
+        text,
+        tag,
+        className: el.className
+          ? String(el.className).split(" ").filter(Boolean).slice(0, 3).join(" ")
+          : null,
+      });
+    };
+
+    document.addEventListener("click", handleDocumentClick, true);
+    return () => document.removeEventListener("click", handleDocumentClick, true);
+  }, [isInAdvancedTraining]);
+
+  // Auto-open chapter list briefly when the active chapter changes
+  const prevChapterIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!progress) return;
+    const prevId = prevChapterIdRef.current;
+    const currentId = progress.activeChapterId;
+    prevChapterIdRef.current = currentId;
+
+    if (prevId && currentId && prevId !== currentId && !progress.chapterListOpen) {
+      toggleChapterList(true);
+      const timeout = setTimeout(() => toggleChapterList(false), 4000);
+      return () => clearTimeout(timeout);
+    }
+  }, [progress?.activeChapterId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ── Feature 3: Detect new observed actions → toast ──
+  const prevObservedRef = useRef<Record<string, string[]>>({});
+  useEffect(() => {
+    if (!progress) return;
+    const prev = prevObservedRef.current;
+    const current = progress.observedActions || {};
+
+    for (const subId of Object.keys(current)) {
+      const prevActions = prev[subId] || [];
+      const currentActions = current[subId] || [];
+      for (const action of currentActions) {
+        if (!prevActions.includes(action)) {
+          addToast(getActionLabel(action), "action");
+        }
+      }
+    }
+
+    prevObservedRef.current = current;
+  }, [progress?.observedActions]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ── Feature 2: Detect sub-chapter & chapter completions → toast ──
+  const prevCompletedSubsRef = useRef<string[]>([]);
+  const prevCompletedChaptersRef = useRef<string[]>([]);
+  useEffect(() => {
+    if (!progress || !config) return;
+
+    // Sub-chapter completions
+    const prevSubs = prevCompletedSubsRef.current;
+    const currentSubs = progress.completedSubChapterIds || [];
+    for (const subId of currentSubs) {
+      if (!prevSubs.includes(subId)) {
+        // Find sub-chapter name
+        const allSubs = getAllSubChapters(config);
+        const sub = allSubs.find((s: any) => s.id === subId);
+        if (sub) {
+          addToast(`${sub.name}`, "subChapter");
+        }
+      }
+    }
+    prevCompletedSubsRef.current = currentSubs;
+
+    // Chapter completions
+    const prevChapters = prevCompletedChaptersRef.current;
+    const currentChapters = progress.completedChapterIds || [];
+    for (const chId of currentChapters) {
+      if (!prevChapters.includes(chId)) {
+        const ch =
+          config.chapters?.find((c: any) => c.id === chId) ||
+          (config.loginChapter?.id === chId ? config.loginChapter : null) ||
+          (config.completionChapter?.id === chId
+            ? config.completionChapter
+            : null);
+        if (ch) {
+          addToast(`Chapter Complete: ${ch.name}`, "chapter");
+        }
+      }
+    }
+    prevCompletedChaptersRef.current = currentChapters;
+  }, [progress?.completedSubChapterIds, progress?.completedChapterIds]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (!isInAdvancedTraining || !config || !progress) {
+    return <>{children}</>;
+  }
+
+  const activeChapter =
+    config.chapters.find((c: any) => c.id === progress.activeChapterId) ||
+    (config.loginChapter?.id === progress.activeChapterId
+      ? config.loginChapter
+      : null) ||
+    (config.completionChapter?.id === progress.activeChapterId
+      ? config.completionChapter
+      : null);
+
+  // ── Feature 1: Hints — pending actions for the active sub-chapter ──
+  const activeSubChapter = activeChapter?.subChapters?.find(
+    (sc: any) => sc.id === progress.activeSubChapterId,
+  );
+  const observedForSub =
+    progress.observedActions?.[progress.activeSubChapterId || ""] || [];
+  const pendingActions = (activeSubChapter?.requiredActions || []).filter(
+    (ra: any) => !observedForSub.includes(ra.eventName),
+  );
+  const completedActions = (activeSubChapter?.requiredActions || []).filter(
+    (ra: any) => observedForSub.includes(ra.eventName),
+  );
+
+  // ── Feature 4: Overall progress ──
+  const allSubChapters = getAllSubChapters(config);
+  const totalSubs = allSubChapters.length;
+  const completedSubs = (progress.completedSubChapterIds || []).length;
+  const progressPercent = totalSubs > 0 ? Math.round((completedSubs / totalSubs) * 100) : 0;
+
+  return (
+    <>
+      {children}
+
+      {createPortal(
+        <div className="advanced-training-isolation">
+          <div className="advanced-training-overlay">
+            {/* ── Top bar ── */}
+            <div className="advanced-training-top-bar">
+              <div className="advanced-training-controls">
+                <button
+                  className={`advanced-training-btn ${
+                    progress.chapterListOpen ? "active" : ""
+                  }`}
+                  onClick={() => toggleChapterList(!progress.chapterListOpen)}
+                  title="Training Chapters"
+                >
+                  <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
+                    <path d="M3 13h2v-2H3v2zm0 4h2v-2H3v2zm0-8h2V7H3v2zm4 4h14v-2H7v2zm0 4h14v-2H7v2zM7 7v2h14V7H7z" />
+                  </svg>
+                </button>
+                <button
+                  className={`advanced-training-btn ${
+                    progress.mediaViewerOpen ? "active" : ""
+                  }`}
+                  onClick={() => toggleMediaViewer(!progress.mediaViewerOpen)}
+                  title="Media Viewer"
+                  disabled={!activeChapter?.mediaAsset}
+                >
+                  <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
+                    <path d="M8 5v14l11-7z" />
+                  </svg>
+                </button>
+              </div>
+
+              {/* Chapter name + progress bar */}
+              <div className="advanced-training-status">
+                {activeChapter ? (
+                  <span className="advanced-training-chapter-name">
+                    {activeChapter.name}
+                  </span>
+                ) : (
+                  <span>Training Complete</span>
+                )}
+                {totalSubs > 0 && (
+                  <div className="advanced-training-progress-bar">
+                    <div
+                      className={`advanced-training-progress-fill${
+                        progressPercent >= 100 ? " complete" : ""
+                      }`}
+                      style={{width: `${progressPercent}%`}}
+                    />
+                  </div>
+                )}
+              </div>
+
+              <button
+                className="advanced-training-btn advanced-training-close"
+                onClick={stopTraining}
+                title="Exit Training"
+              >
+                <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor">
+                  <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
+                </svg>
+              </button>
+            </div>
+
+            {/* ── Hint bar — shows pending actions for the active sub-chapter ── */}
+            {activeSubChapter && (activeSubChapter.requiredActions?.length > 0) && (
+              <div className="advanced-training-hint-bar">
+                {activeSubChapter.name && (
+                  <span className="hint-task-name">{activeSubChapter.name}</span>
+                )}
+                <div className="hint-actions">
+                  {completedActions.map((ra: any) => (
+                    <span key={ra.id} className="hint-action done">
+                      <svg viewBox="0 0 24 24" width="12" height="12" fill="currentColor">
+                        <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z" />
+                      </svg>
+                      {getActionLabel(ra.eventName, activeChapter?.cardComponent)}
+                    </span>
+                  ))}
+                  {pendingActions.map((ra: any) => (
+                    <span key={ra.id} className="hint-action pending">
+                      <svg viewBox="0 0 24 24" width="12" height="12" fill="currentColor">
+                        <circle cx="12" cy="12" r="5" />
+                      </svg>
+                      {getActionLabel(ra.eventName, activeChapter?.cardComponent)}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* ── Body: sidebar + passthrough ── */}
+            <div className="advanced-training-overlay-body">
+              <div
+                className={`advanced-training-sidebar${
+                  progress.chapterListOpen ? " open" : ""
+                }`}
+              >
+                <AdvancedTrainingChapterList
+                  config={config}
+                  progress={progress}
+                  onSelectChapter={setActiveChapter}
+                  onClose={() => toggleChapterList(false)}
+                />
+              </div>
+
+              <div className="advanced-training-passthrough" />
+            </div>
+
+            {/* ── Media viewer ── */}
+            {progress.mediaViewerOpen && activeChapter?.mediaAsset && (
+              <AdvancedTrainingMediaViewer
+                key={progress.activeChapterId || "media"}
+                src={`/assets${activeChapter.mediaAsset}`}
+                onClose={() => toggleMediaViewer(false)}
+                size={activeChapter.mediaSize || "small"}
+                position={activeChapter.mediaPosition || "bottom-right"}
+              />
+            )}
+
+            {/* ── Toast notifications ── */}
+            {toasts.length > 0 && (
+              <div className="advanced-training-toasts">
+                {toasts.map(toast => (
+                  <div key={toast.id} className={`training-toast ${toast.type}`}>
+                    {toast.type === "action" && (
+                      <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor">
+                        <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z" />
+                      </svg>
+                    )}
+                    {toast.type === "subChapter" && (
+                      <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor">
+                        <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z" />
+                      </svg>
+                    )}
+                    {toast.type === "chapter" && (
+                      <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
+                        <path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zm3.23 15.39L12 15.45l-3.22 1.94.85-3.66-2.83-2.45 3.74-.32L12 7.82l1.46 3.14 3.74.32-2.83 2.45.85 3.66z" />
+                      </svg>
+                    )}
+                    <span>{toast.message}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>,
+        document.body,
+      )}
+    </>
+  );
+};
+
+export default AdvancedTrainingBorder;

--- a/src/components/training/AdvancedTrainingChapterList.scss
+++ b/src/components/training/AdvancedTrainingChapterList.scss
@@ -1,0 +1,230 @@
+.advanced-training-chapter-list {
+  width: 300px;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.75);
+  backdrop-filter: blur(8px);
+  border-right: 2px solid rgba(0, 188, 212, 0.4);
+  z-index: 2000;
+  display: flex;
+  flex-direction: column;
+  color: #e0f7fa;
+  font-size: 13px;
+  font-family: inherit;
+
+  .chapter-list-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 16px;
+    border-bottom: 1px solid rgba(0, 188, 212, 0.3);
+
+    h4 {
+      margin: 0;
+      font-size: 14px;
+      font-weight: 600;
+      color: #00bcd4;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      font-family: inherit;
+      // Reset any layout h4 overrides
+      background: none;
+      -webkit-background-clip: initial;
+      -webkit-text-fill-color: #00bcd4;
+      -webkit-text-stroke: 0;
+      text-shadow: none;
+    }
+  }
+
+  .chapter-list-close {
+    background: none;
+    border: none;
+    color: #80deea;
+    cursor: pointer;
+    padding: 4px;
+    font-family: inherit;
+
+    &:hover {
+      color: #ffffff;
+    }
+  }
+
+  .chapter-list-body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 8px 0;
+  }
+
+  .chapter-item {
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+
+    &.active > .chapter-row {
+      background: rgba(0, 188, 212, 0.1);
+    }
+
+    &.locked {
+      opacity: 0.45;
+
+      > .chapter-row {
+        cursor: not-allowed;
+      }
+    }
+
+    &.just-completed {
+      animation: chapterCompleteGlow 1.5s ease-out;
+    }
+  }
+
+  @keyframes chapterCompleteGlow {
+    0% {
+      background: rgba(76, 175, 80, 0);
+    }
+    15% {
+      background: rgba(76, 175, 80, 0.3);
+    }
+    40% {
+      background: rgba(76, 175, 80, 0.15);
+    }
+    100% {
+      background: rgba(76, 175, 80, 0);
+    }
+  }
+
+  .chapter-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 16px;
+    cursor: pointer;
+    transition: background 0.15s;
+
+    &:hover {
+      background: rgba(0, 188, 212, 0.08);
+    }
+  }
+
+  .chapter-status-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    flex-shrink: 0;
+
+    &.complete {
+      color: #4caf50;
+    }
+
+    &.active {
+      color: #00bcd4;
+    }
+
+    &.pending {
+      color: #546e7a;
+    }
+
+    &.locked {
+      color: #78909c;
+    }
+  }
+
+  .chapter-number {
+    font-size: 11px;
+    font-weight: 600;
+    color: inherit;
+  }
+
+  .chapter-info {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+
+  .chapter-name {
+    font-weight: 500;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .chapter-card {
+    font-size: 11px;
+    color: #78909c;
+  }
+
+  .chapter-play-btn {
+    background: none;
+    border: 1px solid rgba(0, 188, 212, 0.3);
+    border-radius: 50%;
+    color: #80deea;
+    cursor: pointer;
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    padding: 0;
+    font-family: inherit;
+    transition: all 0.2s;
+
+    &:hover {
+      background: rgba(0, 188, 212, 0.2);
+      color: #e0f7fa;
+    }
+  }
+
+  .chapter-expand {
+    display: flex;
+    color: #546e7a;
+    transition: transform 0.2s;
+
+    &.expanded {
+      transform: rotate(180deg);
+    }
+  }
+
+  .sub-chapter-list {
+    padding-left: 48px;
+    padding-bottom: 4px;
+  }
+
+  .sub-chapter-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 16px 6px 0;
+
+    &.complete {
+      .sub-chapter-name {
+        color: #78909c;
+      }
+    }
+  }
+
+  .sub-chapter-status {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    flex-shrink: 0;
+
+    &.complete {
+      color: #4caf50;
+    }
+  }
+
+  .sub-chapter-dot {
+    display: block;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: #546e7a;
+  }
+
+  .sub-chapter-name {
+    font-size: 12px;
+    color: #b0bec5;
+  }
+}

--- a/src/components/training/AdvancedTrainingChapterList.scss
+++ b/src/components/training/AdvancedTrainingChapterList.scss
@@ -1,14 +1,11 @@
 .advanced-training-chapter-list {
-  width: 300px;
+  // Sized by the .training-popover wrapper now
+  width: 100%;
   height: 100%;
-  background: rgba(0, 0, 0, 0.75);
-  backdrop-filter: blur(8px);
-  border-right: 2px solid rgba(0, 188, 212, 0.4);
-  z-index: 2000;
   display: flex;
   flex-direction: column;
-  color: #e0f7fa;
-  font-size: 13px;
+  color: #f5f5f5;
+  font-size: 14px;
   font-family: inherit;
 
   .chapter-list-header {
@@ -16,35 +13,22 @@
     align-items: center;
     justify-content: space-between;
     padding: 12px 16px;
-    border-bottom: 1px solid rgba(0, 188, 212, 0.3);
+    border-bottom: 1px solid var(--training-accent-edge);
 
     h4 {
       margin: 0;
       font-size: 14px;
       font-weight: 600;
-      color: #00bcd4;
+      color: var(--training-accent);
       text-transform: uppercase;
       letter-spacing: 1px;
       font-family: inherit;
       // Reset any layout h4 overrides
       background: none;
       -webkit-background-clip: initial;
-      -webkit-text-fill-color: #00bcd4;
+      -webkit-text-fill-color: var(--training-accent);
       -webkit-text-stroke: 0;
       text-shadow: none;
-    }
-  }
-
-  .chapter-list-close {
-    background: none;
-    border: none;
-    color: #80deea;
-    cursor: pointer;
-    padding: 4px;
-    font-family: inherit;
-
-    &:hover {
-      color: #ffffff;
     }
   }
 
@@ -58,11 +42,19 @@
     border-bottom: 1px solid rgba(255, 255, 255, 0.05);
 
     &.active > .chapter-row {
-      background: rgba(0, 188, 212, 0.1);
+      background: var(--training-accent-soft);
     }
 
     &.locked {
       opacity: 0.45;
+
+      > .chapter-row {
+        cursor: not-allowed;
+      }
+    }
+
+    &.prereq-locked {
+      opacity: 0.55;
 
       > .chapter-row {
         cursor: not-allowed;
@@ -98,7 +90,7 @@
     transition: background 0.15s;
 
     &:hover {
-      background: rgba(0, 188, 212, 0.08);
+      background: rgba(255, 183, 77, 0.08);
     }
   }
 
@@ -116,20 +108,24 @@
     }
 
     &.active {
-      color: #00bcd4;
+      color: var(--training-accent);
     }
 
     &.pending {
-      color: #546e7a;
+      color: #78909c;
     }
 
     &.locked {
       color: #78909c;
     }
+
+    &.prereq-locked {
+      color: #607d8b;
+    }
   }
 
   .chapter-number {
-    font-size: 11px;
+    font-size: 12px;
     font-weight: 600;
     color: inherit;
   }
@@ -149,15 +145,15 @@
   }
 
   .chapter-card {
-    font-size: 11px;
-    color: #78909c;
+    font-size: 12px;
+    color: #90a4ae;
   }
 
   .chapter-play-btn {
     background: none;
-    border: 1px solid rgba(0, 188, 212, 0.3);
+    border: 1px solid var(--training-accent-edge);
     border-radius: 50%;
-    color: #80deea;
+    color: var(--training-accent);
     cursor: pointer;
     width: 24px;
     height: 24px;
@@ -170,14 +166,14 @@
     transition: all 0.2s;
 
     &:hover {
-      background: rgba(0, 188, 212, 0.2);
-      color: #e0f7fa;
+      background: var(--training-accent-soft);
+      color: #fff3e0;
     }
   }
 
   .chapter-expand {
     display: flex;
-    color: #546e7a;
+    color: #78909c;
     transition: transform 0.2s;
 
     &.expanded {
@@ -198,7 +194,7 @@
 
     &.complete {
       .sub-chapter-name {
-        color: #78909c;
+        color: #90a4ae;
       }
     }
   }
@@ -224,7 +220,7 @@
   }
 
   .sub-chapter-name {
-    font-size: 12px;
-    color: #b0bec5;
+    font-size: 13px;
+    color: #cfd8dc;
   }
 }

--- a/src/components/training/AdvancedTrainingChapterList.tsx
+++ b/src/components/training/AdvancedTrainingChapterList.tsx
@@ -1,5 +1,6 @@
 import React, {useState, useEffect, useRef} from "react";
 import {getCardLabel} from "./actionRegistry";
+import {CARD_PREREQUISITES} from "./trainingPrerequisites";
 import "./AdvancedTrainingChapterList.scss";
 
 interface ChapterListProps {
@@ -11,16 +12,15 @@ interface ChapterListProps {
     activeChapterId: string | null;
     completedChapterIds: string[];
     completedSubChapterIds: string[];
+    globalObservedEvents?: string[];
   };
   onSelectChapter: (chapterId: string) => void;
-  onClose: () => void;
 }
 
 const AdvancedTrainingChapterList: React.FC<ChapterListProps> = ({
   config,
   progress,
   onSelectChapter,
-  onClose,
 }) => {
   const [expandedChapters, setExpandedChapters] = useState<
     Record<string, boolean>
@@ -74,6 +74,13 @@ const AdvancedTrainingChapterList: React.FC<ChapterListProps> = ({
     }));
   };
 
+  const isPrerequisiteLocked = (chapter: any) => {
+    const prerequisites = CARD_PREREQUISITES[chapter.cardComponent] || [];
+    if (prerequisites.length === 0) return false;
+    const observed = progress.globalObservedEvents || [];
+    return prerequisites.some((evt: string) => !observed.includes(evt));
+  };
+
   const getChapterStatus = (chapter: any) => {
     if (progress.completedChapterIds.includes(chapter.id)) return "complete";
     if (progress.activeChapterId === chapter.id) return "active";
@@ -97,34 +104,26 @@ const AdvancedTrainingChapterList: React.FC<ChapterListProps> = ({
     <div className="advanced-training-chapter-list">
       <div className="chapter-list-header">
         <h4>Training Chapters</h4>
-        <button className="chapter-list-close" onClick={onClose}>
-          <svg
-            viewBox="0 0 24 24"
-            width="18"
-            height="18"
-            fill="currentColor"
-          >
-            <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
-          </svg>
-        </button>
       </div>
       <div className="chapter-list-body">
         {config.chapters.map((chapter: any, idx: number) => {
           const status = getChapterStatus(chapter);
           const isExpanded = expandedChapters[chapter.id] || false;
           const locked = isChapterLocked(idx);
+          const prereqLocked = !locked && status === "pending" && isPrerequisiteLocked(chapter);
+          const isBlocked = locked || prereqLocked;
           const justCompleted = recentlyCompleted.has(chapter.id);
 
           return (
             <div
               key={chapter.id}
-              className={`chapter-item ${status}${locked ? " locked" : ""}${justCompleted ? " just-completed" : ""}`}
+              className={`chapter-item ${status}${locked ? " locked" : ""}${prereqLocked ? " prereq-locked" : ""}${justCompleted ? " just-completed" : ""}`}
             >
               <div
                 className="chapter-row"
-                onClick={() => !locked && toggleExpand(chapter.id)}
+                onClick={() => !isBlocked && toggleExpand(chapter.id)}
               >
-                <span className={`chapter-status-icon ${status}${locked ? " locked" : ""}`}>
+                <span className={`chapter-status-icon ${status}${locked ? " locked" : ""}${prereqLocked ? " prereq-locked" : ""}`}>
                   {locked ? (
                     <svg
                       viewBox="0 0 24 24"
@@ -133,6 +132,15 @@ const AdvancedTrainingChapterList: React.FC<ChapterListProps> = ({
                       fill="currentColor"
                     >
                       <path d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z" />
+                    </svg>
+                  ) : prereqLocked ? (
+                    <svg
+                      viewBox="0 0 24 24"
+                      width="16"
+                      height="16"
+                      fill="currentColor"
+                    >
+                      <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z" />
                     </svg>
                   ) : status === "complete" ? (
                     <svg
@@ -162,7 +170,7 @@ const AdvancedTrainingChapterList: React.FC<ChapterListProps> = ({
                     {getCardLabel(chapter.cardComponent)}
                   </span>
                 </div>
-                {!locked && (
+                {!isBlocked && (
                   <button
                     className="chapter-play-btn"
                     onClick={e => {
@@ -181,7 +189,7 @@ const AdvancedTrainingChapterList: React.FC<ChapterListProps> = ({
                     </svg>
                   </button>
                 )}
-                {chapter.subChapters?.length > 0 && !locked && (
+                {chapter.subChapters?.length > 0 && !isBlocked && (
                   <span
                     className={`chapter-expand ${isExpanded ? "expanded" : ""}`}
                   >
@@ -196,7 +204,7 @@ const AdvancedTrainingChapterList: React.FC<ChapterListProps> = ({
                   </span>
                 )}
               </div>
-              {isExpanded && !locked && chapter.subChapters?.length > 0 && (
+              {isExpanded && !isBlocked && chapter.subChapters?.length > 0 && (
                 <div className="sub-chapter-list">
                   {chapter.subChapters.map((sub: any) => {
                     const subStatus = getSubChapterStatus(sub);

--- a/src/components/training/AdvancedTrainingChapterList.tsx
+++ b/src/components/training/AdvancedTrainingChapterList.tsx
@@ -1,0 +1,236 @@
+import React, {useState, useEffect, useRef} from "react";
+import {getCardLabel} from "./actionRegistry";
+import "./AdvancedTrainingChapterList.scss";
+
+interface ChapterListProps {
+  config: {
+    sequentialChapters?: boolean;
+    chapters: any[];
+  };
+  progress: {
+    activeChapterId: string | null;
+    completedChapterIds: string[];
+    completedSubChapterIds: string[];
+  };
+  onSelectChapter: (chapterId: string) => void;
+  onClose: () => void;
+}
+
+const AdvancedTrainingChapterList: React.FC<ChapterListProps> = ({
+  config,
+  progress,
+  onSelectChapter,
+  onClose,
+}) => {
+  const [expandedChapters, setExpandedChapters] = useState<
+    Record<string, boolean>
+  >(() => {
+    // Auto-expand the active chapter
+    const initial: Record<string, boolean> = {};
+    if (progress.activeChapterId) {
+      initial[progress.activeChapterId] = true;
+    }
+    return initial;
+  });
+
+  // Track recently completed chapters for animation
+  const [recentlyCompleted, setRecentlyCompleted] = useState<Set<string>>(
+    new Set(),
+  );
+  const prevCompletedRef = useRef<string[]>(progress.completedChapterIds);
+
+  useEffect(() => {
+    const prev = prevCompletedRef.current;
+    const current = progress.completedChapterIds;
+    const newlyCompleted = current.filter(id => !prev.includes(id));
+
+    if (newlyCompleted.length > 0) {
+      setRecentlyCompleted(s => {
+        const next = new Set(s);
+        newlyCompleted.forEach(id => next.add(id));
+        return next;
+      });
+
+      // Clear animation after it plays
+      const timeout = setTimeout(() => {
+        setRecentlyCompleted(s => {
+          const next = new Set(s);
+          newlyCompleted.forEach(id => next.delete(id));
+          return next;
+        });
+      }, 1500);
+
+      prevCompletedRef.current = current;
+      return () => clearTimeout(timeout);
+    }
+
+    prevCompletedRef.current = current;
+  }, [progress.completedChapterIds]);
+
+  const toggleExpand = (chapterId: string) => {
+    setExpandedChapters(prev => ({
+      ...prev,
+      [chapterId]: !prev[chapterId],
+    }));
+  };
+
+  const getChapterStatus = (chapter: any) => {
+    if (progress.completedChapterIds.includes(chapter.id)) return "complete";
+    if (progress.activeChapterId === chapter.id) return "active";
+    return "pending";
+  };
+
+  const getSubChapterStatus = (subChapter: any) => {
+    if (progress.completedSubChapterIds.includes(subChapter.id))
+      return "complete";
+    return "pending";
+  };
+
+  const isChapterLocked = (idx: number) => {
+    if (!config.sequentialChapters) return false;
+    if (idx === 0) return false;
+    const prevChapter = config.chapters[idx - 1];
+    return !progress.completedChapterIds.includes(prevChapter.id);
+  };
+
+  return (
+    <div className="advanced-training-chapter-list">
+      <div className="chapter-list-header">
+        <h4>Training Chapters</h4>
+        <button className="chapter-list-close" onClick={onClose}>
+          <svg
+            viewBox="0 0 24 24"
+            width="18"
+            height="18"
+            fill="currentColor"
+          >
+            <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
+          </svg>
+        </button>
+      </div>
+      <div className="chapter-list-body">
+        {config.chapters.map((chapter: any, idx: number) => {
+          const status = getChapterStatus(chapter);
+          const isExpanded = expandedChapters[chapter.id] || false;
+          const locked = isChapterLocked(idx);
+          const justCompleted = recentlyCompleted.has(chapter.id);
+
+          return (
+            <div
+              key={chapter.id}
+              className={`chapter-item ${status}${locked ? " locked" : ""}${justCompleted ? " just-completed" : ""}`}
+            >
+              <div
+                className="chapter-row"
+                onClick={() => !locked && toggleExpand(chapter.id)}
+              >
+                <span className={`chapter-status-icon ${status}${locked ? " locked" : ""}`}>
+                  {locked ? (
+                    <svg
+                      viewBox="0 0 24 24"
+                      width="16"
+                      height="16"
+                      fill="currentColor"
+                    >
+                      <path d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z" />
+                    </svg>
+                  ) : status === "complete" ? (
+                    <svg
+                      viewBox="0 0 24 24"
+                      width="16"
+                      height="16"
+                      fill="currentColor"
+                    >
+                      <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z" />
+                    </svg>
+                  ) : status === "active" ? (
+                    <svg
+                      viewBox="0 0 24 24"
+                      width="16"
+                      height="16"
+                      fill="currentColor"
+                    >
+                      <path d="M8 5v14l11-7z" />
+                    </svg>
+                  ) : (
+                    <span className="chapter-number">{idx + 1}</span>
+                  )}
+                </span>
+                <div className="chapter-info">
+                  <span className="chapter-name">{chapter.name}</span>
+                  <span className="chapter-card">
+                    {getCardLabel(chapter.cardComponent)}
+                  </span>
+                </div>
+                {!locked && (
+                  <button
+                    className="chapter-play-btn"
+                    onClick={e => {
+                      e.stopPropagation();
+                      onSelectChapter(chapter.id);
+                    }}
+                    title="Go to this chapter"
+                  >
+                    <svg
+                      viewBox="0 0 24 24"
+                      width="14"
+                      height="14"
+                      fill="currentColor"
+                    >
+                      <path d="M8 5v14l11-7z" />
+                    </svg>
+                  </button>
+                )}
+                {chapter.subChapters?.length > 0 && !locked && (
+                  <span
+                    className={`chapter-expand ${isExpanded ? "expanded" : ""}`}
+                  >
+                    <svg
+                      viewBox="0 0 24 24"
+                      width="16"
+                      height="16"
+                      fill="currentColor"
+                    >
+                      <path d="M7 10l5 5 5-5z" />
+                    </svg>
+                  </span>
+                )}
+              </div>
+              {isExpanded && !locked && chapter.subChapters?.length > 0 && (
+                <div className="sub-chapter-list">
+                  {chapter.subChapters.map((sub: any) => {
+                    const subStatus = getSubChapterStatus(sub);
+                    return (
+                      <div
+                        key={sub.id}
+                        className={`sub-chapter-row ${subStatus}`}
+                      >
+                        <span className={`sub-chapter-status ${subStatus}`}>
+                          {subStatus === "complete" ? (
+                            <svg
+                              viewBox="0 0 24 24"
+                              width="14"
+                              height="14"
+                              fill="currentColor"
+                            >
+                              <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z" />
+                            </svg>
+                          ) : (
+                            <span className="sub-chapter-dot" />
+                          )}
+                        </span>
+                        <span className="sub-chapter-name">{sub.name}</span>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default AdvancedTrainingChapterList;

--- a/src/components/training/AdvancedTrainingChapterList.tsx
+++ b/src/components/training/AdvancedTrainingChapterList.tsx
@@ -76,26 +76,37 @@ const AdvancedTrainingChapterList: React.FC<ChapterListProps> = ({
 
   const isPrerequisiteLocked = (chapter: any) => {
     const prerequisites = CARD_PREREQUISITES[chapter.cardComponent] || [];
-    if (prerequisites.length === 0) return false;
+    if (prerequisites.length === 0) {
+      return false;
+    }
     const observed = progress.globalObservedEvents || [];
     return prerequisites.some((evt: string) => !observed.includes(evt));
   };
 
   const getChapterStatus = (chapter: any) => {
-    if (progress.completedChapterIds.includes(chapter.id)) return "complete";
-    if (progress.activeChapterId === chapter.id) return "active";
+    if (progress.completedChapterIds.includes(chapter.id)) {
+      return "complete";
+    }
+    if (progress.activeChapterId === chapter.id) {
+      return "active";
+    }
     return "pending";
   };
 
   const getSubChapterStatus = (subChapter: any) => {
-    if (progress.completedSubChapterIds.includes(subChapter.id))
+    if (progress.completedSubChapterIds.includes(subChapter.id)) {
       return "complete";
+    }
     return "pending";
   };
 
   const isChapterLocked = (idx: number) => {
-    if (!config.sequentialChapters) return false;
-    if (idx === 0) return false;
+    if (!config.sequentialChapters) {
+      return false;
+    }
+    if (idx === 0) {
+      return false;
+    }
     const prevChapter = config.chapters[idx - 1];
     return !progress.completedChapterIds.includes(prevChapter.id);
   };
@@ -110,20 +121,27 @@ const AdvancedTrainingChapterList: React.FC<ChapterListProps> = ({
           const status = getChapterStatus(chapter);
           const isExpanded = expandedChapters[chapter.id] || false;
           const locked = isChapterLocked(idx);
-          const prereqLocked = !locked && status === "pending" && isPrerequisiteLocked(chapter);
+          const prereqLocked =
+            !locked && status === "pending" && isPrerequisiteLocked(chapter);
           const isBlocked = locked || prereqLocked;
           const justCompleted = recentlyCompleted.has(chapter.id);
 
           return (
             <div
               key={chapter.id}
-              className={`chapter-item ${status}${locked ? " locked" : ""}${prereqLocked ? " prereq-locked" : ""}${justCompleted ? " just-completed" : ""}`}
+              className={`chapter-item ${status}${locked ? " locked" : ""}${
+                prereqLocked ? " prereq-locked" : ""
+              }${justCompleted ? " just-completed" : ""}`}
             >
               <div
                 className="chapter-row"
                 onClick={() => !isBlocked && toggleExpand(chapter.id)}
               >
-                <span className={`chapter-status-icon ${status}${locked ? " locked" : ""}${prereqLocked ? " prereq-locked" : ""}`}>
+                <span
+                  className={`chapter-status-icon ${status}${
+                    locked ? " locked" : ""
+                  }${prereqLocked ? " prereq-locked" : ""}`}
+                >
                   {locked ? (
                     <svg
                       viewBox="0 0 24 24"

--- a/src/components/training/AdvancedTrainingMediaViewer.scss
+++ b/src/components/training/AdvancedTrainingMediaViewer.scss
@@ -1,0 +1,96 @@
+.advanced-training-media-viewer {
+  // Positioned relative to .advanced-training-overlay (position:relative),
+  // which is the full viewport. Sidebar open/close doesn't shift this.
+  position: absolute;
+  top: 0;
+  left: 0;
+  min-width: 240px;
+  z-index: 3000;
+  pointer-events: all;
+  background: rgba(0, 0, 0, 0.95);
+  border: 1px solid rgba(0, 188, 212, 0.4);
+  border-radius: 6px;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.5);
+  cursor: grab;
+  user-select: none;
+  font-family: inherit;
+  color: #e0f7fa;
+
+  &:active {
+    cursor: grabbing;
+  }
+
+  .media-viewer-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 6px 10px;
+    border-bottom: 1px solid rgba(0, 188, 212, 0.2);
+    background: rgba(0, 188, 212, 0.08);
+  }
+
+  .media-viewer-title {
+    font-size: 11px;
+    color: #80deea;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+
+  .media-viewer-close {
+    background: none;
+    border: none;
+    color: #78909c;
+    cursor: pointer;
+    padding: 2px;
+    font-family: inherit;
+
+    &:hover {
+      color: #ef9a9a;
+    }
+  }
+
+  .media-viewer-body {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .media-viewer-player {
+    width: 100%;
+    background: #000;
+    line-height: 0;
+
+    video {
+      width: 100%;
+      height: auto;
+    }
+  }
+
+  .media-viewer-controls {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 6px 8px;
+    background: rgba(20, 20, 20, 0.95);
+
+    .media-control {
+      flex-shrink: 0;
+    }
+
+    .media-control--volume-range {
+      flex: 1;
+    }
+
+    .media-control--current-time,
+    .media-control--duration {
+      font-size: 10px;
+      color: #b0bec5;
+      min-width: 30px;
+      text-align: center;
+      font-family: inherit;
+    }
+
+    .media-control--volume {
+      width: 50px;
+    }
+  }
+}

--- a/src/components/training/AdvancedTrainingMediaViewer.scss
+++ b/src/components/training/AdvancedTrainingMediaViewer.scss
@@ -1,6 +1,6 @@
 .advanced-training-media-viewer {
-  // Positioned relative to .advanced-training-overlay (position:relative),
-  // which is the full viewport. Sidebar open/close doesn't shift this.
+  // Positioned within the .advanced-training-isolation container, which fills
+  // the viewport. The transform from useState({x, y}) does the actual placement.
   position: absolute;
   top: 0;
   left: 0;
@@ -8,13 +8,13 @@
   z-index: 3000;
   pointer-events: all;
   background: rgba(0, 0, 0, 0.95);
-  border: 1px solid rgba(0, 188, 212, 0.4);
+  border: 1px solid var(--training-accent-edge);
   border-radius: 6px;
   box-shadow: 0 4px 24px rgba(0, 0, 0, 0.5);
   cursor: grab;
   user-select: none;
   font-family: inherit;
-  color: #e0f7fa;
+  color: #f5f5f5;
 
   &:active {
     cursor: grabbing;
@@ -25,13 +25,13 @@
     align-items: center;
     justify-content: space-between;
     padding: 6px 10px;
-    border-bottom: 1px solid rgba(0, 188, 212, 0.2);
-    background: rgba(0, 188, 212, 0.08);
+    border-bottom: 1px solid var(--training-accent-edge);
+    background: var(--training-accent-soft);
   }
 
   .media-viewer-title {
     font-size: 11px;
-    color: #80deea;
+    color: var(--training-accent);
     text-transform: uppercase;
     letter-spacing: 0.5px;
   }

--- a/src/components/training/AdvancedTrainingMediaViewer.tsx
+++ b/src/components/training/AdvancedTrainingMediaViewer.tsx
@@ -302,7 +302,9 @@ const AdvancedTrainingMediaViewer: React.FC<
             <div
               ref={playerWrapperRef}
               className="media-viewer-player"
-              style={{display: isVideo ? "block" : "none"}}
+              style={isVideo
+                ? {display: "block"}
+                : {position: "absolute", width: 0, height: 0, overflow: "hidden"}}
             >
               <Player src={src} onClick={() => playPause()} />
             </div>

--- a/src/components/training/AdvancedTrainingMediaViewer.tsx
+++ b/src/components/training/AdvancedTrainingMediaViewer.tsx
@@ -104,11 +104,13 @@ const SeekBar = withMediaProps(SeekBarComp);
 interface AdvancedTrainingMediaViewerProps {
   src: string;
   onClose: () => void;
+  onVideoEnd?: () => void;
   size?: "small" | "medium" | "large";
   position?: string;
 }
 
 const SIZE_WIDTHS = {small: 0.25, medium: 0.40, large: 0.60};
+const STRIP_HEIGHT = 64;
 
 function computeInitialPosition(
   position: string,
@@ -117,8 +119,8 @@ function computeInitialPosition(
   const viewerW = window.innerWidth * (SIZE_WIDTHS[size] || 0.25);
   const viewerH = 280;
   const margin = 16;
-  const contentH = window.innerHeight - 36;
   const contentW = window.innerWidth;
+  const contentH = window.innerHeight - STRIP_HEIGHT;
 
   const [vert, horiz] = position.split("-");
 
@@ -139,10 +141,12 @@ const VIDEO_EXTENSIONS = ["mov", "mp4", "ogv", "webm", "m4v"];
 
 const AdvancedTrainingMediaViewer: React.FC<
   AdvancedTrainingMediaViewerProps
-> = ({src, onClose, size = "small", position = "bottom-right"}) => {
+> = ({src, onClose, onVideoEnd, size = "small", position = "bottom-right"}) => {
   const [pos, setPos] = useState(() => computeInitialPosition(position, size));
   const [isDragging, setIsDragging] = useState(false);
   const dragStartRef = useRef({x: 0, y: 0, posX: 0, posY: 0});
+  const playerWrapperRef = useRef<HTMLDivElement>(null);
+  const videoEndFiredRef = useRef(false);
 
   const ext = (src.match(/\.([^.]+)$/)?.[1] || "").toLowerCase();
   const isVideo = VIDEO_EXTENSIONS.includes(ext);
@@ -163,6 +167,37 @@ const AdvancedTrainingMediaViewer: React.FC<
     },
     [pos],
   );
+
+  // Fire onVideoEnd once when the video's ended event fires
+  useEffect(() => {
+    if (!onVideoEnd || !isVideo) return;
+    const wrapper = playerWrapperRef.current;
+    if (!wrapper) return;
+
+    const attachListener = () => {
+      const video = wrapper.querySelector("video");
+      if (!video) return;
+      const handleEnded = () => {
+        if (!videoEndFiredRef.current) {
+          videoEndFiredRef.current = true;
+          onVideoEnd();
+        }
+      };
+      video.addEventListener("ended", handleEnded);
+      return () => video.removeEventListener("ended", handleEnded);
+    };
+
+    // The video element may not exist immediately; poll briefly
+    let cleanup: (() => void) | undefined;
+    const timer = setTimeout(() => {
+      cleanup = attachListener();
+    }, 200);
+
+    return () => {
+      clearTimeout(timer);
+      cleanup?.();
+    };
+  }, [onVideoEnd, isVideo]);
 
   useEffect(() => {
     if (!isDragging) return;
@@ -228,6 +263,7 @@ const AdvancedTrainingMediaViewer: React.FC<
         {({playPause}: {playPause: () => void}) => (
           <div className="media-viewer-body">
             <div
+              ref={playerWrapperRef}
               className="media-viewer-player"
               style={{display: isVideo ? "block" : "none"}}
             >

--- a/src/components/training/AdvancedTrainingMediaViewer.tsx
+++ b/src/components/training/AdvancedTrainingMediaViewer.tsx
@@ -1,4 +1,10 @@
-import React, {useRef, useState, useEffect, useCallback, CSSProperties} from "react";
+import React, {
+  useRef,
+  useState,
+  useEffect,
+  useCallback,
+  CSSProperties,
+} from "react";
 // @ts-ignore - react-media-player has no type declarations
 import {Media, Player, controls, withMediaProps} from "react-media-player";
 import "./AdvancedTrainingMediaViewer.scss";
@@ -86,15 +92,16 @@ const SeekBarComp: React.FC<{media: any; className?: string}> = ({
       }}
       onMouseUp={(e: any) => {
         media.seekTo(+e.target.value);
-        if (isPlayingRef.current) media.play();
+        if (isPlayingRef.current) {
+          media.play();
+        }
       }}
       onChange={(e: any) => {
         setSeekValue(+e.target.value);
       }}
       className={className}
       style={{
-        backgroundSize:
-          (seekValue * 100) / (media.duration || 1) + "% 100%",
+        backgroundSize: (seekValue * 100) / (media.duration || 1) + "% 100%",
       }}
     />
   );
@@ -110,7 +117,7 @@ interface AdvancedTrainingMediaViewerProps {
   stripPosition?: "top" | "bottom";
 }
 
-const SIZE_WIDTHS = {small: 0.25, medium: 0.40, large: 0.60};
+const SIZE_WIDTHS = {small: 0.25, medium: 0.4, large: 0.6};
 const STRIP_HEIGHT = 64;
 const MARGIN = 16;
 
@@ -125,13 +132,21 @@ function getPositionStyle(
 
   const style: CSSProperties = {};
 
-  if (horiz === "left") style.left = MARGIN;
-  else if (horiz === "right") style.right = MARGIN;
-  else style.left = "50%"; // center
+  if (horiz === "left") {
+    style.left = MARGIN;
+  } else if (horiz === "right") {
+    style.right = MARGIN;
+  } else {
+    style.left = "50%";
+  } // center
 
-  if (vert === "top") style.top = stripPosition === "top" ? STRIP_HEIGHT + MARGIN : MARGIN;
-  else if (vert === "bottom") style.bottom = stripPosition === "bottom" ? STRIP_HEIGHT + MARGIN : MARGIN;
-  else style.top = "50%"; // middle
+  if (vert === "top") {
+    style.top = stripPosition === "top" ? STRIP_HEIGHT + MARGIN : MARGIN;
+  } else if (vert === "bottom") {
+    style.bottom = stripPosition === "bottom" ? STRIP_HEIGHT + MARGIN : MARGIN;
+  } else {
+    style.top = "50%";
+  } // middle
 
   const tx = horiz === "center" ? "-50%" : "0px";
   const ty = vert === "middle" ? "-50%" : "0px";
@@ -147,7 +162,14 @@ const VIDEO_EXTENSIONS = ["mov", "mp4", "ogv", "webm", "m4v"];
 
 const AdvancedTrainingMediaViewer: React.FC<
   AdvancedTrainingMediaViewerProps
-> = ({src, onClose, onVideoEnd, size = "small", position = "bottom-right", stripPosition = "bottom"}) => {
+> = ({
+  src,
+  onClose,
+  onVideoEnd,
+  size = "small",
+  position = "bottom-right",
+  stripPosition = "bottom",
+}) => {
   // `dragPos` is only set once the user starts dragging. Before that, CSS
   // handles placement accurately (no hardcoded height guessing needed).
   const [dragPos, setDragPos] = useState<{x: number; y: number} | null>(null);
@@ -160,7 +182,9 @@ const AdvancedTrainingMediaViewer: React.FC<
   // to re-run (and never detaches mid-playback) just because the prop's
   // function identity changed due to a parent re-render.
   const onVideoEndRef = useRef(onVideoEnd);
-  useEffect(() => { onVideoEndRef.current = onVideoEnd; });
+  useEffect(() => {
+    onVideoEndRef.current = onVideoEnd;
+  });
 
   const ext = (src.match(/\.([^.]+)$/)?.[1] || "").toLowerCase();
   const isVideo = VIDEO_EXTENSIONS.includes(ext);
@@ -168,7 +192,20 @@ const AdvancedTrainingMediaViewer: React.FC<
   const handleMouseDown = useCallback(
     (e: React.MouseEvent) => {
       const tag = (e.target as HTMLElement).tagName;
-      if (["INPUT", "BUTTON", "SVG", "CIRCLE", "POLYGON", "RECT", "PATH", "G"].includes(tag)) return;
+      if (
+        [
+          "INPUT",
+          "BUTTON",
+          "SVG",
+          "CIRCLE",
+          "POLYGON",
+          "RECT",
+          "PATH",
+          "G",
+        ].includes(tag)
+      ) {
+        return;
+      }
 
       // On first drag, capture the element's current pixel position so we can
       // switch from CSS-based layout to transform-based drag coordinates.
@@ -202,11 +239,15 @@ const AdvancedTrainingMediaViewer: React.FC<
   // causing a re-run.
   useEffect(() => {
     const wrapper = playerWrapperRef.current;
-    if (!wrapper) return;
+    if (!wrapper) {
+      return;
+    }
 
     const attachListener = () => {
       const mediaEl = wrapper.querySelector("video, audio");
-      if (!mediaEl) return;
+      if (!mediaEl) {
+        return;
+      }
       const handleEnded = () => {
         if (!videoEndFiredRef.current) {
           videoEndFiredRef.current = true;
@@ -230,7 +271,9 @@ const AdvancedTrainingMediaViewer: React.FC<
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
-    if (!isDragging) return;
+    if (!isDragging) {
+      return;
+    }
 
     const handleMouseMove = (e: MouseEvent) => {
       const dx = e.clientX - dragStartRef.current.x;
@@ -245,10 +288,7 @@ const AdvancedTrainingMediaViewer: React.FC<
         ),
         y: Math.max(
           0,
-          Math.min(
-            window.innerHeight * 0.75,
-            dragStartRef.current.posY + dy,
-          ),
+          Math.min(window.innerHeight * 0.75, dragStartRef.current.posY + dy),
         ),
       });
     };
@@ -270,7 +310,13 @@ const AdvancedTrainingMediaViewer: React.FC<
   // Before the user drags: let CSS handle placement precisely.
   // After dragging: switch to pixel-based transform coordinates.
   const positionStyle: CSSProperties = dragPos
-    ? {left: 0, top: 0, right: "auto", bottom: "auto", transform: `translate(${dragPos.x}px, ${dragPos.y}px)`}
+    ? {
+        left: 0,
+        top: 0,
+        right: "auto",
+        bottom: "auto",
+        transform: `translate(${dragPos.x}px, ${dragPos.y}px)`,
+      }
     : getPositionStyle(position, size, stripPosition);
 
   return (
@@ -286,12 +332,7 @@ const AdvancedTrainingMediaViewer: React.FC<
       <div className="media-viewer-header">
         <span className="media-viewer-title">Training Media</span>
         <button className="media-viewer-close" onClick={onClose}>
-          <svg
-            viewBox="0 0 24 24"
-            width="14"
-            height="14"
-            fill="currentColor"
-          >
+          <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
             <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
           </svg>
         </button>
@@ -302,9 +343,16 @@ const AdvancedTrainingMediaViewer: React.FC<
             <div
               ref={playerWrapperRef}
               className="media-viewer-player"
-              style={isVideo
-                ? {display: "block"}
-                : {position: "absolute", width: 0, height: 0, overflow: "hidden"}}
+              style={
+                isVideo
+                  ? {display: "block"}
+                  : {
+                      position: "absolute",
+                      width: 0,
+                      height: 0,
+                      overflow: "hidden",
+                    }
+              }
             >
               <Player src={src} onClick={() => playPause()} />
             </div>

--- a/src/components/training/AdvancedTrainingMediaViewer.tsx
+++ b/src/components/training/AdvancedTrainingMediaViewer.tsx
@@ -1,4 +1,4 @@
-import React, {useRef, useState, useEffect, useCallback} from "react";
+import React, {useRef, useState, useEffect, useCallback, CSSProperties} from "react";
 // @ts-ignore - react-media-player has no type declarations
 import {Media, Player, controls, withMediaProps} from "react-media-player";
 import "./AdvancedTrainingMediaViewer.scss";
@@ -107,87 +107,117 @@ interface AdvancedTrainingMediaViewerProps {
   onVideoEnd?: () => void;
   size?: "small" | "medium" | "large";
   position?: string;
+  stripPosition?: "top" | "bottom";
 }
 
 const SIZE_WIDTHS = {small: 0.25, medium: 0.40, large: 0.60};
 const STRIP_HEIGHT = 64;
+const MARGIN = 16;
 
-function computeInitialPosition(
+// Return CSS properties that accurately position the viewer using browser layout
+// rather than guessing the element height in JavaScript.
+function getPositionStyle(
   position: string,
   size: "small" | "medium" | "large",
-): {x: number; y: number} {
-  const viewerW = window.innerWidth * (SIZE_WIDTHS[size] || 0.25);
-  const viewerH = 280;
-  const margin = 16;
-  const contentW = window.innerWidth;
-  const contentH = window.innerHeight - STRIP_HEIGHT;
-
+  stripPosition: "top" | "bottom" = "bottom",
+): CSSProperties {
   const [vert, horiz] = position.split("-");
 
-  let x: number;
-  if (horiz === "left") x = margin;
-  else if (horiz === "right") x = contentW - viewerW - margin;
-  else x = (contentW - viewerW) / 2;
+  const style: CSSProperties = {};
 
-  let y: number;
-  if (vert === "top") y = margin;
-  else if (vert === "bottom") y = contentH - viewerH - margin;
-  else y = (contentH - viewerH) / 2;
+  if (horiz === "left") style.left = MARGIN;
+  else if (horiz === "right") style.right = MARGIN;
+  else style.left = "50%"; // center
 
-  return {x: Math.max(0, x), y: Math.max(0, y)};
+  if (vert === "top") style.top = stripPosition === "top" ? STRIP_HEIGHT + MARGIN : MARGIN;
+  else if (vert === "bottom") style.bottom = stripPosition === "bottom" ? STRIP_HEIGHT + MARGIN : MARGIN;
+  else style.top = "50%"; // middle
+
+  const tx = horiz === "center" ? "-50%" : "0px";
+  const ty = vert === "middle" ? "-50%" : "0px";
+  if (tx !== "0px" || ty !== "0px") {
+    style.transform = `translate(${tx}, ${ty})`;
+  }
+
+  // Width is still set via viewerWidth in the component
+  return style;
 }
 
 const VIDEO_EXTENSIONS = ["mov", "mp4", "ogv", "webm", "m4v"];
 
 const AdvancedTrainingMediaViewer: React.FC<
   AdvancedTrainingMediaViewerProps
-> = ({src, onClose, onVideoEnd, size = "small", position = "bottom-right"}) => {
-  const [pos, setPos] = useState(() => computeInitialPosition(position, size));
+> = ({src, onClose, onVideoEnd, size = "small", position = "bottom-right", stripPosition = "bottom"}) => {
+  // `dragPos` is only set once the user starts dragging. Before that, CSS
+  // handles placement accurately (no hardcoded height guessing needed).
+  const [dragPos, setDragPos] = useState<{x: number; y: number} | null>(null);
   const [isDragging, setIsDragging] = useState(false);
   const dragStartRef = useRef({x: 0, y: 0, posX: 0, posY: 0});
+  const viewerRef = useRef<HTMLDivElement>(null);
   const playerWrapperRef = useRef<HTMLDivElement>(null);
   const videoEndFiredRef = useRef(false);
+  // Keep a stable ref to onVideoEnd so the ended-listener effect never needs
+  // to re-run (and never detaches mid-playback) just because the prop's
+  // function identity changed due to a parent re-render.
+  const onVideoEndRef = useRef(onVideoEnd);
+  useEffect(() => { onVideoEndRef.current = onVideoEnd; });
 
   const ext = (src.match(/\.([^.]+)$/)?.[1] || "").toLowerCase();
   const isVideo = VIDEO_EXTENSIONS.includes(ext);
 
   const handleMouseDown = useCallback(
     (e: React.MouseEvent) => {
-      // Don't drag on interactive elements
       const tag = (e.target as HTMLElement).tagName;
       if (["INPUT", "BUTTON", "SVG", "CIRCLE", "POLYGON", "RECT", "PATH", "G"].includes(tag)) return;
+
+      // On first drag, capture the element's current pixel position so we can
+      // switch from CSS-based layout to transform-based drag coordinates.
+      let startPosX = dragPos?.x ?? 0;
+      let startPosY = dragPos?.y ?? 0;
+      if (!dragPos && viewerRef.current) {
+        const rect = viewerRef.current.getBoundingClientRect();
+        startPosX = rect.left;
+        startPosY = rect.top;
+        setDragPos({x: startPosX, y: startPosY});
+      }
 
       setIsDragging(true);
       dragStartRef.current = {
         x: e.clientX,
         y: e.clientY,
-        posX: pos.x,
-        posY: pos.y,
+        posX: startPosX,
+        posY: startPosY,
       };
     },
-    [pos],
+    [dragPos],
   );
 
-  // Fire onVideoEnd once when the video's ended event fires
+  // Fire onVideoEnd once when the media element's ended event fires.
+  // Works for both video and audio assets.
+  //
+  // Intentionally uses [] deps — the viewer is keyed on activeChapterId so it
+  // remounts on chapter change. Within a chapter this effect must never re-run,
+  // because tearing down and re-attaching the listener opens a window where the
+  // ended event can be missed. onVideoEndRef keeps the callback current without
+  // causing a re-run.
   useEffect(() => {
-    if (!onVideoEnd || !isVideo) return;
     const wrapper = playerWrapperRef.current;
     if (!wrapper) return;
 
     const attachListener = () => {
-      const video = wrapper.querySelector("video");
-      if (!video) return;
+      const mediaEl = wrapper.querySelector("video, audio");
+      if (!mediaEl) return;
       const handleEnded = () => {
         if (!videoEndFiredRef.current) {
           videoEndFiredRef.current = true;
-          onVideoEnd();
+          onVideoEndRef.current?.();
         }
       };
-      video.addEventListener("ended", handleEnded);
-      return () => video.removeEventListener("ended", handleEnded);
+      mediaEl.addEventListener("ended", handleEnded);
+      return () => mediaEl.removeEventListener("ended", handleEnded);
     };
 
-    // The video element may not exist immediately; poll briefly
+    // The media element may not exist immediately; poll briefly
     let cleanup: (() => void) | undefined;
     const timer = setTimeout(() => {
       cleanup = attachListener();
@@ -197,7 +227,7 @@ const AdvancedTrainingMediaViewer: React.FC<
       clearTimeout(timer);
       cleanup?.();
     };
-  }, [onVideoEnd, isVideo]);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (!isDragging) return;
@@ -205,11 +235,11 @@ const AdvancedTrainingMediaViewer: React.FC<
     const handleMouseMove = (e: MouseEvent) => {
       const dx = e.clientX - dragStartRef.current.x;
       const dy = e.clientY - dragStartRef.current.y;
-      setPos({
+      setDragPos({
         x: Math.max(
           0,
           Math.min(
-            window.innerWidth * 0.75,
+            window.innerWidth * (1 - (SIZE_WIDTHS[size] || 0.25)),
             dragStartRef.current.posX + dx,
           ),
         ),
@@ -237,11 +267,18 @@ const AdvancedTrainingMediaViewer: React.FC<
 
   const viewerWidth = `${(SIZE_WIDTHS[size] || 0.25) * 100}vw`;
 
+  // Before the user drags: let CSS handle placement precisely.
+  // After dragging: switch to pixel-based transform coordinates.
+  const positionStyle: CSSProperties = dragPos
+    ? {left: 0, top: 0, right: "auto", bottom: "auto", transform: `translate(${dragPos.x}px, ${dragPos.y}px)`}
+    : getPositionStyle(position, size, stripPosition);
+
   return (
     <div
+      ref={viewerRef}
       className="advanced-training-media-viewer"
       style={{
-        transform: `translate(${pos.x}px, ${pos.y}px)`,
+        ...positionStyle,
         width: viewerWidth,
       }}
       onMouseDown={handleMouseDown}

--- a/src/components/training/AdvancedTrainingMediaViewer.tsx
+++ b/src/components/training/AdvancedTrainingMediaViewer.tsx
@@ -1,0 +1,251 @@
+import React, {useRef, useState, useEffect, useCallback} from "react";
+// @ts-ignore - react-media-player has no type declarations
+import {Media, Player, controls, withMediaProps} from "react-media-player";
+import "./AdvancedTrainingMediaViewer.scss";
+
+const {CurrentTime, Duration, Volume} = controls;
+
+// Reuse the same withMediaProps pattern from the legacy training player
+const PlayPauseComp: React.FC<{media: any; className?: string}> = ({
+  media,
+  className,
+}) => (
+  <svg
+    role="button"
+    width="30px"
+    height="30px"
+    viewBox="0 0 36 36"
+    className={className}
+    onClick={() => media.playPause()}
+  >
+    <circle fill="#373D3F" cx="18" cy="18" r="18" />
+    {media.isPlaying ? (
+      <g key="pause">
+        <rect x="12" y="11" fill="#CDD7DB" width="4" height="14" />
+        <rect x="20" y="11" fill="#CDD7DB" width="4" height="14" />
+      </g>
+    ) : (
+      <polygon key="play" fill="#CDD7DB" points="14,11 26,18 14,25" />
+    )}
+  </svg>
+);
+const PlayPause = withMediaProps(PlayPauseComp);
+
+const MuteUnmuteComp: React.FC<{media: any; className?: string}> = ({
+  media,
+  className,
+}) => (
+  <svg
+    width="30px"
+    height="30px"
+    viewBox="0 0 36 36"
+    className={className}
+    onClick={() => media.muteUnmute()}
+  >
+    <circle fill="#373D3F" cx="18" cy="18" r="18" />
+    <polygon
+      fill="#CDD7DB"
+      points="11,14.844 11,21.442 14.202,21.442 17.656,25 17.656,11 14.074,14.844"
+    />
+    {media.volume > 0 && !media.isMuted && (
+      <path
+        fill="#CDD7DB"
+        d="M21.733,18c0-1.518-0.91-2.819-2.211-3.402v6.804C20.824,20.818,21.733,19.518,21.733,18z"
+      />
+    )}
+    {(media.volume === 0 || media.isMuted) && (
+      <polygon
+        fill="#CDD7DB"
+        points="24.839,15.955 23.778,14.895 21.733,16.94 19.688,14.895 18.628,15.955 20.673,18 18.628,20.045 19.688,21.106 21.733,19.061 23.778,21.106 24.839,20.045 22.794,18"
+      />
+    )}
+  </svg>
+);
+const MuteUnmute = withMediaProps(MuteUnmuteComp);
+
+const SeekBarComp: React.FC<{media: any; className?: string}> = ({
+  media,
+  className,
+}) => {
+  const [seekValue, setSeekValue] = useState(media.currentTime);
+  const isPlayingRef = useRef(false);
+
+  useEffect(() => {
+    setSeekValue(media.currentTime);
+  }, [media.currentTime]);
+
+  return (
+    <input
+      type="range"
+      step="any"
+      max={media.duration.toFixed(4)}
+      value={seekValue}
+      onMouseDown={() => {
+        isPlayingRef.current = media.isPlaying;
+        media.pause();
+      }}
+      onMouseUp={(e: any) => {
+        media.seekTo(+e.target.value);
+        if (isPlayingRef.current) media.play();
+      }}
+      onChange={(e: any) => {
+        setSeekValue(+e.target.value);
+      }}
+      className={className}
+      style={{
+        backgroundSize:
+          (seekValue * 100) / (media.duration || 1) + "% 100%",
+      }}
+    />
+  );
+};
+const SeekBar = withMediaProps(SeekBarComp);
+
+interface AdvancedTrainingMediaViewerProps {
+  src: string;
+  onClose: () => void;
+  size?: "small" | "medium" | "large";
+  position?: string;
+}
+
+const SIZE_WIDTHS = {small: 0.25, medium: 0.40, large: 0.60};
+
+function computeInitialPosition(
+  position: string,
+  size: "small" | "medium" | "large",
+): {x: number; y: number} {
+  const viewerW = window.innerWidth * (SIZE_WIDTHS[size] || 0.25);
+  const viewerH = 280;
+  const margin = 16;
+  const contentH = window.innerHeight - 36;
+  const contentW = window.innerWidth;
+
+  const [vert, horiz] = position.split("-");
+
+  let x: number;
+  if (horiz === "left") x = margin;
+  else if (horiz === "right") x = contentW - viewerW - margin;
+  else x = (contentW - viewerW) / 2;
+
+  let y: number;
+  if (vert === "top") y = margin;
+  else if (vert === "bottom") y = contentH - viewerH - margin;
+  else y = (contentH - viewerH) / 2;
+
+  return {x: Math.max(0, x), y: Math.max(0, y)};
+}
+
+const VIDEO_EXTENSIONS = ["mov", "mp4", "ogv", "webm", "m4v"];
+
+const AdvancedTrainingMediaViewer: React.FC<
+  AdvancedTrainingMediaViewerProps
+> = ({src, onClose, size = "small", position = "bottom-right"}) => {
+  const [pos, setPos] = useState(() => computeInitialPosition(position, size));
+  const [isDragging, setIsDragging] = useState(false);
+  const dragStartRef = useRef({x: 0, y: 0, posX: 0, posY: 0});
+
+  const ext = (src.match(/\.([^.]+)$/)?.[1] || "").toLowerCase();
+  const isVideo = VIDEO_EXTENSIONS.includes(ext);
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      // Don't drag on interactive elements
+      const tag = (e.target as HTMLElement).tagName;
+      if (["INPUT", "BUTTON", "SVG", "CIRCLE", "POLYGON", "RECT", "PATH", "G"].includes(tag)) return;
+
+      setIsDragging(true);
+      dragStartRef.current = {
+        x: e.clientX,
+        y: e.clientY,
+        posX: pos.x,
+        posY: pos.y,
+      };
+    },
+    [pos],
+  );
+
+  useEffect(() => {
+    if (!isDragging) return;
+
+    const handleMouseMove = (e: MouseEvent) => {
+      const dx = e.clientX - dragStartRef.current.x;
+      const dy = e.clientY - dragStartRef.current.y;
+      setPos({
+        x: Math.max(
+          0,
+          Math.min(
+            window.innerWidth * 0.75,
+            dragStartRef.current.posX + dx,
+          ),
+        ),
+        y: Math.max(
+          0,
+          Math.min(
+            window.innerHeight * 0.75,
+            dragStartRef.current.posY + dy,
+          ),
+        ),
+      });
+    };
+
+    const handleMouseUp = () => {
+      setIsDragging(false);
+    };
+
+    document.addEventListener("mousemove", handleMouseMove);
+    document.addEventListener("mouseup", handleMouseUp);
+    return () => {
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("mouseup", handleMouseUp);
+    };
+  }, [isDragging]);
+
+  const viewerWidth = `${(SIZE_WIDTHS[size] || 0.25) * 100}vw`;
+
+  return (
+    <div
+      className="advanced-training-media-viewer"
+      style={{
+        transform: `translate(${pos.x}px, ${pos.y}px)`,
+        width: viewerWidth,
+      }}
+      onMouseDown={handleMouseDown}
+    >
+      <div className="media-viewer-header">
+        <span className="media-viewer-title">Training Media</span>
+        <button className="media-viewer-close" onClick={onClose}>
+          <svg
+            viewBox="0 0 24 24"
+            width="14"
+            height="14"
+            fill="currentColor"
+          >
+            <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
+          </svg>
+        </button>
+      </div>
+      <Media>
+        {({playPause}: {playPause: () => void}) => (
+          <div className="media-viewer-body">
+            <div
+              className="media-viewer-player"
+              style={{display: isVideo ? "block" : "none"}}
+            >
+              <Player src={src} onClick={() => playPause()} />
+            </div>
+            <div className="media-viewer-controls">
+              <PlayPause className="media-control media-control--play-pause" />
+              <CurrentTime className="media-control media-control--current-time" />
+              <SeekBar className="media-control media-control--volume-range" />
+              <Duration className="media-control media-control--duration" />
+              <MuteUnmute className="media-control media-control--mute-unmute" />
+              <Volume className="media-control media-control--volume" />
+            </div>
+          </div>
+        )}
+      </Media>
+    </div>
+  );
+};
+
+export default AdvancedTrainingMediaViewer;

--- a/src/components/training/actionRegistry.ts
+++ b/src/components/training/actionRegistry.ts
@@ -132,11 +132,30 @@ const actionRegistry: CardActions[] = [
 ];
 
 /**
+ * Actions always available regardless of which card component is active.
+ * These cover simulator-wide events like login that aren't tied to a specific card.
+ */
+const GLOBAL_ACTIONS: ActionDefinition[] = [
+  {eventName: "clientLogin", label: "Log In to Station"},
+];
+
+export function getGlobalActions(): ActionDefinition[] {
+  return GLOBAL_ACTIONS;
+}
+
+/**
  * Synthetic event fired by the media viewer when a video reaches the end.
  * Add this as a requiredAction on a subchapter to require the crew to watch
  * the training video before the subchapter counts as complete.
  */
 export const VIDEO_COMPLETE_EVENT = "__videoComplete__";
+
+/**
+ * The GraphQL mutation event fired when a crew member logs in to their station.
+ * Add this as a requiredAction on a login-chapter subchapter to gate completion
+ * on the crew actually logging in.
+ */
+export const LOGIN_EVENT = "clientLogin";
 
 /**
  * Check if an event name represents a click action (vs a GraphQL mutation).
@@ -153,7 +172,7 @@ export function getActionLabel(
   cardComponent?: string,
 ): string {
   // Handle the video completion sentinel
-  if (eventName === VIDEO_COMPLETE_EVENT) return "Video finishes";
+  if (eventName === VIDEO_COMPLETE_EVENT) return "Media finishes";
 
   // Handle click-type actions
   if (isClickAction(eventName)) {

--- a/src/components/training/actionRegistry.ts
+++ b/src/components/training/actionRegistry.ts
@@ -132,6 +132,13 @@ const actionRegistry: CardActions[] = [
 ];
 
 /**
+ * Synthetic event fired by the media viewer when a video reaches the end.
+ * Add this as a requiredAction on a subchapter to require the crew to watch
+ * the training video before the subchapter counts as complete.
+ */
+export const VIDEO_COMPLETE_EVENT = "__videoComplete__";
+
+/**
  * Check if an event name represents a click action (vs a GraphQL mutation).
  */
 export function isClickAction(eventName: string): boolean {
@@ -145,6 +152,9 @@ export function getActionLabel(
   eventName: string,
   cardComponent?: string,
 ): string {
+  // Handle the video completion sentinel
+  if (eventName === VIDEO_COMPLETE_EVENT) return "Video finishes";
+
   // Handle click-type actions
   if (isClickAction(eventName)) {
     const text = eventName.slice("click:".length);

--- a/src/components/training/actionRegistry.ts
+++ b/src/components/training/actionRegistry.ts
@@ -1,0 +1,190 @@
+/**
+ * Action Registry for the Advanced Training System.
+ *
+ * Maps GraphQL mutation event names to human-readable labels, organized by
+ * card component. Used in both the FD record-mode configuration and the
+ * crew-side progress display.
+ */
+
+export interface ActionDefinition {
+  eventName: string;
+  label: string;
+}
+
+export interface CardActions {
+  cardComponent: string;
+  cardLabel: string;
+  actions: ActionDefinition[];
+}
+
+const actionRegistry: CardActions[] = [
+  {
+    cardComponent: "ShieldControl",
+    cardLabel: "Shield Control",
+    actions: [
+      {eventName: "shieldRaised", label: "Raise Shields"},
+      {eventName: "shieldLowered", label: "Lower Shields"},
+      {eventName: "shieldFrequencySet", label: "Adjust Shield Frequency"},
+      {eventName: "shieldFrequencySetAll", label: "Set All Shield Frequencies"},
+    ],
+  },
+  {
+    cardComponent: "Navigation",
+    cardLabel: "Navigation",
+    actions: [
+      {eventName: "navCalculateCourse", label: "Calculate Course"},
+      {eventName: "navCancelCalculation", label: "Cancel Calculation"},
+      {eventName: "navCourseEntry", label: "Enter Course Coordinates"},
+    ],
+  },
+  {
+    cardComponent: "NavigationAdvanced",
+    cardLabel: "Advanced Navigation",
+    actions: [
+      {eventName: "rotationSet", label: "Adjust Rotation"},
+      {eventName: "setEngineAcceleration", label: "Set Engine Acceleration"},
+    ],
+  },
+  {
+    cardComponent: "Sensors",
+    cardLabel: "Sensors",
+    actions: [
+      {eventName: "pingSensors", label: "Ping Sensors"},
+      {eventName: "setSensorPingMode", label: "Set Ping Mode"},
+      {eventName: "sensorScanRequest", label: "Request Sensor Scan"},
+      {eventName: "sensorScanCancel", label: "Cancel Sensor Scan"},
+      {eventName: "removeProcessedData", label: "Clear Processed Data"},
+      {
+        eventName: "setTargetingCalculatedTarget",
+        label: "Set Calculated Target",
+      },
+    ],
+  },
+  {
+    cardComponent: "EngineControl",
+    cardLabel: "Engine Control",
+    actions: [{eventName: "setSpeed", label: "Change Engine Speed"}],
+  },
+  {
+    cardComponent: "ReactorControl",
+    cardLabel: "Reactor Control",
+    actions: [
+      {eventName: "reactorChangeEfficiency", label: "Set Reactor Efficiency"},
+      {eventName: "engineCool", label: "Apply Coolant"},
+      {eventName: "reactorSetWingPower", label: "Distribute Wing Power"},
+    ],
+  },
+  {
+    cardComponent: "Targeting",
+    cardLabel: "Targeting",
+    actions: [
+      {eventName: "targetTargetingContact", label: "Lock Target"},
+      {eventName: "untargetTargetingContact", label: "Release Target"},
+      {eventName: "targetSystem", label: "Target System"},
+      {
+        eventName: "setTargetingEnteredTarget",
+        label: "Enter Target Coordinates",
+      },
+      {eventName: "chargePhaserBeam", label: "Charge Phaser"},
+      {eventName: "stopChargingPhasers", label: "Stop Charging"},
+      {eventName: "dischargePhaserBeam", label: "Fire Phaser"},
+    ],
+  },
+  {
+    cardComponent: "TorpedoLoading",
+    cardLabel: "Torpedo Loading",
+    actions: [
+      {eventName: "loadWarhead", label: "Load Torpedo"},
+      {eventName: "unloadWarhead", label: "Unload Torpedo"},
+      {eventName: "fireWarhead", label: "Fire Torpedo"},
+    ],
+  },
+  {
+    cardComponent: "CommShortRange",
+    cardLabel: "Short Range Comm",
+    actions: [
+      {eventName: "commHail", label: "Initiate Hail"},
+      {eventName: "cancelHail", label: "Cancel Hail"},
+      {eventName: "commConnectArrow", label: "Connect to Hail"},
+      {eventName: "commDisconnectArrow", label: "Disconnect"},
+      {eventName: "muteShortRangeComm", label: "Toggle Mute"},
+    ],
+  },
+  {
+    cardComponent: "LongRangeComm",
+    cardLabel: "Long Range Comm",
+    actions: [
+      {eventName: "longRangeMessageSend", label: "Send Message"},
+      {eventName: "deleteLongRangeMessage", label: "Delete Message"},
+    ],
+  },
+  {
+    cardComponent: "Transporters",
+    cardLabel: "Transporters",
+    actions: [
+      {eventName: "setTransportTarget", label: "Set Transport Target"},
+      {eventName: "setTransportDestination", label: "Set Transport Destination"},
+      {eventName: "setTransportCharge", label: "Charge Transporters"},
+      {eventName: "beginTransportScan", label: "Begin Transport Scan"},
+      {eventName: "cancelTransportScan", label: "Cancel Scan"},
+    ],
+  },
+];
+
+/**
+ * Check if an event name represents a click action (vs a GraphQL mutation).
+ */
+export function isClickAction(eventName: string): boolean {
+  return eventName.startsWith("click:");
+}
+
+/**
+ * Get the human-readable label for an event name, optionally scoped to a card.
+ */
+export function getActionLabel(
+  eventName: string,
+  cardComponent?: string,
+): string {
+  // Handle click-type actions
+  if (isClickAction(eventName)) {
+    const text = eventName.slice("click:".length);
+    return `Click: ${text}`;
+  }
+
+  if (cardComponent) {
+    const card = actionRegistry.find(c => c.cardComponent === cardComponent);
+    const action = card?.actions.find(a => a.eventName === eventName);
+    if (action) return action.label;
+  }
+  // Fall back to searching all cards
+  for (const card of actionRegistry) {
+    const action = card.actions.find(a => a.eventName === eventName);
+    if (action) return action.label;
+  }
+  // Last resort: humanize the event name
+  return eventName
+    .replace(/([A-Z])/g, " $1")
+    .replace(/^./, s => s.toUpperCase())
+    .trim();
+}
+
+/**
+ * Get all actions available for a specific card component.
+ */
+export function getActionsForCard(cardComponent: string): ActionDefinition[] {
+  return (
+    actionRegistry.find(c => c.cardComponent === cardComponent)?.actions || []
+  );
+}
+
+/**
+ * Get the card label for a component name.
+ */
+export function getCardLabel(cardComponent: string): string {
+  return (
+    actionRegistry.find(c => c.cardComponent === cardComponent)?.cardLabel ||
+    cardComponent
+  );
+}
+
+export default actionRegistry;

--- a/src/components/training/actionRegistry.ts
+++ b/src/components/training/actionRegistry.ts
@@ -123,7 +123,10 @@ const actionRegistry: CardActions[] = [
     cardLabel: "Transporters",
     actions: [
       {eventName: "setTransportTarget", label: "Set Transport Target"},
-      {eventName: "setTransportDestination", label: "Set Transport Destination"},
+      {
+        eventName: "setTransportDestination",
+        label: "Set Transport Destination",
+      },
       {eventName: "setTransportCharge", label: "Charge Transporters"},
       {eventName: "beginTransportScan", label: "Begin Transport Scan"},
       {eventName: "cancelTransportScan", label: "Cancel Scan"},
@@ -172,7 +175,9 @@ export function getActionLabel(
   cardComponent?: string,
 ): string {
   // Handle the video completion sentinel
-  if (eventName === VIDEO_COMPLETE_EVENT) return "Media finishes";
+  if (eventName === VIDEO_COMPLETE_EVENT) {
+    return "Media finishes";
+  }
 
   // Handle click-type actions
   if (isClickAction(eventName)) {
@@ -183,12 +188,16 @@ export function getActionLabel(
   if (cardComponent) {
     const card = actionRegistry.find(c => c.cardComponent === cardComponent);
     const action = card?.actions.find(a => a.eventName === eventName);
-    if (action) return action.label;
+    if (action) {
+      return action.label;
+    }
   }
   // Fall back to searching all cards
   for (const card of actionRegistry) {
     const action = card.actions.find(a => a.eventName === eventName);
-    if (action) return action.label;
+    if (action) {
+      return action.label;
+    }
   }
   // Last resort: humanize the event name
   return eventName

--- a/src/components/training/index.ts
+++ b/src/components/training/index.ts
@@ -1,0 +1,5 @@
+export {default as AdvancedTrainingBorder} from "./AdvancedTrainingBorder";
+export {default as AdvancedTrainingChapterList} from "./AdvancedTrainingChapterList";
+export {default as AdvancedTrainingMediaViewer} from "./AdvancedTrainingMediaViewer";
+export {useAdvancedTraining} from "./useAdvancedTraining";
+export {default as actionRegistry, getActionLabel, getActionsForCard, getCardLabel} from "./actionRegistry";

--- a/src/components/training/index.ts
+++ b/src/components/training/index.ts
@@ -2,4 +2,9 @@ export {default as AdvancedTrainingBorder} from "./AdvancedTrainingBorder";
 export {default as AdvancedTrainingChapterList} from "./AdvancedTrainingChapterList";
 export {default as AdvancedTrainingMediaViewer} from "./AdvancedTrainingMediaViewer";
 export {useAdvancedTraining} from "./useAdvancedTraining";
-export {default as actionRegistry, getActionLabel, getActionsForCard, getCardLabel} from "./actionRegistry";
+export {
+  default as actionRegistry,
+  getActionLabel,
+  getActionsForCard,
+  getCardLabel,
+} from "./actionRegistry";

--- a/src/components/training/queries.ts
+++ b/src/components/training/queries.ts
@@ -13,6 +13,7 @@ export const ADVANCED_TRAINING_PROGRESS_FRAGMENT = gql`
     completedChapterIds
     completedSubChapterIds
     observedActions
+    globalObservedEvents
     mediaViewerOpen
     chapterListOpen
   }

--- a/src/components/training/queries.ts
+++ b/src/components/training/queries.ts
@@ -1,0 +1,186 @@
+import gql from "graphql-tag.macro";
+
+// --- Fragments ---
+
+export const ADVANCED_TRAINING_PROGRESS_FRAGMENT = gql`
+  fragment AdvancedTrainingProgressFragment on AdvancedTrainingProgress {
+    id
+    clientId
+    simulatorId
+    stationName
+    activeChapterId
+    activeSubChapterId
+    completedChapterIds
+    completedSubChapterIds
+    observedActions
+    mediaViewerOpen
+    chapterListOpen
+  }
+`;
+
+export const ADVANCED_TRAINING_CONFIG_FRAGMENT = gql`
+  fragment AdvancedTrainingConfigFragment on AdvancedTrainingConfig {
+    enabled
+    chapters {
+      id
+      name
+      cardComponent
+      mediaAsset
+      autoOpenMedia
+      autoAdvance
+      cardSwitchBehavior
+      subChapters {
+        id
+        name
+        requiredActions {
+          id
+          eventName
+          args
+        }
+      }
+    }
+  }
+`;
+
+// --- Mutations ---
+
+export const START_ADVANCED_TRAINING = gql`
+  mutation ClientStartAdvancedTraining($clientId: ID!) {
+    clientStartAdvancedTraining(clientId: $clientId)
+  }
+`;
+
+export const STOP_ADVANCED_TRAINING = gql`
+  mutation ClientStopAdvancedTraining($clientId: ID!) {
+    clientStopAdvancedTraining(clientId: $clientId)
+  }
+`;
+
+export const ADVANCED_TRAINING_ACTION = gql`
+  mutation ClientAdvancedTrainingAction(
+    $clientId: ID!
+    $eventName: String!
+    $args: JSON
+  ) {
+    clientAdvancedTrainingAction(
+      clientId: $clientId
+      eventName: $eventName
+      args: $args
+    )
+  }
+`;
+
+export const SET_ACTIVE_CHAPTER = gql`
+  mutation AdvancedTrainingSetActiveChapter($clientId: ID!, $chapterId: ID!) {
+    advancedTrainingSetActiveChapter(clientId: $clientId, chapterId: $chapterId)
+  }
+`;
+
+export const TOGGLE_MEDIA_VIEWER = gql`
+  mutation AdvancedTrainingToggleMediaViewer($clientId: ID!, $open: Boolean!) {
+    advancedTrainingToggleMediaViewer(clientId: $clientId, open: $open)
+  }
+`;
+
+export const TOGGLE_CHAPTER_LIST = gql`
+  mutation AdvancedTrainingToggleChapterList($clientId: ID!, $open: Boolean!) {
+    advancedTrainingToggleChapterList(clientId: $clientId, open: $open)
+  }
+`;
+
+// --- FD Mutations ---
+
+export const FD_ADVANCE_CHAPTER = gql`
+  mutation FdAdvanceTrainingChapter($clientId: ID!, $chapterId: ID!) {
+    advancedTrainingSetActiveChapter(clientId: $clientId, chapterId: $chapterId)
+  }
+`;
+
+export const FD_COMPLETE_SUBCHAPTER = gql`
+  mutation FdCompleteTrainingSubChapter($clientId: ID!, $subChapterId: ID!) {
+    fdCompleteTrainingSubChapter(clientId: $clientId, subChapterId: $subChapterId)
+  }
+`;
+
+export const FD_RESET_PROGRESS = gql`
+  mutation FdResetTrainingProgress($clientId: ID!) {
+    fdResetTrainingProgress(clientId: $clientId)
+  }
+`;
+
+// --- Sandbox Flight (for recording modal) ---
+
+export const START_SANDBOX_FLIGHT = gql`
+  mutation StartSandboxFlight($name: String!, $simulators: [SimulatorInput!]!) {
+    startFlight(name: $name, simulators: $simulators)
+  }
+`;
+
+export const DELETE_SANDBOX_FLIGHT = gql`
+  mutation DeleteSandboxFlight($flightId: ID!) {
+    deleteFlight(flightId: $flightId)
+  }
+`;
+
+export const SANDBOX_FLIGHT_SIMULATORS = gql`
+  query SandboxFlightSimulators($flightId: ID!) {
+    flights(id: $flightId) {
+      id
+      simulators {
+        id
+      }
+    }
+  }
+`;
+
+// --- Config Mutations ---
+
+export const SET_STATION_ADVANCED_TRAINING = gql`
+  mutation SetStationAdvancedTraining(
+    $stationSetID: ID!
+    $stationName: String!
+    $config: AdvancedTrainingConfigInput!
+  ) {
+    setStationAdvancedTraining(
+      stationSetID: $stationSetID
+      stationName: $stationName
+      config: $config
+    )
+  }
+`;
+
+export const TOGGLE_ADVANCED_TRAINING_MODE = gql`
+  mutation ToggleAdvancedTrainingMode(
+    $stationSetID: ID!
+    $stationName: String!
+    $enabled: Boolean!
+  ) {
+    toggleAdvancedTrainingMode(
+      stationSetID: $stationSetID
+      stationName: $stationName
+      enabled: $enabled
+    )
+  }
+`;
+
+// --- Subscriptions ---
+
+export const ADVANCED_TRAINING_PROGRESS_SUB = gql`
+  subscription AdvancedTrainingProgressUpdate($simulatorId: ID) {
+    advancedTrainingProgressUpdate(simulatorId: $simulatorId) {
+      ...AdvancedTrainingProgressFragment
+    }
+  }
+  ${ADVANCED_TRAINING_PROGRESS_FRAGMENT}
+`;
+
+// --- Queries ---
+
+export const ADVANCED_TRAINING_PROGRESS_QUERY = gql`
+  query AdvancedTrainingProgress($clientId: ID, $simulatorId: ID) {
+    advancedTrainingProgress(clientId: $clientId, simulatorId: $simulatorId) {
+      ...AdvancedTrainingProgressFragment
+    }
+  }
+  ${ADVANCED_TRAINING_PROGRESS_FRAGMENT}
+`;

--- a/src/components/training/queries.ts
+++ b/src/components/training/queries.ts
@@ -33,6 +33,12 @@ export const STOP_ADVANCED_TRAINING = gql`
   }
 `;
 
+export const CLIENT_REQUEST_TRAINING_HELP = gql`
+  mutation ClientRequestTrainingHelp($clientId: ID!) {
+    clientRequestTrainingHelp(clientId: $clientId)
+  }
+`;
+
 export const ADVANCED_TRAINING_ACTION = gql`
   mutation ClientAdvancedTrainingAction(
     $clientId: ID!
@@ -75,7 +81,10 @@ export const FD_ADVANCE_CHAPTER = gql`
 
 export const FD_COMPLETE_SUBCHAPTER = gql`
   mutation FdCompleteTrainingSubChapter($clientId: ID!, $subChapterId: ID!) {
-    fdCompleteTrainingSubChapter(clientId: $clientId, subChapterId: $subChapterId)
+    fdCompleteTrainingSubChapter(
+      clientId: $clientId
+      subChapterId: $subChapterId
+    )
   }
 `;
 

--- a/src/components/training/queries.ts
+++ b/src/components/training/queries.ts
@@ -19,30 +19,6 @@ export const ADVANCED_TRAINING_PROGRESS_FRAGMENT = gql`
   }
 `;
 
-export const ADVANCED_TRAINING_CONFIG_FRAGMENT = gql`
-  fragment AdvancedTrainingConfigFragment on AdvancedTrainingConfig {
-    enabled
-    chapters {
-      id
-      name
-      cardComponent
-      mediaAsset
-      autoOpenMedia
-      autoAdvance
-      cardSwitchBehavior
-      subChapters {
-        id
-        name
-        requiredActions {
-          id
-          eventName
-          args
-        }
-      }
-    }
-  }
-`;
-
 // --- Mutations ---
 
 export const START_ADVANCED_TRAINING = gql`

--- a/src/components/training/trainingPrerequisites.ts
+++ b/src/components/training/trainingPrerequisites.ts
@@ -1,0 +1,9 @@
+/**
+ * Client-side mirror of server/classes/trainingPrerequisites.ts.
+ *
+ * Keep in sync with the server version. Used by the chapter list to show
+ * chapters as "not yet available" until their prerequisites have been observed.
+ */
+export const CARD_PREREQUISITES: Record<string, string[]> = {
+  // Add entries as needed for your mission systems.
+};

--- a/src/components/training/useAdvancedTraining.ts
+++ b/src/components/training/useAdvancedTraining.ts
@@ -1,0 +1,151 @@
+import {useEffect, useCallback, useRef} from "react";
+import {useMutation, useSubscription, useQuery} from "react-apollo";
+import {subscribe} from "helpers/pubsub";
+import {
+  ADVANCED_TRAINING_ACTION,
+  ADVANCED_TRAINING_PROGRESS_SUB,
+  ADVANCED_TRAINING_PROGRESS_QUERY,
+  START_ADVANCED_TRAINING,
+  STOP_ADVANCED_TRAINING,
+  SET_ACTIVE_CHAPTER,
+  TOGGLE_MEDIA_VIEWER,
+  TOGGLE_CHAPTER_LIST,
+} from "./queries";
+
+interface AdvancedTrainingConfig {
+  enabled: boolean;
+  chapters: any[];
+  loginChapter?: any;
+  completionChapter?: any;
+}
+
+interface UseAdvancedTrainingParams {
+  clientId: string;
+  simulatorId: string;
+  advancedTrainingConfig: AdvancedTrainingConfig | null;
+}
+
+export function useAdvancedTraining({
+  clientId,
+  simulatorId,
+  advancedTrainingConfig,
+}: UseAdvancedTrainingParams) {
+  const isActive = useRef(false);
+
+  // Mutations
+  const [recordActionMutation] = useMutation(ADVANCED_TRAINING_ACTION);
+  const [startTrainingMutation] = useMutation(START_ADVANCED_TRAINING);
+  const [stopTrainingMutation] = useMutation(STOP_ADVANCED_TRAINING);
+  const [setActiveChapterMutation] = useMutation(SET_ACTIVE_CHAPTER);
+  const [toggleMediaMutation] = useMutation(TOGGLE_MEDIA_VIEWER);
+  const [toggleChapterListMutation] = useMutation(TOGGLE_CHAPTER_LIST);
+
+  // Query for initial state
+  const {data: queryData} = useQuery(ADVANCED_TRAINING_PROGRESS_QUERY, {
+    variables: {clientId},
+    fetchPolicy: "network-only",
+  });
+
+  // Subscription for real-time updates
+  const {data: subData} = useSubscription(ADVANCED_TRAINING_PROGRESS_SUB, {
+    variables: {simulatorId},
+  });
+
+  // Find this client's progress
+  const progressList =
+    subData?.advancedTrainingProgressUpdate ||
+    queryData?.advancedTrainingProgress ||
+    [];
+  const progress = progressList.find((p: any) => p.clientId === clientId);
+
+  isActive.current = !!progress;
+
+  // Record an action (mutation or click) to the server
+  const recordAction = useCallback(
+    (eventName: string, args?: any) => {
+      if (!isActive.current) return;
+      recordActionMutation({
+        variables: {
+          clientId,
+          eventName,
+          args: args || null,
+        },
+      });
+    },
+    [clientId, recordActionMutation],
+  );
+
+  // Observe mutations from the Apollo client middleware pub/sub
+  useEffect(() => {
+    if (!progress || !advancedTrainingConfig?.enabled) return;
+
+    // Ignore training system mutations to prevent infinite loops:
+    // recordAction sends clientAdvancedTrainingAction, which would fire
+    // another mutation-event, triggering recordAction again.
+    const ignoredMutations = new Set([
+      "clockSync",
+      "clientAdvancedTrainingAction",
+      "clientStartAdvancedTraining",
+      "clientStopAdvancedTraining",
+      "advancedTrainingSetActiveChapter",
+      "advancedTrainingToggleMediaViewer",
+      "advancedTrainingToggleChapterList",
+      "fdCompleteTrainingSubChapter",
+      "fdResetTrainingProgress",
+      "clientSetTraining",
+      "clientSetCard",
+    ]);
+
+    const unsubscribe = subscribe(
+      "mutation-event",
+      ({event, args}: {event: string; args: any}) => {
+        if (ignoredMutations.has(event)) return;
+        recordAction(event, args);
+      },
+    );
+
+    return unsubscribe;
+  }, [progress, advancedTrainingConfig?.enabled, recordAction]);
+
+  // Actions
+  const startTraining = useCallback(() => {
+    startTrainingMutation({variables: {clientId}});
+  }, [clientId, startTrainingMutation]);
+
+  const stopTraining = useCallback(() => {
+    stopTrainingMutation({variables: {clientId}});
+  }, [clientId, stopTrainingMutation]);
+
+  const setActiveChapter = useCallback(
+    (chapterId: string) => {
+      setActiveChapterMutation({variables: {clientId, chapterId}});
+    },
+    [clientId, setActiveChapterMutation],
+  );
+
+  const toggleMediaViewer = useCallback(
+    (open: boolean) => {
+      toggleMediaMutation({variables: {clientId, open}});
+    },
+    [clientId, toggleMediaMutation],
+  );
+
+  const toggleChapterList = useCallback(
+    (open: boolean) => {
+      toggleChapterListMutation({variables: {clientId, open}});
+    },
+    [clientId, toggleChapterListMutation],
+  );
+
+  return {
+    progress,
+    config: advancedTrainingConfig,
+    isInAdvancedTraining: !!progress,
+    recordAction,
+    startTraining,
+    stopTraining,
+    setActiveChapter,
+    toggleMediaViewer,
+    toggleChapterList,
+  };
+}

--- a/src/components/training/useAdvancedTraining.ts
+++ b/src/components/training/useAdvancedTraining.ts
@@ -14,6 +14,8 @@ import {
 
 interface AdvancedTrainingConfig {
   enabled: boolean;
+  sequentialChapters?: boolean;
+  stripPosition?: string;
   chapters: any[];
   loginChapter?: any;
   completionChapter?: any;
@@ -51,14 +53,18 @@ export function useAdvancedTraining({
     variables: {simulatorId},
   });
 
-  // Find this client's progress
+  // Prefer subscription data only once it contains a non-empty list, so an
+  // early empty subscription event doesn't wipe valid initial query data.
   const progressList =
-    subData?.advancedTrainingProgressUpdate ||
-    queryData?.advancedTrainingProgress ||
+    (subData?.advancedTrainingProgressUpdate?.length
+      ? subData.advancedTrainingProgressUpdate
+      : null) ??
+    queryData?.advancedTrainingProgress ??
     [];
   const progress = progressList.find((p: any) => p.clientId === clientId);
+  const isInAdvancedTraining = !!progress;
 
-  isActive.current = !!progress;
+  isActive.current = isInAdvancedTraining;
 
   // Record an action (mutation or click) to the server
   const recordAction = useCallback(
@@ -77,7 +83,7 @@ export function useAdvancedTraining({
 
   // Observe mutations from the Apollo client middleware pub/sub
   useEffect(() => {
-    if (!progress || !advancedTrainingConfig?.enabled) return;
+    if (!isInAdvancedTraining || !advancedTrainingConfig?.enabled) return;
 
     // Ignore training system mutations to prevent infinite loops:
     // recordAction sends clientAdvancedTrainingAction, which would fire
@@ -105,7 +111,7 @@ export function useAdvancedTraining({
     );
 
     return unsubscribe;
-  }, [progress, advancedTrainingConfig?.enabled, recordAction]);
+  }, [isInAdvancedTraining, advancedTrainingConfig?.enabled, recordAction]);
 
   // Actions
   const startTraining = useCallback(() => {
@@ -140,7 +146,7 @@ export function useAdvancedTraining({
   return {
     progress,
     config: advancedTrainingConfig,
-    isInAdvancedTraining: !!progress,
+    isInAdvancedTraining,
     recordAction,
     startTraining,
     stopTraining,

--- a/src/components/training/useAdvancedTraining.ts
+++ b/src/components/training/useAdvancedTraining.ts
@@ -17,6 +17,7 @@ interface AdvancedTrainingConfig {
   sequentialChapters?: boolean;
   stripPosition?: string;
   chapters: any[];
+  inFlightChapters?: any[];
   loginChapter?: any;
   completionChapter?: any;
 }
@@ -69,7 +70,9 @@ export function useAdvancedTraining({
   // Record an action (mutation or click) to the server
   const recordAction = useCallback(
     (eventName: string, args?: any) => {
-      if (!isActive.current) return;
+      if (!isActive.current) {
+        return;
+      }
       recordActionMutation({
         variables: {
           clientId,
@@ -83,7 +86,9 @@ export function useAdvancedTraining({
 
   // Observe mutations from the Apollo client middleware pub/sub
   useEffect(() => {
-    if (!isInAdvancedTraining || !advancedTrainingConfig?.enabled) return;
+    if (!isInAdvancedTraining || !advancedTrainingConfig?.enabled) {
+      return;
+    }
 
     // Ignore training system mutations to prevent infinite loops:
     // recordAction sends clientAdvancedTrainingAction, which would fire
@@ -93,6 +98,7 @@ export function useAdvancedTraining({
       "clientAdvancedTrainingAction",
       "clientStartAdvancedTraining",
       "clientStopAdvancedTraining",
+      "clientRequestTrainingHelp",
       "advancedTrainingSetActiveChapter",
       "advancedTrainingToggleMediaViewer",
       "advancedTrainingToggleChapterList",
@@ -105,7 +111,9 @@ export function useAdvancedTraining({
     const unsubscribe = subscribe(
       "mutation-event",
       ({event, args}: {event: string; args: any}) => {
-        if (ignoredMutations.has(event)) return;
+        if (ignoredMutations.has(event)) {
+          return;
+        }
         recordAction(event, args);
       },
     );

--- a/src/components/views/AdvancedTraining/core.scss
+++ b/src/components/views/AdvancedTraining/core.scss
@@ -1,0 +1,153 @@
+.advanced-training-core {
+  height: 100%;
+  overflow-y: auto;
+  padding: 4px;
+  font-size: 12px;
+
+  .no-clients-msg {
+    color: #78909c;
+    text-align: center;
+    padding: 12px;
+  }
+
+  .client-block {
+    background: rgba(0, 0, 0, 0.3);
+    border: 1px solid rgba(0, 188, 212, 0.2);
+    border-radius: 4px;
+    padding: 6px;
+    margin-bottom: 6px;
+  }
+
+  .client-header-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 3px;
+  }
+
+  .client-name {
+    font-weight: 600;
+    color: #e0f7fa;
+    flex: 1;
+  }
+
+  .client-station-name {
+    color: #546e7a;
+    font-size: 11px;
+  }
+
+  .active-info {
+    font-size: 11px;
+    color: #b0bec5;
+    margin-bottom: 4px;
+    padding: 2px 4px;
+    background: rgba(0, 188, 212, 0.08);
+    border-left: 2px solid #00bcd4;
+    border-radius: 2px;
+
+    strong {
+      color: #e0f7fa;
+    }
+
+    .card-label {
+      color: #546e7a;
+      margin-left: 6px;
+    }
+  }
+
+  .chapters-compact {
+    margin-bottom: 4px;
+  }
+
+  .ch-row {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.03);
+    flex-wrap: wrap;
+
+    &.active .ch-name {
+      color: #00bcd4;
+      font-weight: 600;
+    }
+
+    &.completed .ch-name {
+      color: #4caf50;
+    }
+
+    &.completed .ch-idx {
+      color: #4caf50;
+    }
+  }
+
+  .ch-idx {
+    color: #546e7a;
+    min-width: 14px;
+    font-size: 11px;
+  }
+
+  .ch-name {
+    flex: 1;
+    color: #b0bec5;
+  }
+
+  .ch-prog {
+    font-size: 10px;
+    color: #546e7a;
+  }
+
+  .ch-btn {
+    font-size: 10px;
+    padding: 0 6px;
+    line-height: 1.4;
+  }
+
+  .sc-row {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 1px 0 1px 20px;
+    font-size: 11px;
+
+    &.done .sc-name {
+      color: #546e7a;
+      text-decoration: line-through;
+    }
+
+    &.done .sc-check {
+      color: #4caf50;
+    }
+  }
+
+  .sc-check {
+    color: #546e7a;
+    font-size: 9px;
+    min-width: 12px;
+  }
+
+  .sc-name {
+    flex: 1;
+    color: #b0bec5;
+  }
+
+  .sc-btn {
+    font-size: 9px;
+    padding: 0 4px;
+    line-height: 1.3;
+  }
+
+  .actions-row {
+    display: flex;
+    gap: 4px;
+    margin-top: 4px;
+    padding-top: 4px;
+    border-top: 1px solid rgba(255, 255, 255, 0.05);
+
+    .btn {
+      font-size: 10px;
+      padding: 1px 6px;
+    }
+  }
+}

--- a/src/components/views/AdvancedTraining/core.tsx
+++ b/src/components/views/AdvancedTraining/core.tsx
@@ -1,0 +1,276 @@
+import React from "react";
+import {Button, Badge, Progress} from "helpers/reactstrap";
+import {useMutation, useSubscription, useQuery} from "react-apollo";
+import gql from "graphql-tag.macro";
+import {
+  ADVANCED_TRAINING_PROGRESS_SUB,
+  FD_ADVANCE_CHAPTER,
+  FD_COMPLETE_SUBCHAPTER,
+  FD_RESET_PROGRESS,
+} from "components/training/queries";
+import {getCardLabel} from "components/training/actionRegistry";
+import "./core.scss";
+
+const CLIENTS_FOR_SIM_QUERY = gql`
+  query AdvancedTrainingCoreClients($simulatorId: ID!) {
+    clients(simulatorId: $simulatorId) {
+      id
+      label
+      connected
+      station {
+        name
+      }
+    }
+  }
+`;
+
+const CLIENTS_SUB = gql`
+  subscription AdvancedTrainingCoreClientsSub($simulatorId: ID!) {
+    clientChanged(simulatorId: $simulatorId) {
+      id
+      label
+      connected
+      station {
+        name
+      }
+    }
+  }
+`;
+
+const SIM_STATIONS_QUERY = gql`
+  query AdvancedTrainingCoreStations($simulatorId: ID!) {
+    simulators(id: $simulatorId) {
+      id
+      stationSets {
+        id
+        stations {
+          name
+          advancedTraining {
+            enabled
+            chapters {
+              id
+              name
+              cardComponent
+              subChapters {
+                id
+                name
+                requiredActions {
+                  id
+                  eventName
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+interface AdvancedTrainingCoreProps {
+  simulator: {id: string};
+}
+
+const AdvancedTrainingCore: React.FC<AdvancedTrainingCoreProps> = ({
+  simulator,
+}) => {
+  const {data: clientsData} = useQuery(CLIENTS_FOR_SIM_QUERY, {
+    variables: {simulatorId: simulator.id},
+  });
+  useSubscription(CLIENTS_SUB, {
+    variables: {simulatorId: simulator.id},
+  });
+
+  const {data: simData} = useQuery(SIM_STATIONS_QUERY, {
+    variables: {simulatorId: simulator.id},
+  });
+
+  const {data: progressData} = useSubscription(ADVANCED_TRAINING_PROGRESS_SUB, {
+    variables: {simulatorId: simulator.id},
+  });
+
+  const [advanceChapter] = useMutation(FD_ADVANCE_CHAPTER);
+  const [completeSubChapter] = useMutation(FD_COMPLETE_SUBCHAPTER);
+  const [resetProgress] = useMutation(FD_RESET_PROGRESS);
+
+  const progressList =
+    progressData?.advancedTrainingProgressUpdate || [];
+  const clients = clientsData?.clients || [];
+  const sim = simData?.simulators?.[0];
+
+  const getStationConfig = (stationName: string) => {
+    if (!sim) return null;
+    for (const ss of sim.stationSets || []) {
+      const station = ss.stations?.find((s: any) => s.name === stationName);
+      if (station?.advancedTraining?.enabled) {
+        return station.advancedTraining;
+      }
+    }
+    return null;
+  };
+
+  const trainingClients = clients.filter((client: any) => {
+    if (!client.connected || !client.station) return false;
+    return progressList.some((p: any) => p.clientId === client.id);
+  });
+
+  if (trainingClients.length === 0) {
+    return (
+      <div className="advanced-training-core">
+        <p className="no-clients-msg">No crew in advanced training.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="advanced-training-core">
+      {trainingClients.map((client: any) => {
+        const progress = progressList.find(
+          (p: any) => p.clientId === client.id,
+        );
+        const stationName =
+          client.station?.name || client.station || "";
+        const config = getStationConfig(stationName);
+        if (!progress || !config) return null;
+
+        const chapters = config.chapters || [];
+        const activeChapter = chapters.find(
+          (c: any) => c.id === progress.activeChapterId,
+        );
+
+        const totalSub = chapters.reduce(
+          (sum: number, ch: any) => sum + (ch.subChapters?.length || 0),
+          0,
+        );
+        const completedSub =
+          progress.completedSubChapterIds?.length || 0;
+        const pct = totalSub > 0 ? Math.round((completedSub / totalSub) * 100) : 0;
+
+        return (
+          <div key={client.id} className="client-block">
+            <div className="client-header-row">
+              <span className="client-name">
+                {client.label || client.id}
+              </span>
+              <span className="client-station-name">{stationName}</span>
+              <Badge color={pct === 100 ? "success" : "info"} pill>
+                {pct}%
+              </Badge>
+            </div>
+
+            <Progress
+              value={pct}
+              color={pct === 100 ? "success" : "info"}
+              style={{height: "4px", marginBottom: "4px"}}
+            />
+
+            {activeChapter && (
+              <div className="active-info">
+                Active: <strong>{activeChapter.name}</strong>
+                <span className="card-label">
+                  {getCardLabel(activeChapter.cardComponent)}
+                </span>
+              </div>
+            )}
+
+            <div className="chapters-compact">
+              {chapters.map((ch: any, idx: number) => {
+                const isCompleted =
+                  progress.completedChapterIds?.includes(ch.id);
+                const isActive = progress.activeChapterId === ch.id;
+                const chSubCount = ch.subChapters?.length || 0;
+                const chCompleted =
+                  ch.subChapters?.filter((sc: any) =>
+                    progress.completedSubChapterIds?.includes(sc.id),
+                  ).length || 0;
+
+                return (
+                  <div
+                    key={ch.id}
+                    className={`ch-row ${isActive ? "active" : ""} ${
+                      isCompleted ? "completed" : ""
+                    }`}
+                  >
+                    <span className="ch-idx">{idx + 1}</span>
+                    <span className="ch-name">{ch.name}</span>
+                    <span className="ch-prog">
+                      {chCompleted}/{chSubCount}
+                    </span>
+                    {!isActive && !isCompleted && (
+                      <Button
+                        size="sm"
+                        color="info"
+                        outline
+                        className="ch-btn"
+                        onClick={() =>
+                          advanceChapter({
+                            variables: {
+                              clientId: client.id,
+                              chapterId: ch.id,
+                            },
+                          })
+                        }
+                      >
+                        Go
+                      </Button>
+                    )}
+
+                    {isActive &&
+                      ch.subChapters?.map((sc: any) => {
+                        const scDone =
+                          progress.completedSubChapterIds?.includes(sc.id);
+                        return (
+                          <div
+                            key={sc.id}
+                            className={`sc-row ${scDone ? "done" : ""}`}
+                          >
+                            <span className="sc-check">
+                              {scDone ? "\u2713" : "\u25CB"}
+                            </span>
+                            <span className="sc-name">{sc.name}</span>
+                            {!scDone && (
+                              <Button
+                                size="sm"
+                                color="success"
+                                outline
+                                className="sc-btn"
+                                onClick={() =>
+                                  completeSubChapter({
+                                    variables: {
+                                      clientId: client.id,
+                                      subChapterId: sc.id,
+                                    },
+                                  })
+                                }
+                              >
+                                Done
+                              </Button>
+                            )}
+                          </div>
+                        );
+                      })}
+                  </div>
+                );
+              })}
+            </div>
+
+            <div className="actions-row">
+              <Button
+                size="sm"
+                color="warning"
+                outline
+                onClick={() =>
+                  resetProgress({variables: {clientId: client.id}})
+                }
+              >
+                Reset
+              </Button>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default AdvancedTrainingCore;

--- a/src/components/views/AdvancedTraining/core.tsx
+++ b/src/components/views/AdvancedTraining/core.tsx
@@ -93,13 +93,14 @@ const AdvancedTrainingCore: React.FC<AdvancedTrainingCoreProps> = ({
   const [completeSubChapter] = useMutation(FD_COMPLETE_SUBCHAPTER);
   const [resetProgress] = useMutation(FD_RESET_PROGRESS);
 
-  const progressList =
-    progressData?.advancedTrainingProgressUpdate || [];
+  const progressList = progressData?.advancedTrainingProgressUpdate || [];
   const clients = clientsData?.clients || [];
   const sim = simData?.simulators?.[0];
 
   const getStationConfig = (stationName: string) => {
-    if (!sim) return null;
+    if (!sim) {
+      return null;
+    }
     for (const ss of sim.stationSets || []) {
       const station = ss.stations?.find((s: any) => s.name === stationName);
       if (station?.advancedTraining?.enabled) {
@@ -110,7 +111,9 @@ const AdvancedTrainingCore: React.FC<AdvancedTrainingCoreProps> = ({
   };
 
   const trainingClients = clients.filter((client: any) => {
-    if (!client.connected || !client.station) return false;
+    if (!client.connected || !client.station) {
+      return false;
+    }
     return progressList.some((p: any) => p.clientId === client.id);
   });
 
@@ -128,10 +131,11 @@ const AdvancedTrainingCore: React.FC<AdvancedTrainingCoreProps> = ({
         const progress = progressList.find(
           (p: any) => p.clientId === client.id,
         );
-        const stationName =
-          client.station?.name || client.station || "";
+        const stationName = client.station?.name || client.station || "";
         const config = getStationConfig(stationName);
-        if (!progress || !config) return null;
+        if (!progress || !config) {
+          return null;
+        }
 
         const chapters = config.chapters || [];
         const activeChapter = chapters.find(
@@ -142,16 +146,14 @@ const AdvancedTrainingCore: React.FC<AdvancedTrainingCoreProps> = ({
           (sum: number, ch: any) => sum + (ch.subChapters?.length || 0),
           0,
         );
-        const completedSub =
-          progress.completedSubChapterIds?.length || 0;
-        const pct = totalSub > 0 ? Math.round((completedSub / totalSub) * 100) : 0;
+        const completedSub = progress.completedSubChapterIds?.length || 0;
+        const pct =
+          totalSub > 0 ? Math.round((completedSub / totalSub) * 100) : 0;
 
         return (
           <div key={client.id} className="client-block">
             <div className="client-header-row">
-              <span className="client-name">
-                {client.label || client.id}
-              </span>
+              <span className="client-name">{client.label || client.id}</span>
               <span className="client-station-name">{stationName}</span>
               <Badge color={pct === 100 ? "success" : "info"} pill>
                 {pct}%
@@ -175,8 +177,9 @@ const AdvancedTrainingCore: React.FC<AdvancedTrainingCoreProps> = ({
 
             <div className="chapters-compact">
               {chapters.map((ch: any, idx: number) => {
-                const isCompleted =
-                  progress.completedChapterIds?.includes(ch.id);
+                const isCompleted = progress.completedChapterIds?.includes(
+                  ch.id,
+                );
                 const isActive = progress.activeChapterId === ch.id;
                 const chSubCount = ch.subChapters?.length || 0;
                 const chCompleted =

--- a/src/components/views/index.ts
+++ b/src/components/views/index.ts
@@ -230,6 +230,7 @@ const HullPlatingCore = React.lazy(() => import("./HullPlating/core"));
 const EdVenturesAppCore = React.lazy(() => import("./EdVenturesApp/core"));
 const AdvancedNavigationCore = React.lazy(() => import("./AdvancedNavAndAstrometrics/CoreAdvancedNavigation"));
 const AstrometricsCore = React.lazy(() => import("./AdvancedNavAndAstrometrics/CoreAstrometrics"));
+const AdvancedTrainingCore = React.lazy(() => import("./AdvancedTraining/core"));
 // Widgets
 const ComposerWidget = React.lazy(() => import("./LongRangeComm/Composer"));
 const CalculatorWidget = React.lazy(() => import("./Widgets/calculator"));
@@ -543,7 +544,8 @@ export const Cores = {
   HullPlatingCore,
   EdVenturesAppCore,
   AdvancedNavigationCore,
-  AstrometricsCore
+  AstrometricsCore,
+  AdvancedTrainingCore
 };
 
 export default Views;

--- a/src/containers/FlightDirector/AdvancedTrainingDashboard/AdvancedTrainingDashboard.scss
+++ b/src/containers/FlightDirector/AdvancedTrainingDashboard/AdvancedTrainingDashboard.scss
@@ -1,0 +1,181 @@
+.advanced-training-dashboard {
+  padding: 20px;
+
+  .dashboard-title {
+    color: #00bcd4;
+    font-weight: 600;
+    margin-bottom: 20px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+  }
+
+  .no-clients {
+    text-align: center;
+    padding: 40px 20px;
+    color: #b0bec5;
+  }
+
+  .client-training-card {
+    background: rgba(0, 0, 0, 0.3);
+    border: 1px solid rgba(0, 188, 212, 0.2);
+  }
+
+  .client-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background: rgba(0, 188, 212, 0.08);
+    border-bottom: 1px solid rgba(0, 188, 212, 0.2);
+  }
+
+  .client-info {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .client-label {
+    font-weight: 600;
+    color: #e0f7fa;
+  }
+
+  .client-station {
+    font-size: 12px;
+    color: #78909c;
+  }
+
+  .client-body {
+    padding: 12px;
+  }
+
+  .progress-section {
+    margin-bottom: 12px;
+  }
+
+  .progress-label {
+    color: #78909c;
+    display: block;
+    margin-bottom: 4px;
+  }
+
+  .section-label {
+    color: #546e7a;
+    text-transform: uppercase;
+    font-size: 10px;
+    letter-spacing: 0.5px;
+  }
+
+  .active-chapter {
+    margin-bottom: 12px;
+    padding: 8px;
+    background: rgba(0, 188, 212, 0.08);
+    border-radius: 4px;
+    border-left: 3px solid #00bcd4;
+
+    .chapter-name {
+      font-weight: 600;
+      color: #e0f7fa;
+    }
+
+    .chapter-card {
+      font-size: 12px;
+      color: #78909c;
+    }
+  }
+
+  .chapter-list {
+    margin-bottom: 12px;
+  }
+
+  .chapter-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 4px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+    flex-wrap: wrap;
+
+    &.active {
+      background: rgba(0, 188, 212, 0.05);
+
+      .chapter-name-text {
+        color: #00bcd4;
+        font-weight: 600;
+      }
+    }
+
+    &.completed {
+      .chapter-name-text {
+        color: #4caf50;
+      }
+
+      .chapter-index {
+        color: #4caf50;
+      }
+    }
+  }
+
+  .chapter-index {
+    color: #546e7a;
+    font-size: 12px;
+    min-width: 18px;
+  }
+
+  .chapter-name-text {
+    flex: 1;
+    font-size: 13px;
+    color: #b0bec5;
+  }
+
+  .chapter-progress-text {
+    font-size: 11px;
+    color: #546e7a;
+  }
+
+  .chapter-action-btn {
+    font-size: 11px;
+    padding: 1px 8px;
+  }
+
+  .sub-chapter-row {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 3px 4px 3px 26px;
+    font-size: 12px;
+
+    &.completed {
+      .sub-name {
+        color: #78909c;
+        text-decoration: line-through;
+      }
+      .sub-check {
+        color: #4caf50;
+      }
+    }
+  }
+
+  .sub-check {
+    color: #546e7a;
+    font-size: 10px;
+    min-width: 14px;
+  }
+
+  .sub-name {
+    flex: 1;
+    color: #b0bec5;
+  }
+
+  .sub-action-btn {
+    font-size: 10px;
+    padding: 0px 6px;
+  }
+
+  .intervention-actions {
+    display: flex;
+    gap: 8px;
+    margin-top: 8px;
+    padding-top: 8px;
+    border-top: 1px solid rgba(255, 255, 255, 0.05);
+  }
+}

--- a/src/containers/FlightDirector/AdvancedTrainingDashboard/index.tsx
+++ b/src/containers/FlightDirector/AdvancedTrainingDashboard/index.tsx
@@ -87,28 +87,26 @@ const AdvancedTrainingDashboard: React.FC = () => {
   const [completeSubChapter] = useMutation(FD_COMPLETE_SUBCHAPTER);
   const [resetProgress] = useMutation(FD_RESET_PROGRESS);
 
-  const progressList =
-    progressData?.advancedTrainingProgressUpdate || [];
+  const progressList = progressData?.advancedTrainingProgressUpdate || [];
 
   const clients = clientsData?.clients || [];
 
   // Find clients that have advanced training configured
   const trainingClients = clients.filter((client: any) => {
-    if (!client.connected || !client.station || !client.simulatorId)
+    if (!client.connected || !client.station || !client.simulatorId) {
       return false;
-    const progress = progressList.find(
-      (p: any) => p.clientId === client.id,
-    );
+    }
+    const progress = progressList.find((p: any) => p.clientId === client.id);
     return !!progress;
   });
 
   const getClientConfig = (client: any) => {
     const sim = client.simulator;
-    if (!sim) return null;
+    if (!sim) {
+      return null;
+    }
     for (const ss of sim.stationSets || []) {
-      const station = ss.stations?.find(
-        (s: any) => s.name === client.station,
-      );
+      const station = ss.stations?.find((s: any) => s.name === client.station);
       if (station?.advancedTraining?.enabled) {
         return station.advancedTraining;
       }
@@ -136,7 +134,9 @@ const AdvancedTrainingDashboard: React.FC = () => {
             (p: any) => p.clientId === client.id,
           );
           const config = getClientConfig(client);
-          if (!progress || !config) return null;
+          if (!progress || !config) {
+            return null;
+          }
 
           const chapters = config.chapters || [];
           const activeChapter = chapters.find(
@@ -149,9 +149,10 @@ const AdvancedTrainingDashboard: React.FC = () => {
           );
           const completedSubChapters =
             progress.completedSubChapterIds?.length || 0;
-          const overallPercent = totalSubChapters > 0
-            ? Math.round((completedSubChapters / totalSubChapters) * 100)
-            : 0;
+          const overallPercent =
+            totalSubChapters > 0
+              ? Math.round((completedSubChapters / totalSubChapters) * 100)
+              : 0;
 
           return (
             <Col key={client.id} lg={6} xl={4} style={{marginBottom: "16px"}}>
@@ -200,8 +201,7 @@ const AdvancedTrainingDashboard: React.FC = () => {
                     {chapters.map((ch: any, idx: number) => {
                       const isCompleted =
                         progress.completedChapterIds?.includes(ch.id);
-                      const isActive =
-                        progress.activeChapterId === ch.id;
+                      const isActive = progress.activeChapterId === ch.id;
                       const chSubCount = ch.subChapters?.length || 0;
                       const chCompleted =
                         ch.subChapters?.filter((sc: any) =>
@@ -211,9 +211,9 @@ const AdvancedTrainingDashboard: React.FC = () => {
                       return (
                         <div
                           key={ch.id}
-                          className={`chapter-row ${
-                            isActive ? "active" : ""
-                          } ${isCompleted ? "completed" : ""}`}
+                          className={`chapter-row ${isActive ? "active" : ""} ${
+                            isCompleted ? "completed" : ""
+                          }`}
                         >
                           <span className="chapter-index">{idx + 1}</span>
                           <span className="chapter-name-text">{ch.name}</span>

--- a/src/containers/FlightDirector/AdvancedTrainingDashboard/index.tsx
+++ b/src/containers/FlightDirector/AdvancedTrainingDashboard/index.tsx
@@ -1,0 +1,311 @@
+import React from "react";
+import {
+  Container,
+  Row,
+  Col,
+  Card,
+  CardBody,
+  CardHeader,
+  Button,
+  Progress,
+  Badge,
+} from "helpers/reactstrap";
+import {useQuery, useMutation, useSubscription} from "react-apollo";
+import gql from "graphql-tag.macro";
+import {
+  ADVANCED_TRAINING_PROGRESS_SUB,
+  FD_ADVANCE_CHAPTER,
+  FD_COMPLETE_SUBCHAPTER,
+  FD_RESET_PROGRESS,
+} from "components/training/queries";
+import {getActionLabel, getCardLabel} from "components/training/actionRegistry";
+import "./AdvancedTrainingDashboard.scss";
+
+const CLIENTS_QUERY = gql`
+  query AdvancedTrainingClients {
+    clients(all: true) {
+      id
+      label
+      connected
+      simulatorId
+      station
+      training
+      simulator {
+        id
+        name
+        stationSets {
+          id
+          stations {
+            name
+            advancedTraining {
+              enabled
+              chapters {
+                id
+                name
+                cardComponent
+                subChapters {
+                  id
+                  name
+                  requiredActions {
+                    id
+                    eventName
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const CLIENTS_SUB = gql`
+  subscription AdvancedTrainingClientsSub {
+    clientChanged {
+      id
+      label
+      connected
+      simulatorId
+      station
+      training
+    }
+  }
+`;
+
+const AdvancedTrainingDashboard: React.FC = () => {
+  const {data: clientsData} = useQuery(CLIENTS_QUERY, {
+    fetchPolicy: "network-only",
+  });
+  useSubscription(CLIENTS_SUB);
+
+  const {data: progressData} = useSubscription(ADVANCED_TRAINING_PROGRESS_SUB, {
+    variables: {},
+  });
+
+  const [advanceChapter] = useMutation(FD_ADVANCE_CHAPTER);
+  const [completeSubChapter] = useMutation(FD_COMPLETE_SUBCHAPTER);
+  const [resetProgress] = useMutation(FD_RESET_PROGRESS);
+
+  const progressList =
+    progressData?.advancedTrainingProgressUpdate || [];
+
+  const clients = clientsData?.clients || [];
+
+  // Find clients that have advanced training configured
+  const trainingClients = clients.filter((client: any) => {
+    if (!client.connected || !client.station || !client.simulatorId)
+      return false;
+    const progress = progressList.find(
+      (p: any) => p.clientId === client.id,
+    );
+    return !!progress;
+  });
+
+  const getClientConfig = (client: any) => {
+    const sim = client.simulator;
+    if (!sim) return null;
+    for (const ss of sim.stationSets || []) {
+      const station = ss.stations?.find(
+        (s: any) => s.name === client.station,
+      );
+      if (station?.advancedTraining?.enabled) {
+        return station.advancedTraining;
+      }
+    }
+    return null;
+  };
+
+  return (
+    <Container className="advanced-training-dashboard" fluid>
+      <h4 className="dashboard-title">Advanced Training Dashboard</h4>
+
+      {trainingClients.length === 0 && (
+        <div className="no-clients">
+          <p>No crew members are currently in advanced training.</p>
+          <small style={{color: "#78909c"}}>
+            Crew members can start advanced training from their login screen
+            when it is configured for their station.
+          </small>
+        </div>
+      )}
+
+      <Row>
+        {trainingClients.map((client: any) => {
+          const progress = progressList.find(
+            (p: any) => p.clientId === client.id,
+          );
+          const config = getClientConfig(client);
+          if (!progress || !config) return null;
+
+          const chapters = config.chapters || [];
+          const activeChapter = chapters.find(
+            (c: any) => c.id === progress.activeChapterId,
+          );
+
+          const totalSubChapters = chapters.reduce(
+            (sum: number, ch: any) => sum + (ch.subChapters?.length || 0),
+            0,
+          );
+          const completedSubChapters =
+            progress.completedSubChapterIds?.length || 0;
+          const overallPercent = totalSubChapters > 0
+            ? Math.round((completedSubChapters / totalSubChapters) * 100)
+            : 0;
+
+          return (
+            <Col key={client.id} lg={6} xl={4} style={{marginBottom: "16px"}}>
+              <Card className="client-training-card">
+                <CardHeader className="client-header">
+                  <div className="client-info">
+                    <span className="client-label">
+                      {client.label || client.id}
+                    </span>
+                    <span className="client-station">{client.station}</span>
+                  </div>
+                  <Badge
+                    color={overallPercent === 100 ? "success" : "info"}
+                    pill
+                  >
+                    {overallPercent}%
+                  </Badge>
+                </CardHeader>
+                <CardBody className="client-body">
+                  {/* Overall progress */}
+                  <div className="progress-section">
+                    <small className="progress-label">
+                      Overall: {completedSubChapters}/{totalSubChapters}{" "}
+                      sub-tasks
+                    </small>
+                    <Progress
+                      value={overallPercent}
+                      color={overallPercent === 100 ? "success" : "info"}
+                      style={{height: "6px"}}
+                    />
+                  </div>
+
+                  {/* Active chapter */}
+                  {activeChapter && (
+                    <div className="active-chapter">
+                      <small className="section-label">Active Chapter:</small>
+                      <div className="chapter-name">{activeChapter.name}</div>
+                      <div className="chapter-card">
+                        {getCardLabel(activeChapter.cardComponent)}
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Chapter list */}
+                  <div className="chapter-list">
+                    {chapters.map((ch: any, idx: number) => {
+                      const isCompleted =
+                        progress.completedChapterIds?.includes(ch.id);
+                      const isActive =
+                        progress.activeChapterId === ch.id;
+                      const chSubCount = ch.subChapters?.length || 0;
+                      const chCompleted =
+                        ch.subChapters?.filter((sc: any) =>
+                          progress.completedSubChapterIds?.includes(sc.id),
+                        ).length || 0;
+
+                      return (
+                        <div
+                          key={ch.id}
+                          className={`chapter-row ${
+                            isActive ? "active" : ""
+                          } ${isCompleted ? "completed" : ""}`}
+                        >
+                          <span className="chapter-index">{idx + 1}</span>
+                          <span className="chapter-name-text">{ch.name}</span>
+                          <span className="chapter-progress-text">
+                            {chCompleted}/{chSubCount}
+                          </span>
+                          {!isActive && !isCompleted && (
+                            <Button
+                              size="sm"
+                              color="info"
+                              outline
+                              className="chapter-action-btn"
+                              onClick={() =>
+                                advanceChapter({
+                                  variables: {
+                                    clientId: client.id,
+                                    chapterId: ch.id,
+                                  },
+                                })
+                              }
+                            >
+                              Go
+                            </Button>
+                          )}
+
+                          {/* Sub-chapters for active chapter */}
+                          {isActive &&
+                            ch.subChapters?.map((sc: any) => {
+                              const scCompleted =
+                                progress.completedSubChapterIds?.includes(
+                                  sc.id,
+                                );
+                              return (
+                                <div
+                                  key={sc.id}
+                                  className={`sub-chapter-row ${
+                                    scCompleted ? "completed" : ""
+                                  }`}
+                                >
+                                  <span className="sub-check">
+                                    {scCompleted ? "\u2713" : "\u25CB"}
+                                  </span>
+                                  <span className="sub-name">{sc.name}</span>
+                                  {!scCompleted && (
+                                    <Button
+                                      size="sm"
+                                      color="success"
+                                      outline
+                                      className="sub-action-btn"
+                                      onClick={() =>
+                                        completeSubChapter({
+                                          variables: {
+                                            clientId: client.id,
+                                            subChapterId: sc.id,
+                                          },
+                                        })
+                                      }
+                                    >
+                                      Complete
+                                    </Button>
+                                  )}
+                                </div>
+                              );
+                            })}
+                        </div>
+                      );
+                    })}
+                  </div>
+
+                  {/* Actions */}
+                  <div className="intervention-actions">
+                    <Button
+                      size="sm"
+                      color="warning"
+                      outline
+                      onClick={() =>
+                        resetProgress({
+                          variables: {clientId: client.id},
+                        })
+                      }
+                    >
+                      Reset Progress
+                    </Button>
+                  </div>
+                </CardBody>
+              </Card>
+            </Col>
+          );
+        })}
+      </Row>
+    </Container>
+  );
+};
+
+export default AdvancedTrainingDashboard;

--- a/src/containers/FlightDirector/SimulatorConfig/config/Stations/AdvancedTrainingConfig.tsx
+++ b/src/containers/FlightDirector/SimulatorConfig/config/Stations/AdvancedTrainingConfig.tsx
@@ -1,0 +1,889 @@
+import React, {useState, useCallback} from "react";
+import {
+  Button,
+  Input,
+  Label,
+  FormGroup,
+  CustomInput,
+  Card,
+  CardBody,
+  CardHeader,
+  Collapse,
+  Modal,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  Container,
+} from "helpers/reactstrap";
+import {useMutation} from "react-apollo";
+import {useParams, useNavigate} from "react-router-dom";
+import {useStationSetConfigSubscription} from "generated/graphql";
+import FileExplorer from "components/views/TacticalMap/fileExplorer";
+import {
+  SET_STATION_ADVANCED_TRAINING,
+  TOGGLE_ADVANCED_TRAINING_MODE,
+} from "components/training/queries";
+import {getActionLabel} from "components/training/actionRegistry";
+import RecordActionsModal from "./RecordActionsModal";
+
+const MEDIA_POSITIONS = [
+  "top-left",
+  "top-center",
+  "top-right",
+  "middle-left",
+  "middle-center",
+  "middle-right",
+  "bottom-left",
+  "bottom-center",
+  "bottom-right",
+];
+
+function emptyChapter(id: string, name: string) {
+  return {
+    id,
+    name,
+    cardComponent: "",
+    mediaAsset: null,
+    autoOpenMedia: false,
+    autoAdvance: false,
+    cardSwitchBehavior: "manual",
+    mediaSize: "small",
+    mediaPosition: "bottom-right",
+    subChapters: [],
+  };
+}
+
+function serializeChapter(ch: any) {
+  return {
+    id: ch.id,
+    name: ch.name,
+    cardComponent: ch.cardComponent || "",
+    mediaAsset: ch.mediaAsset || null,
+    autoOpenMedia: ch.autoOpenMedia ?? false,
+    autoAdvance: ch.autoAdvance ?? false,
+    cardSwitchBehavior: ch.cardSwitchBehavior || "manual",
+    mediaSize: ch.mediaSize || "small",
+    mediaPosition: ch.mediaPosition || "bottom-right",
+    subChapters: (ch.subChapters || []).map((sc: any) => ({
+      id: sc.id,
+      name: sc.name,
+      requiredActions: (sc.requiredActions || []).map((ra: any) => ({
+        id: ra.id,
+        eventName: ra.eventName,
+        args: ra.args || null,
+      })),
+    })),
+  };
+}
+
+interface ChapterEditorProps {
+  chapter: any;
+  index: number;
+  label?: string;
+  stationCards: any[];
+  isExpanded: boolean;
+  onToggleExpand: () => void;
+  onUpdate: (updates: any) => void;
+  onRemove?: () => void;
+  onAddSubChapter: () => void;
+  onRemoveSubChapter: (subId: string) => void;
+  onUpdateSubChapter: (subId: string, updates: any) => void;
+  onStartRecording: (subId: string) => void;
+  onSetMediaPicker: () => void;
+  showCardSelector?: boolean;
+}
+
+const ChapterEditor: React.FC<ChapterEditorProps> = ({
+  chapter,
+  index,
+  label,
+  stationCards,
+  isExpanded,
+  onToggleExpand,
+  onUpdate,
+  onRemove,
+  onAddSubChapter,
+  onRemoveSubChapter,
+  onUpdateSubChapter,
+  onStartRecording,
+  onSetMediaPicker,
+  showCardSelector = true,
+}) => {
+  return (
+    <Card style={{marginBottom: "8px", background: "rgba(0,0,0,0.2)"}}>
+      <CardHeader
+        onClick={onToggleExpand}
+        style={{
+          cursor: "pointer",
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          padding: "8px 12px",
+        }}
+      >
+        <span>
+          <strong>
+            {label || `${index + 1}. ${chapter.name}`}
+          </strong>
+          {showCardSelector && (
+            <small style={{marginLeft: "8px", color: "#888"}}>
+              {chapter.cardComponent}
+            </small>
+          )}
+        </span>
+        {onRemove && (
+          <Button
+            size="sm"
+            color="danger"
+            outline
+            onClick={(e: React.MouseEvent) => {
+              e.stopPropagation();
+              onRemove();
+            }}
+          >
+            Remove
+          </Button>
+        )}
+      </CardHeader>
+      <Collapse isOpen={isExpanded}>
+        <CardBody style={{padding: "12px"}}>
+          <FormGroup>
+            <Label>Chapter Name</Label>
+            <Input
+              value={chapter.name}
+              onChange={e => onUpdate({name: e.target.value})}
+            />
+          </FormGroup>
+          {showCardSelector && (
+            <FormGroup>
+              <Label>Card</Label>
+              <Input
+                type="select"
+                value={chapter.cardComponent}
+                onChange={e => onUpdate({cardComponent: e.target.value})}
+              >
+                <option value="">-- Select Card --</option>
+                {stationCards.map((c: any) => (
+                  <option key={c.component} value={c.component}>
+                    {c.name} ({c.component})
+                  </option>
+                ))}
+              </Input>
+            </FormGroup>
+          )}
+          <FormGroup>
+            <Label>
+              Media Asset: {chapter.mediaAsset || <em>None</em>}
+            </Label>
+            <div style={{display: "flex", gap: "4px"}}>
+              <Button size="sm" color="secondary" onClick={onSetMediaPicker}>
+                Browse
+              </Button>
+              {chapter.mediaAsset && (
+                <Button
+                  size="sm"
+                  color="warning"
+                  onClick={() => onUpdate({mediaAsset: null})}
+                >
+                  Clear
+                </Button>
+              )}
+            </div>
+          </FormGroup>
+          {chapter.mediaAsset && (
+            <>
+              <FormGroup style={{display: "flex", gap: "16px", alignItems: "flex-start", flexWrap: "wrap"}}>
+                <div>
+                  <Label style={{display: "block", marginBottom: "4px"}}>Media Size</Label>
+                  <Input
+                    type="select"
+                    bsSize="sm"
+                    style={{width: "auto"}}
+                    value={chapter.mediaSize || "small"}
+                    onChange={e => onUpdate({mediaSize: e.target.value})}
+                  >
+                    <option value="small">Small (25%)</option>
+                    <option value="medium">Medium (40%)</option>
+                    <option value="large">Large (60%)</option>
+                  </Input>
+                </div>
+                <div>
+                  <Label style={{display: "block", marginBottom: "4px"}}>Media Position</Label>
+                  <div
+                    style={{
+                      display: "grid",
+                      gridTemplateColumns: "repeat(3, 28px)",
+                      gap: "3px",
+                    }}
+                  >
+                    {MEDIA_POSITIONS.map(pos => (
+                      <button
+                        key={pos}
+                        title={pos}
+                        onClick={() => onUpdate({mediaPosition: pos})}
+                        style={{
+                          width: "28px",
+                          height: "28px",
+                          background:
+                            (chapter.mediaPosition || "bottom-right") === pos
+                              ? "#00bcd4"
+                              : "rgba(255,255,255,0.1)",
+                          border: "1px solid rgba(255,255,255,0.2)",
+                          borderRadius: "3px",
+                          cursor: "pointer",
+                          padding: 0,
+                        }}
+                      />
+                    ))}
+                  </div>
+                  <div style={{fontSize: "11px", color: "#78909c", marginTop: "2px"}}>
+                    {chapter.mediaPosition || "bottom-right"}
+                  </div>
+                </div>
+              </FormGroup>
+            </>
+          )}
+          <FormGroup style={{display: "flex", gap: "16px", flexWrap: "wrap"}}>
+            <Label check style={{display: "flex", gap: "4px"}}>
+              <input
+                type="checkbox"
+                checked={chapter.autoOpenMedia ?? false}
+                onChange={e => onUpdate({autoOpenMedia: e.target.checked})}
+              />
+              Auto-open media
+            </Label>
+            <Label check style={{display: "flex", gap: "4px"}}>
+              <input
+                type="checkbox"
+                checked={chapter.autoAdvance ?? false}
+                onChange={e => onUpdate({autoAdvance: e.target.checked})}
+              />
+              Auto-advance
+            </Label>
+            {showCardSelector && (
+              <Label>
+                Card switch:{" "}
+                <Input
+                  type="select"
+                  bsSize="sm"
+                  style={{display: "inline-block", width: "auto"}}
+                  value={chapter.cardSwitchBehavior || "manual"}
+                  onChange={e => onUpdate({cardSwitchBehavior: e.target.value})}
+                >
+                  <option value="manual">Manual</option>
+                  <option value="auto">Auto</option>
+                </Input>
+              </Label>
+            )}
+          </FormGroup>
+
+          {/* Sub-chapters */}
+          <div style={{marginTop: "8px"}}>
+            <Label style={{fontWeight: 600}}>Sub-Chapters</Label>
+            {(chapter.subChapters || []).map((sub: any, sIdx: number) => (
+              <div
+                key={sub.id}
+                style={{
+                  border: "1px solid rgba(255,255,255,0.1)",
+                  borderRadius: "4px",
+                  padding: "8px",
+                  marginBottom: "6px",
+                  background: "rgba(0,0,0,0.15)",
+                }}
+              >
+                <div
+                  style={{
+                    display: "flex",
+                    gap: "8px",
+                    alignItems: "center",
+                    marginBottom: "6px",
+                  }}
+                >
+                  <span style={{color: "#888", minWidth: "20px"}}>
+                    {index + 1}.{sIdx + 1}
+                  </span>
+                  <Input
+                    bsSize="sm"
+                    value={sub.name}
+                    onChange={e => onUpdateSubChapter(sub.id, {name: e.target.value})}
+                    style={{flex: 1}}
+                  />
+                  <Button
+                    size="sm"
+                    color="info"
+                    outline
+                    onClick={() => onStartRecording(sub.id)}
+                  >
+                    Record Actions
+                  </Button>
+                  <Button
+                    size="sm"
+                    color="danger"
+                    outline
+                    onClick={() => onRemoveSubChapter(sub.id)}
+                  >
+                    X
+                  </Button>
+                </div>
+                {sub.requiredActions?.length > 0 && (
+                  <div style={{paddingLeft: "28px", fontSize: "12px", color: "#aaa"}}>
+                    Required:{" "}
+                    {sub.requiredActions
+                      .map((ra: any) =>
+                        getActionLabel(ra.eventName, chapter.cardComponent),
+                      )
+                      .join(", ")}
+                  </div>
+                )}
+              </div>
+            ))}
+            <Button size="sm" color="success" outline onClick={onAddSubChapter}>
+              + Add Sub-Chapter
+            </Button>
+          </div>
+        </CardBody>
+      </Collapse>
+    </Card>
+  );
+};
+
+const AdvancedTrainingConfig: React.FC = () => {
+  const {simulatorId, stationSetId, stationName: encodedStationName} = useParams();
+  const stationName = decodeURI(encodedStationName || "");
+  const navigate = useNavigate();
+
+  const {data: stationData} = useStationSetConfigSubscription();
+  const stationSets = stationData?.stationSetUpdate?.filter(
+    (s: any) => s?.simulator?.id === simulatorId,
+  );
+  const stationSet = stationSets?.find((s: any) => s?.id === stationSetId);
+  const station = stationSet?.stations?.find((s: any) => s?.name === stationName);
+
+  const advancedTraining = (station as any)?.advancedTraining;
+  const enabled = advancedTraining?.enabled ?? false;
+  const sequentialChapters = advancedTraining?.sequentialChapters ?? false;
+  const chapters = advancedTraining?.chapters ?? [];
+
+  const [toggleMode] = useMutation(TOGGLE_ADVANCED_TRAINING_MODE);
+  const [saveConfig] = useMutation(SET_STATION_ADVANCED_TRAINING);
+
+  // Local editing state
+  const [editingChapters, setEditingChapters] = useState<any[] | null>(null);
+  const [editingSequential, setEditingSequential] = useState<boolean | null>(null);
+  const [editingLoginChapter, setEditingLoginChapter] = useState<any | null | undefined>(undefined);
+  const [editingCompletionChapter, setEditingCompletionChapter] = useState<any | null | undefined>(undefined);
+  const [expandedChapter, setExpandedChapter] = useState<string | null>(null);
+  const [recordingSubChapter, setRecordingSubChapter] = useState<string | null>(null);
+  const [mediaPickerChapter, setMediaPickerChapter] = useState<string | null>(null);
+
+  const isEditing = editingChapters !== null;
+  const displayChapters = isEditing ? editingChapters : chapters;
+
+  // undefined = not editing; null = editing with no special chapter; object = editing with chapter
+  const editingLogin = editingLoginChapter !== undefined ? editingLoginChapter : advancedTraining?.loginChapter ?? null;
+  const editingCompletion = editingCompletionChapter !== undefined ? editingCompletionChapter : advancedTraining?.completionChapter ?? null;
+
+  const stationCards = station?.cards || [];
+
+  const handleToggle = () => {
+    if (!stationSetId || !stationName) return;
+    toggleMode({
+      variables: {stationSetID: stationSetId, stationName, enabled: !enabled},
+    });
+  };
+
+  const goBack = () => {
+    navigate(
+      `/config/simulator/${simulatorId}/Stations/${stationSetId}/${encodeURI(stationName)}`,
+    );
+  };
+
+  const startEditing = () => {
+    setEditingChapters(JSON.parse(JSON.stringify(chapters)));
+    setEditingSequential(sequentialChapters);
+    setEditingLoginChapter(
+      advancedTraining?.loginChapter
+        ? JSON.parse(JSON.stringify(advancedTraining.loginChapter))
+        : null,
+    );
+    setEditingCompletionChapter(
+      advancedTraining?.completionChapter
+        ? JSON.parse(JSON.stringify(advancedTraining.completionChapter))
+        : null,
+    );
+  };
+
+  const cancelEditing = () => {
+    setEditingChapters(null);
+    setEditingSequential(null);
+    setEditingLoginChapter(undefined);
+    setEditingCompletionChapter(undefined);
+    setExpandedChapter(null);
+  };
+
+  const saveEditing = () => {
+    if (!stationSetId || !stationName || !editingChapters) return;
+    saveConfig({
+      variables: {
+        stationSetID: stationSetId,
+        stationName,
+        config: {
+          enabled,
+          sequentialChapters: editingSequential ?? sequentialChapters,
+          chapters: editingChapters.map(serializeChapter),
+          loginChapter: editingLogin ? serializeChapter(editingLogin) : null,
+          completionChapter: editingCompletion
+            ? serializeChapter(editingCompletion)
+            : null,
+        },
+      },
+    });
+    setEditingChapters(null);
+    setEditingLoginChapter(undefined);
+    setEditingCompletionChapter(undefined);
+    setExpandedChapter(null);
+  };
+
+  const addChapter = () => {
+    if (!editingChapters) return;
+    const newChapter = emptyChapter(
+      `ch-${Date.now()}`,
+      "New Chapter",
+    );
+    (newChapter as any).cardComponent = stationCards[0]?.component || "";
+    setEditingChapters([...editingChapters, newChapter]);
+    setExpandedChapter(newChapter.id);
+  };
+
+  const removeChapter = (chapterId: string) => {
+    if (!editingChapters) return;
+    setEditingChapters(editingChapters.filter((c: any) => c.id !== chapterId));
+    if (expandedChapter === chapterId) setExpandedChapter(null);
+  };
+
+  const updateChapter = useCallback(
+    (chapterId: string, updates: any) => {
+      if (!editingChapters) return;
+      setEditingChapters(
+        editingChapters.map((c: any) =>
+          c.id === chapterId ? {...c, ...updates} : c,
+        ),
+      );
+    },
+    [editingChapters],
+  );
+
+  const addSubChapter = (chapterId: string, isSpecial?: "login" | "completion") => {
+    const newSub = {
+      id: `sc-${Date.now()}`,
+      name: "New Sub-Chapter",
+      requiredActions: [],
+    };
+    if (isSpecial === "login") {
+      setEditingLoginChapter((prev: any) => ({
+        ...prev,
+        subChapters: [...(prev?.subChapters || []), newSub],
+      }));
+    } else if (isSpecial === "completion") {
+      setEditingCompletionChapter((prev: any) => ({
+        ...prev,
+        subChapters: [...(prev?.subChapters || []), newSub],
+      }));
+    } else {
+      if (!editingChapters) return;
+      setEditingChapters(
+        editingChapters.map((c: any) =>
+          c.id === chapterId
+            ? {...c, subChapters: [...(c.subChapters || []), newSub]}
+            : c,
+        ),
+      );
+    }
+  };
+
+  const removeSubChapter = (chapterId: string, subChapterId: string, isSpecial?: "login" | "completion") => {
+    if (isSpecial === "login") {
+      setEditingLoginChapter((prev: any) => ({
+        ...prev,
+        subChapters: prev.subChapters.filter((s: any) => s.id !== subChapterId),
+      }));
+    } else if (isSpecial === "completion") {
+      setEditingCompletionChapter((prev: any) => ({
+        ...prev,
+        subChapters: prev.subChapters.filter((s: any) => s.id !== subChapterId),
+      }));
+    } else {
+      if (!editingChapters) return;
+      setEditingChapters(
+        editingChapters.map((c: any) =>
+          c.id === chapterId
+            ? {...c, subChapters: c.subChapters.filter((s: any) => s.id !== subChapterId)}
+            : c,
+        ),
+      );
+    }
+  };
+
+  const updateSubChapter = (
+    chapterId: string,
+    subChapterId: string,
+    updates: any,
+    isSpecial?: "login" | "completion",
+  ) => {
+    if (isSpecial === "login") {
+      setEditingLoginChapter((prev: any) => ({
+        ...prev,
+        subChapters: prev.subChapters.map((s: any) =>
+          s.id === subChapterId ? {...s, ...updates} : s,
+        ),
+      }));
+    } else if (isSpecial === "completion") {
+      setEditingCompletionChapter((prev: any) => ({
+        ...prev,
+        subChapters: prev.subChapters.map((s: any) =>
+          s.id === subChapterId ? {...s, ...updates} : s,
+        ),
+      }));
+    } else {
+      if (!editingChapters) return;
+      setEditingChapters(
+        editingChapters.map((c: any) =>
+          c.id === chapterId
+            ? {
+                ...c,
+                subChapters: c.subChapters.map((s: any) =>
+                  s.id === subChapterId ? {...s, ...updates} : s,
+                ),
+              }
+            : c,
+        ),
+      );
+    }
+  };
+
+  // Record mode helpers
+  const startRecording = (chapterId: string, subChapterId: string) => {
+    setRecordingSubChapter(`${chapterId}:${subChapterId}`);
+  };
+
+  const cancelRecording = () => {
+    setRecordingSubChapter(null);
+  };
+
+  const saveRecording = (actions: any[]) => {
+    if (!recordingSubChapter || !editingChapters) return;
+    const [chapterId, subChapterId] = recordingSubChapter.split(":");
+    updateSubChapter(chapterId, subChapterId, {requiredActions: actions});
+    setRecordingSubChapter(null);
+  };
+
+  const recordingChapterId = recordingSubChapter?.split(":")[0];
+  const recordingSubChapterId = recordingSubChapter?.split(":")[1];
+  const recordingChapter = editingChapters?.find(
+    (c: any) => c.id === recordingChapterId,
+  );
+  const recordingSubChapterData = recordingChapter?.subChapters?.find(
+    (s: any) => s.id === recordingSubChapterId,
+  );
+
+  if (!station) {
+    return (
+      <Container className="advanced-training-config-page">
+        <p>Loading station data...</p>
+        <Button color="secondary" onClick={goBack}>
+          Back to Station Config
+        </Button>
+      </Container>
+    );
+  }
+
+  return (
+    <Container className="advanced-training-config-page" fluid>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "12px",
+          marginBottom: "16px",
+        }}
+      >
+        <Button color="secondary" size="sm" onClick={goBack}>
+          &larr; Back
+        </Button>
+        <h4 style={{margin: 0}}>
+          Advanced Training &mdash; {stationName}
+        </h4>
+      </div>
+
+      <Label
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "8px",
+          fontWeight: 600,
+          marginBottom: "16px",
+        }}
+      >
+        <CustomInput
+          type="switch"
+          id="advanced-training-toggle"
+          checked={enabled}
+          onChange={handleToggle}
+        />
+        Enable Advanced Training
+      </Label>
+
+      {enabled && (
+        <div
+          style={{
+            border: "1px solid rgba(0,188,212,0.3)",
+            borderRadius: "4px",
+            padding: "16px",
+          }}
+        >
+          {!isEditing ? (
+            <>
+              <div style={{marginBottom: "8px"}}>
+                <strong>{chapters.length}</strong> chapter
+                {chapters.length !== 1 ? "s" : ""} configured
+                {advancedTraining?.loginChapter && (
+                  <span style={{marginLeft: "8px", color: "#80deea"}}>
+                    + login chapter
+                  </span>
+                )}
+                {advancedTraining?.completionChapter && (
+                  <span style={{marginLeft: "8px", color: "#80deea"}}>
+                    + completion chapter
+                  </span>
+                )}
+              </div>
+              {chapters.map((ch: any, idx: number) => (
+                <div
+                  key={ch.id}
+                  style={{padding: "4px 8px", fontSize: "13px", color: "#ccc"}}
+                >
+                  {idx + 1}. {ch.name}{" "}
+                  <span style={{color: "#888"}}>
+                    ({ch.cardComponent}, {ch.subChapters?.length || 0} sub-tasks)
+                  </span>
+                </div>
+              ))}
+              <Button
+                size="sm"
+                color="info"
+                onClick={startEditing}
+                style={{marginTop: "8px"}}
+              >
+                Edit Chapters
+              </Button>
+            </>
+          ) : (
+            <>
+              <FormGroup style={{marginBottom: "12px"}}>
+                <Label check style={{display: "flex", gap: "8px", fontWeight: 500}}>
+                  <input
+                    type="checkbox"
+                    checked={editingSequential ?? sequentialChapters}
+                    onChange={e => setEditingSequential(e.target.checked)}
+                  />
+                  Sequential chapters (lock until previous complete)
+                </Label>
+              </FormGroup>
+
+              {/* Login chapter */}
+              <div style={{marginBottom: "12px"}}>
+                <Label check style={{display: "flex", gap: "8px", fontWeight: 500, marginBottom: "6px"}}>
+                  <input
+                    type="checkbox"
+                    checked={!!editingLogin}
+                    onChange={e => {
+                      if (e.target.checked) {
+                        setEditingLoginChapter(emptyChapter(`login-${Date.now()}`, "Login Chapter"));
+                      } else {
+                        setEditingLoginChapter(null);
+                        if (expandedChapter === editingLogin?.id) setExpandedChapter(null);
+                      }
+                    }}
+                  />
+                  Login Chapter (shown on login screen before training starts)
+                </Label>
+                {editingLogin && (
+                  <ChapterEditor
+                    chapter={editingLogin}
+                    index={-1}
+                    label={`Login: ${editingLogin.name}`}
+                    stationCards={stationCards}
+                    isExpanded={expandedChapter === editingLogin.id}
+                    onToggleExpand={() =>
+                      setExpandedChapter(
+                        expandedChapter === editingLogin.id ? null : editingLogin.id,
+                      )
+                    }
+                    onUpdate={updates =>
+                      setEditingLoginChapter((prev: any) => ({...prev, ...updates}))
+                    }
+                    onAddSubChapter={() => addSubChapter(editingLogin.id, "login")}
+                    onRemoveSubChapter={subId => removeSubChapter(editingLogin.id, subId, "login")}
+                    onUpdateSubChapter={(subId, updates) =>
+                      updateSubChapter(editingLogin.id, subId, updates, "login")
+                    }
+                    onStartRecording={subId => startRecording(editingLogin.id, subId)}
+                    onSetMediaPicker={() => setMediaPickerChapter(`login:${editingLogin.id}`)}
+                    showCardSelector={false}
+                  />
+                )}
+              </div>
+
+              {/* Regular chapters */}
+              {displayChapters?.map((chapter: any, chIdx: number) => (
+                <ChapterEditor
+                  key={chapter.id}
+                  chapter={chapter}
+                  index={chIdx}
+                  stationCards={stationCards}
+                  isExpanded={expandedChapter === chapter.id}
+                  onToggleExpand={() =>
+                    setExpandedChapter(
+                      expandedChapter === chapter.id ? null : chapter.id,
+                    )
+                  }
+                  onUpdate={updates => updateChapter(chapter.id, updates)}
+                  onRemove={() => removeChapter(chapter.id)}
+                  onAddSubChapter={() => addSubChapter(chapter.id)}
+                  onRemoveSubChapter={subId => removeSubChapter(chapter.id, subId)}
+                  onUpdateSubChapter={(subId, updates) =>
+                    updateSubChapter(chapter.id, subId, updates)
+                  }
+                  onStartRecording={subId => startRecording(chapter.id, subId)}
+                  onSetMediaPicker={() => setMediaPickerChapter(chapter.id)}
+                />
+              ))}
+
+              {/* Completion chapter */}
+              <div style={{marginTop: "8px", marginBottom: "12px"}}>
+                <Label check style={{display: "flex", gap: "8px", fontWeight: 500, marginBottom: "6px"}}>
+                  <input
+                    type="checkbox"
+                    checked={!!editingCompletion}
+                    onChange={e => {
+                      if (e.target.checked) {
+                        setEditingCompletionChapter(
+                          emptyChapter(`completion-${Date.now()}`, "Training Complete"),
+                        );
+                      } else {
+                        setEditingCompletionChapter(null);
+                        if (expandedChapter === editingCompletion?.id)
+                          setExpandedChapter(null);
+                      }
+                    }}
+                  />
+                  Completion Chapter (shown after all chapters are finished)
+                </Label>
+                {editingCompletion && (
+                  <ChapterEditor
+                    chapter={editingCompletion}
+                    index={displayChapters?.length || 0}
+                    label={`Completion: ${editingCompletion.name}`}
+                    stationCards={stationCards}
+                    isExpanded={expandedChapter === editingCompletion.id}
+                    onToggleExpand={() =>
+                      setExpandedChapter(
+                        expandedChapter === editingCompletion.id
+                          ? null
+                          : editingCompletion.id,
+                      )
+                    }
+                    onUpdate={updates =>
+                      setEditingCompletionChapter((prev: any) => ({...prev, ...updates}))
+                    }
+                    onAddSubChapter={() =>
+                      addSubChapter(editingCompletion.id, "completion")
+                    }
+                    onRemoveSubChapter={subId =>
+                      removeSubChapter(editingCompletion.id, subId, "completion")
+                    }
+                    onUpdateSubChapter={(subId, updates) =>
+                      updateSubChapter(editingCompletion.id, subId, updates, "completion")
+                    }
+                    onStartRecording={subId => startRecording(editingCompletion.id, subId)}
+                    onSetMediaPicker={() =>
+                      setMediaPickerChapter(`completion:${editingCompletion.id}`)
+                    }
+                    showCardSelector={false}
+                  />
+                )}
+              </div>
+
+              <div style={{display: "flex", gap: "8px", marginTop: "8px"}}>
+                <Button size="sm" color="success" outline onClick={addChapter}>
+                  + Add Chapter
+                </Button>
+                <Button size="sm" color="primary" onClick={saveEditing}>
+                  Save
+                </Button>
+                <Button size="sm" color="secondary" outline onClick={cancelEditing}>
+                  Cancel
+                </Button>
+              </div>
+            </>
+          )}
+        </div>
+      )}
+
+      {/* Media picker modal */}
+      <Modal
+        isOpen={!!mediaPickerChapter}
+        toggle={() => setMediaPickerChapter(null)}
+      >
+        <ModalHeader toggle={() => setMediaPickerChapter(null)}>
+          Select Training Media
+        </ModalHeader>
+        <ModalBody>
+          <FileExplorer
+            directory="/Training"
+            selectedFiles={[]}
+            onClick={(_evt: any, container: any) => {
+              if (mediaPickerChapter) {
+                const isLogin = mediaPickerChapter.startsWith("login:");
+                const isCompletion = mediaPickerChapter.startsWith("completion:");
+                if (isLogin) {
+                  setEditingLoginChapter((prev: any) => ({
+                    ...prev,
+                    mediaAsset: container.fullPath,
+                  }));
+                } else if (isCompletion) {
+                  setEditingCompletionChapter((prev: any) => ({
+                    ...prev,
+                    mediaAsset: container.fullPath,
+                  }));
+                } else {
+                  updateChapter(mediaPickerChapter, {mediaAsset: container.fullPath});
+                }
+              }
+              setMediaPickerChapter(null);
+            }}
+          />
+        </ModalBody>
+        <ModalFooter>
+          <Button color="secondary" onClick={() => setMediaPickerChapter(null)}>
+            Cancel
+          </Button>
+        </ModalFooter>
+      </Modal>
+
+      {/* Record actions modal */}
+      <RecordActionsModal
+        isOpen={!!recordingSubChapter}
+        chapter={recordingChapter}
+        existingActions={recordingSubChapterData?.requiredActions || []}
+        simulatorId={simulatorId || ""}
+        stationSetId={stationSetId || ""}
+        stationName={stationName}
+        onSave={saveRecording}
+        onCancel={cancelRecording}
+      />
+    </Container>
+  );
+};
+
+export default AdvancedTrainingConfig;

--- a/src/containers/FlightDirector/SimulatorConfig/config/Stations/AdvancedTrainingConfig.tsx
+++ b/src/containers/FlightDirector/SimulatorConfig/config/Stations/AdvancedTrainingConfig.tsx
@@ -23,7 +23,7 @@ import {
   SET_STATION_ADVANCED_TRAINING,
   TOGGLE_ADVANCED_TRAINING_MODE,
 } from "components/training/queries";
-import {getActionLabel, VIDEO_COMPLETE_EVENT} from "components/training/actionRegistry";
+import {getActionLabel, VIDEO_COMPLETE_EVENT, LOGIN_EVENT} from "components/training/actionRegistry";
 import RecordActionsModal from "./RecordActionsModal";
 
 const MEDIA_POSITIONS = [
@@ -46,6 +46,7 @@ function emptyChapter(id: string, name: string) {
     mediaAsset: null,
     autoOpenMedia: false,
     autoAdvance: false,
+    autoLogin: "none",
     cardSwitchBehavior: "manual",
     mediaSize: "small",
     mediaPosition: "bottom-right",
@@ -61,6 +62,7 @@ function serializeChapter(ch: any) {
     mediaAsset: ch.mediaAsset || null,
     autoOpenMedia: ch.autoOpenMedia ?? false,
     autoAdvance: ch.autoAdvance ?? false,
+    autoLogin: ch.autoLogin ?? "none",
     cardSwitchBehavior: ch.cardSwitchBehavior || "manual",
     mediaSize: ch.mediaSize || "small",
     mediaPosition: ch.mediaPosition || "bottom-right",
@@ -91,6 +93,7 @@ interface ChapterEditorProps {
   onStartRecording: (subId: string) => void;
   onSetMediaPicker: () => void;
   showCardSelector?: boolean;
+  isLoginChapter?: boolean;
 }
 
 const ChapterEditor: React.FC<ChapterEditorProps> = ({
@@ -108,6 +111,7 @@ const ChapterEditor: React.FC<ChapterEditorProps> = ({
   onStartRecording,
   onSetMediaPicker,
   showCardSelector = true,
+  isLoginChapter = false,
 }) => {
   return (
     <Card style={{marginBottom: "8px", background: "rgba(0,0,0,0.2)"}}>
@@ -353,7 +357,39 @@ const ChapterEditor: React.FC<ChapterEditorProps> = ({
                           }
                         }}
                       />
-                      Require video to finish
+                      Require media to finish
+                    </Label>
+                  </div>
+                )}
+                {isLoginChapter && (
+                  <div style={{paddingLeft: "28px"}}>
+                    <Label check style={{display: "flex", gap: "6px", fontSize: "12px", color: "#aaa"}}>
+                      <input
+                        type="checkbox"
+                        checked={(sub.requiredActions || []).some(
+                          (ra: any) => ra.eventName === LOGIN_EVENT,
+                        )}
+                        onChange={e => {
+                          const current = sub.requiredActions || [];
+                          if (e.target.checked) {
+                            if (!current.some((ra: any) => ra.eventName === LOGIN_EVENT)) {
+                              onUpdateSubChapter(sub.id, {
+                                requiredActions: [
+                                  ...current,
+                                  {id: `li-${sub.id}`, eventName: LOGIN_EVENT},
+                                ],
+                              });
+                            }
+                          } else {
+                            onUpdateSubChapter(sub.id, {
+                              requiredActions: current.filter(
+                                (ra: any) => ra.eventName !== LOGIN_EVENT,
+                              ),
+                            });
+                          }
+                        }}
+                      />
+                      Require login to proceed
                     </Label>
                   </div>
                 )}
@@ -765,29 +801,51 @@ const AdvancedTrainingConfig: React.FC = () => {
                   Login Chapter (shown on login screen before training starts)
                 </Label>
                 {editingLogin && (
-                  <ChapterEditor
-                    chapter={editingLogin}
-                    index={-1}
-                    label={`Login: ${editingLogin.name}`}
-                    stationCards={stationCards}
-                    isExpanded={expandedChapter === editingLogin.id}
-                    onToggleExpand={() =>
-                      setExpandedChapter(
-                        expandedChapter === editingLogin.id ? null : editingLogin.id,
-                      )
-                    }
-                    onUpdate={updates =>
-                      setEditingLoginChapter((prev: any) => ({...prev, ...updates}))
-                    }
-                    onAddSubChapter={() => addSubChapter(editingLogin.id, "login")}
-                    onRemoveSubChapter={subId => removeSubChapter(editingLogin.id, subId, "login")}
-                    onUpdateSubChapter={(subId, updates) =>
-                      updateSubChapter(editingLogin.id, subId, updates, "login")
-                    }
-                    onStartRecording={subId => startRecording(editingLogin.id, subId)}
-                    onSetMediaPicker={() => setMediaPickerChapter(`login:${editingLogin.id}`)}
-                    showCardSelector={false}
-                  />
+                  <>
+                    <div style={{paddingLeft: "24px", marginBottom: "8px", fontSize: "13px"}}>
+                      <div style={{fontWeight: 500, marginBottom: "4px"}}>Station Login</div>
+                      {(["none", "immediate", "on-complete"] as const).map(opt => (
+                        <Label key={opt} check style={{display: "flex", gap: "6px", marginBottom: "3px", fontWeight: 400}}>
+                          <input
+                            type="radio"
+                            name={`autoLogin-${editingLogin.id}`}
+                            value={opt}
+                            checked={(editingLogin.autoLogin ?? "none") === opt}
+                            onChange={() =>
+                              setEditingLoginChapter((prev: any) => ({...prev, autoLogin: opt}))
+                            }
+                          />
+                          {opt === "none" && "None (crew logs in manually)"}
+                          {opt === "immediate" && "Auto-login when training starts"}
+                          {opt === "on-complete" && "Auto-login after login chapter completes"}
+                        </Label>
+                      ))}
+                    </div>
+                    <ChapterEditor
+                      chapter={editingLogin}
+                      index={-1}
+                      label={`Login: ${editingLogin.name}`}
+                      stationCards={stationCards}
+                      isExpanded={expandedChapter === editingLogin.id}
+                      onToggleExpand={() =>
+                        setExpandedChapter(
+                          expandedChapter === editingLogin.id ? null : editingLogin.id,
+                        )
+                      }
+                      onUpdate={updates =>
+                        setEditingLoginChapter((prev: any) => ({...prev, ...updates}))
+                      }
+                      onAddSubChapter={() => addSubChapter(editingLogin.id, "login")}
+                      onRemoveSubChapter={subId => removeSubChapter(editingLogin.id, subId, "login")}
+                      onUpdateSubChapter={(subId, updates) =>
+                        updateSubChapter(editingLogin.id, subId, updates, "login")
+                      }
+                      onStartRecording={subId => startRecording(editingLogin.id, subId)}
+                      onSetMediaPicker={() => setMediaPickerChapter(`login:${editingLogin.id}`)}
+                      showCardSelector={false}
+                      isLoginChapter
+                    />
+                  </>
                 )}
               </div>
 

--- a/src/containers/FlightDirector/SimulatorConfig/config/Stations/AdvancedTrainingConfig.tsx
+++ b/src/containers/FlightDirector/SimulatorConfig/config/Stations/AdvancedTrainingConfig.tsx
@@ -1,422 +1,18 @@
-import React, {useState, useCallback} from "react";
-import {
-  Button,
-  Input,
-  Label,
-  FormGroup,
-  CustomInput,
-  Card,
-  CardBody,
-  CardHeader,
-  Collapse,
-  Modal,
-  ModalHeader,
-  ModalBody,
-  ModalFooter,
-  Container,
-} from "helpers/reactstrap";
+import React from "react";
+import {Button, Label, CustomInput, Container} from "helpers/reactstrap";
 import {useMutation} from "react-apollo";
 import {useParams, useNavigate} from "react-router-dom";
 import {useStationSetConfigSubscription} from "generated/graphql";
-import FileExplorer from "components/views/TacticalMap/fileExplorer";
-import {
-  SET_STATION_ADVANCED_TRAINING,
-  TOGGLE_ADVANCED_TRAINING_MODE,
-} from "components/training/queries";
-import {getActionLabel, VIDEO_COMPLETE_EVENT, LOGIN_EVENT} from "components/training/actionRegistry";
-import RecordActionsModal from "./RecordActionsModal";
-
-const MEDIA_POSITIONS = [
-  "top-left",
-  "top-center",
-  "top-right",
-  "middle-left",
-  "middle-center",
-  "middle-right",
-  "bottom-left",
-  "bottom-center",
-  "bottom-right",
-];
-
-function emptyChapter(id: string, name: string) {
-  return {
-    id,
-    name,
-    cardComponent: "",
-    mediaAsset: null,
-    autoOpenMedia: false,
-    autoAdvance: false,
-    autoLogin: "none",
-    cardSwitchBehavior: "manual",
-    mediaSize: "small",
-    mediaPosition: "bottom-right",
-    subChapters: [],
-  };
-}
-
-function serializeChapter(ch: any) {
-  return {
-    id: ch.id,
-    name: ch.name,
-    cardComponent: ch.cardComponent || "",
-    mediaAsset: ch.mediaAsset || null,
-    autoOpenMedia: ch.autoOpenMedia ?? false,
-    autoAdvance: ch.autoAdvance ?? false,
-    autoLogin: ch.autoLogin ?? "none",
-    cardSwitchBehavior: ch.cardSwitchBehavior || "manual",
-    mediaSize: ch.mediaSize || "small",
-    mediaPosition: ch.mediaPosition || "bottom-right",
-    subChapters: (ch.subChapters || []).map((sc: any) => ({
-      id: sc.id,
-      name: sc.name,
-      requiredActions: (sc.requiredActions || []).map((ra: any) => ({
-        id: ra.id,
-        eventName: ra.eventName,
-        args: ra.args || null,
-      })),
-    })),
-  };
-}
-
-interface ChapterEditorProps {
-  chapter: any;
-  index: number;
-  label?: string;
-  stationCards: any[];
-  isExpanded: boolean;
-  onToggleExpand: () => void;
-  onUpdate: (updates: any) => void;
-  onRemove?: () => void;
-  onAddSubChapter: () => void;
-  onRemoveSubChapter: (subId: string) => void;
-  onUpdateSubChapter: (subId: string, updates: any) => void;
-  onStartRecording: (subId: string) => void;
-  onSetMediaPicker: () => void;
-  showCardSelector?: boolean;
-  isLoginChapter?: boolean;
-}
-
-const ChapterEditor: React.FC<ChapterEditorProps> = ({
-  chapter,
-  index,
-  label,
-  stationCards,
-  isExpanded,
-  onToggleExpand,
-  onUpdate,
-  onRemove,
-  onAddSubChapter,
-  onRemoveSubChapter,
-  onUpdateSubChapter,
-  onStartRecording,
-  onSetMediaPicker,
-  showCardSelector = true,
-  isLoginChapter = false,
-}) => {
-  return (
-    <Card style={{marginBottom: "8px", background: "rgba(0,0,0,0.2)"}}>
-      <CardHeader
-        onClick={onToggleExpand}
-        style={{
-          cursor: "pointer",
-          display: "flex",
-          justifyContent: "space-between",
-          alignItems: "center",
-          padding: "8px 12px",
-        }}
-      >
-        <span>
-          <strong>
-            {label || `${index + 1}. ${chapter.name}`}
-          </strong>
-          {showCardSelector && (
-            <small style={{marginLeft: "8px", color: "#888"}}>
-              {chapter.cardComponent}
-            </small>
-          )}
-        </span>
-        {onRemove && (
-          <Button
-            size="sm"
-            color="danger"
-            outline
-            onClick={(e: React.MouseEvent) => {
-              e.stopPropagation();
-              onRemove();
-            }}
-          >
-            Remove
-          </Button>
-        )}
-      </CardHeader>
-      <Collapse isOpen={isExpanded}>
-        <CardBody style={{padding: "12px"}}>
-          <FormGroup>
-            <Label>Chapter Name</Label>
-            <Input
-              value={chapter.name}
-              onChange={e => onUpdate({name: e.target.value})}
-            />
-          </FormGroup>
-          {showCardSelector && (
-            <FormGroup>
-              <Label>Card</Label>
-              <Input
-                type="select"
-                value={chapter.cardComponent}
-                onChange={e => onUpdate({cardComponent: e.target.value})}
-              >
-                <option value="">-- Select Card --</option>
-                {stationCards.map((c: any) => (
-                  <option key={c.component} value={c.component}>
-                    {c.name} ({c.component})
-                  </option>
-                ))}
-              </Input>
-            </FormGroup>
-          )}
-          <FormGroup>
-            <Label>
-              Media Asset: {chapter.mediaAsset || <em>None</em>}
-            </Label>
-            <div style={{display: "flex", gap: "4px"}}>
-              <Button size="sm" color="secondary" onClick={onSetMediaPicker}>
-                Browse
-              </Button>
-              {chapter.mediaAsset && (
-                <Button
-                  size="sm"
-                  color="warning"
-                  onClick={() => onUpdate({mediaAsset: null})}
-                >
-                  Clear
-                </Button>
-              )}
-            </div>
-          </FormGroup>
-          {chapter.mediaAsset && (
-            <>
-              <FormGroup style={{display: "flex", gap: "16px", alignItems: "flex-start", flexWrap: "wrap"}}>
-                <div>
-                  <Label style={{display: "block", marginBottom: "4px"}}>Media Size</Label>
-                  <Input
-                    type="select"
-                    bsSize="sm"
-                    style={{width: "auto"}}
-                    value={chapter.mediaSize || "small"}
-                    onChange={e => onUpdate({mediaSize: e.target.value})}
-                  >
-                    <option value="small">Small (25%)</option>
-                    <option value="medium">Medium (40%)</option>
-                    <option value="large">Large (60%)</option>
-                  </Input>
-                </div>
-                <div>
-                  <Label style={{display: "block", marginBottom: "4px"}}>Media Position</Label>
-                  <div
-                    style={{
-                      display: "grid",
-                      gridTemplateColumns: "repeat(3, 28px)",
-                      gap: "3px",
-                    }}
-                  >
-                    {MEDIA_POSITIONS.map(pos => (
-                      <button
-                        key={pos}
-                        title={pos}
-                        onClick={() => onUpdate({mediaPosition: pos})}
-                        style={{
-                          width: "28px",
-                          height: "28px",
-                          background:
-                            (chapter.mediaPosition || "bottom-right") === pos
-                              ? "#00bcd4"
-                              : "rgba(255,255,255,0.1)",
-                          border: "1px solid rgba(255,255,255,0.2)",
-                          borderRadius: "3px",
-                          cursor: "pointer",
-                          padding: 0,
-                        }}
-                      />
-                    ))}
-                  </div>
-                  <div style={{fontSize: "11px", color: "#78909c", marginTop: "2px"}}>
-                    {chapter.mediaPosition || "bottom-right"}
-                  </div>
-                </div>
-              </FormGroup>
-            </>
-          )}
-          <FormGroup style={{display: "flex", gap: "16px", flexWrap: "wrap"}}>
-            <Label check style={{display: "flex", gap: "4px"}}>
-              <input
-                type="checkbox"
-                checked={chapter.autoOpenMedia ?? false}
-                onChange={e => onUpdate({autoOpenMedia: e.target.checked})}
-              />
-              Auto-open media
-            </Label>
-            <Label check style={{display: "flex", gap: "4px"}}>
-              <input
-                type="checkbox"
-                checked={chapter.autoAdvance ?? false}
-                onChange={e => onUpdate({autoAdvance: e.target.checked})}
-              />
-              Auto-advance
-            </Label>
-            {showCardSelector && (
-              <Label>
-                Card switch:{" "}
-                <Input
-                  type="select"
-                  bsSize="sm"
-                  style={{display: "inline-block", width: "auto"}}
-                  value={chapter.cardSwitchBehavior || "manual"}
-                  onChange={e => onUpdate({cardSwitchBehavior: e.target.value})}
-                >
-                  <option value="manual">Manual</option>
-                  <option value="auto">Auto</option>
-                </Input>
-              </Label>
-            )}
-          </FormGroup>
-
-          {/* Sub-chapters */}
-          <div style={{marginTop: "8px"}}>
-            <Label style={{fontWeight: 600}}>Sub-Chapters</Label>
-            {(chapter.subChapters || []).map((sub: any, sIdx: number) => (
-              <div
-                key={sub.id}
-                style={{
-                  border: "1px solid rgba(255,255,255,0.1)",
-                  borderRadius: "4px",
-                  padding: "8px",
-                  marginBottom: "6px",
-                  background: "rgba(0,0,0,0.15)",
-                }}
-              >
-                <div
-                  style={{
-                    display: "flex",
-                    gap: "8px",
-                    alignItems: "center",
-                    marginBottom: "6px",
-                  }}
-                >
-                  <span style={{color: "#888", minWidth: "20px"}}>
-                    {index + 1}.{sIdx + 1}
-                  </span>
-                  <Input
-                    bsSize="sm"
-                    value={sub.name}
-                    onChange={e => onUpdateSubChapter(sub.id, {name: e.target.value})}
-                    style={{flex: 1}}
-                  />
-                  <Button
-                    size="sm"
-                    color="info"
-                    outline
-                    onClick={() => onStartRecording(sub.id)}
-                  >
-                    Record Actions
-                  </Button>
-                  <Button
-                    size="sm"
-                    color="danger"
-                    outline
-                    onClick={() => onRemoveSubChapter(sub.id)}
-                  >
-                    X
-                  </Button>
-                </div>
-                {chapter.mediaAsset && (
-                  <div style={{paddingLeft: "28px"}}>
-                    <Label check style={{display: "flex", gap: "6px", fontSize: "12px", color: "#aaa"}}>
-                      <input
-                        type="checkbox"
-                        checked={(sub.requiredActions || []).some(
-                          (ra: any) => ra.eventName === VIDEO_COMPLETE_EVENT,
-                        )}
-                        onChange={e => {
-                          const current = sub.requiredActions || [];
-                          if (e.target.checked) {
-                            if (!current.some((ra: any) => ra.eventName === VIDEO_COMPLETE_EVENT)) {
-                              onUpdateSubChapter(sub.id, {
-                                requiredActions: [
-                                  ...current,
-                                  {id: `vc-${sub.id}`, eventName: VIDEO_COMPLETE_EVENT},
-                                ],
-                              });
-                            }
-                          } else {
-                            onUpdateSubChapter(sub.id, {
-                              requiredActions: current.filter(
-                                (ra: any) => ra.eventName !== VIDEO_COMPLETE_EVENT,
-                              ),
-                            });
-                          }
-                        }}
-                      />
-                      Require media to finish
-                    </Label>
-                  </div>
-                )}
-                {isLoginChapter && (
-                  <div style={{paddingLeft: "28px"}}>
-                    <Label check style={{display: "flex", gap: "6px", fontSize: "12px", color: "#aaa"}}>
-                      <input
-                        type="checkbox"
-                        checked={(sub.requiredActions || []).some(
-                          (ra: any) => ra.eventName === LOGIN_EVENT,
-                        )}
-                        onChange={e => {
-                          const current = sub.requiredActions || [];
-                          if (e.target.checked) {
-                            if (!current.some((ra: any) => ra.eventName === LOGIN_EVENT)) {
-                              onUpdateSubChapter(sub.id, {
-                                requiredActions: [
-                                  ...current,
-                                  {id: `li-${sub.id}`, eventName: LOGIN_EVENT},
-                                ],
-                              });
-                            }
-                          } else {
-                            onUpdateSubChapter(sub.id, {
-                              requiredActions: current.filter(
-                                (ra: any) => ra.eventName !== LOGIN_EVENT,
-                              ),
-                            });
-                          }
-                        }}
-                      />
-                      Require login to proceed
-                    </Label>
-                  </div>
-                )}
-                {sub.requiredActions?.length > 0 && (
-                  <div style={{paddingLeft: "28px", fontSize: "12px", color: "#aaa"}}>
-                    Required:{" "}
-                    {sub.requiredActions
-                      .map((ra: any) =>
-                        getActionLabel(ra.eventName, chapter.cardComponent),
-                      )
-                      .join(", ")}
-                  </div>
-                )}
-              </div>
-            ))}
-            <Button size="sm" color="success" outline onClick={onAddSubChapter}>
-              + Add Sub-Chapter
-            </Button>
-          </div>
-        </CardBody>
-      </Collapse>
-    </Card>
-  );
-};
+import {TOGGLE_ADVANCED_TRAINING_MODE} from "components/training/queries";
+import {useAdvancedTrainingConfigEditor} from "./useAdvancedTrainingConfigEditor";
+import AdvancedTrainingEditor from "./AdvancedTrainingEditor";
 
 const AdvancedTrainingConfig: React.FC = () => {
-  const {simulatorId, stationSetId, stationName: encodedStationName} = useParams();
+  const {
+    simulatorId,
+    stationSetId,
+    stationName: encodedStationName,
+  } = useParams();
   const stationName = decodeURI(encodedStationName || "");
   const navigate = useNavigate();
 
@@ -425,37 +21,34 @@ const AdvancedTrainingConfig: React.FC = () => {
     (s: any) => s?.simulator?.id === simulatorId,
   );
   const stationSet = stationSets?.find((s: any) => s?.id === stationSetId);
-  const station = stationSet?.stations?.find((s: any) => s?.name === stationName);
+  const station = stationSet?.stations?.find(
+    (s: any) => s?.name === stationName,
+  );
 
   const advancedTraining = (station as any)?.advancedTraining;
   const enabled = advancedTraining?.enabled ?? false;
   const sequentialChapters = advancedTraining?.sequentialChapters ?? false;
   const chapters = advancedTraining?.chapters ?? [];
-
-  const [toggleMode] = useMutation(TOGGLE_ADVANCED_TRAINING_MODE);
-  const [saveConfig] = useMutation(SET_STATION_ADVANCED_TRAINING);
-
-  // Local editing state
-  const [editingChapters, setEditingChapters] = useState<any[] | null>(null);
-  const [editingSequential, setEditingSequential] = useState<boolean | null>(null);
-  const [editingStripPosition, setEditingStripPosition] = useState<"top" | "bottom" | null>(null);
-  const [editingLoginChapter, setEditingLoginChapter] = useState<any | null | undefined>(undefined);
-  const [editingCompletionChapter, setEditingCompletionChapter] = useState<any | null | undefined>(undefined);
-  const [expandedChapter, setExpandedChapter] = useState<string | null>(null);
-  const [recordingSubChapter, setRecordingSubChapter] = useState<string | null>(null);
-  const [mediaPickerChapter, setMediaPickerChapter] = useState<string | null>(null);
-
-  const isEditing = editingChapters !== null;
-  const displayChapters = isEditing ? editingChapters : chapters;
-
-  // undefined = not editing; null = editing with no special chapter; object = editing with chapter
-  const editingLogin = editingLoginChapter !== undefined ? editingLoginChapter : advancedTraining?.loginChapter ?? null;
-  const editingCompletion = editingCompletionChapter !== undefined ? editingCompletionChapter : advancedTraining?.completionChapter ?? null;
-
+  const inFlightChapters = advancedTraining?.inFlightChapters ?? [];
   const stationCards = station?.cards || [];
 
+  const [toggleMode] = useMutation(TOGGLE_ADVANCED_TRAINING_MODE);
+
+  const editor = useAdvancedTrainingConfigEditor({
+    advancedTraining,
+    chapters,
+    inFlightChapters,
+    sequentialChapters,
+    enabled,
+    stationCards,
+    stationSetId,
+    stationName,
+  });
+
   const handleToggle = () => {
-    if (!stationSetId || !stationName) return;
+    if (!stationSetId || !stationName) {
+      return;
+    }
     toggleMode({
       variables: {stationSetID: stationSetId, stationName, enabled: !enabled},
     });
@@ -463,200 +56,11 @@ const AdvancedTrainingConfig: React.FC = () => {
 
   const goBack = () => {
     navigate(
-      `/config/simulator/${simulatorId}/Stations/${stationSetId}/${encodeURI(stationName)}`,
-    );
-  };
-
-  const startEditing = () => {
-    setEditingChapters(JSON.parse(JSON.stringify(chapters)));
-    setEditingSequential(sequentialChapters);
-    setEditingStripPosition(advancedTraining?.stripPosition || "bottom");
-    setEditingLoginChapter(
-      advancedTraining?.loginChapter
-        ? JSON.parse(JSON.stringify(advancedTraining.loginChapter))
-        : null,
-    );
-    setEditingCompletionChapter(
-      advancedTraining?.completionChapter
-        ? JSON.parse(JSON.stringify(advancedTraining.completionChapter))
-        : null,
-    );
-  };
-
-  const cancelEditing = () => {
-    setEditingChapters(null);
-    setEditingSequential(null);
-    setEditingStripPosition(null);
-    setEditingLoginChapter(undefined);
-    setEditingCompletionChapter(undefined);
-    setExpandedChapter(null);
-  };
-
-  const saveEditing = () => {
-    if (!stationSetId || !stationName || !editingChapters) return;
-    saveConfig({
-      variables: {
-        stationSetID: stationSetId,
+      `/config/simulator/${simulatorId}/Stations/${stationSetId}/${encodeURI(
         stationName,
-        config: {
-          enabled,
-          sequentialChapters: editingSequential ?? sequentialChapters,
-          stripPosition: editingStripPosition ?? advancedTraining?.stripPosition ?? "bottom",
-          chapters: editingChapters.map(serializeChapter),
-          loginChapter: editingLogin ? serializeChapter(editingLogin) : null,
-          completionChapter: editingCompletion
-            ? serializeChapter(editingCompletion)
-            : null,
-        },
-      },
-    });
-    setEditingChapters(null);
-    setEditingLoginChapter(undefined);
-    setEditingCompletionChapter(undefined);
-    setExpandedChapter(null);
-  };
-
-  const addChapter = () => {
-    if (!editingChapters) return;
-    const newChapter = emptyChapter(
-      `ch-${Date.now()}`,
-      "New Chapter",
+      )}`,
     );
-    (newChapter as any).cardComponent = stationCards[0]?.component || "";
-    setEditingChapters([...editingChapters, newChapter]);
-    setExpandedChapter(newChapter.id);
   };
-
-  const removeChapter = (chapterId: string) => {
-    if (!editingChapters) return;
-    setEditingChapters(editingChapters.filter((c: any) => c.id !== chapterId));
-    if (expandedChapter === chapterId) setExpandedChapter(null);
-  };
-
-  const updateChapter = useCallback(
-    (chapterId: string, updates: any) => {
-      if (!editingChapters) return;
-      setEditingChapters(
-        editingChapters.map((c: any) =>
-          c.id === chapterId ? {...c, ...updates} : c,
-        ),
-      );
-    },
-    [editingChapters],
-  );
-
-  const addSubChapter = (chapterId: string, isSpecial?: "login" | "completion") => {
-    const newSub = {
-      id: `sc-${Date.now()}`,
-      name: "New Sub-Chapter",
-      requiredActions: [],
-    };
-    if (isSpecial === "login") {
-      setEditingLoginChapter((prev: any) => ({
-        ...prev,
-        subChapters: [...(prev?.subChapters || []), newSub],
-      }));
-    } else if (isSpecial === "completion") {
-      setEditingCompletionChapter((prev: any) => ({
-        ...prev,
-        subChapters: [...(prev?.subChapters || []), newSub],
-      }));
-    } else {
-      if (!editingChapters) return;
-      setEditingChapters(
-        editingChapters.map((c: any) =>
-          c.id === chapterId
-            ? {...c, subChapters: [...(c.subChapters || []), newSub]}
-            : c,
-        ),
-      );
-    }
-  };
-
-  const removeSubChapter = (chapterId: string, subChapterId: string, isSpecial?: "login" | "completion") => {
-    if (isSpecial === "login") {
-      setEditingLoginChapter((prev: any) => ({
-        ...prev,
-        subChapters: prev.subChapters.filter((s: any) => s.id !== subChapterId),
-      }));
-    } else if (isSpecial === "completion") {
-      setEditingCompletionChapter((prev: any) => ({
-        ...prev,
-        subChapters: prev.subChapters.filter((s: any) => s.id !== subChapterId),
-      }));
-    } else {
-      if (!editingChapters) return;
-      setEditingChapters(
-        editingChapters.map((c: any) =>
-          c.id === chapterId
-            ? {...c, subChapters: c.subChapters.filter((s: any) => s.id !== subChapterId)}
-            : c,
-        ),
-      );
-    }
-  };
-
-  const updateSubChapter = (
-    chapterId: string,
-    subChapterId: string,
-    updates: any,
-    isSpecial?: "login" | "completion",
-  ) => {
-    if (isSpecial === "login") {
-      setEditingLoginChapter((prev: any) => ({
-        ...prev,
-        subChapters: prev.subChapters.map((s: any) =>
-          s.id === subChapterId ? {...s, ...updates} : s,
-        ),
-      }));
-    } else if (isSpecial === "completion") {
-      setEditingCompletionChapter((prev: any) => ({
-        ...prev,
-        subChapters: prev.subChapters.map((s: any) =>
-          s.id === subChapterId ? {...s, ...updates} : s,
-        ),
-      }));
-    } else {
-      if (!editingChapters) return;
-      setEditingChapters(
-        editingChapters.map((c: any) =>
-          c.id === chapterId
-            ? {
-                ...c,
-                subChapters: c.subChapters.map((s: any) =>
-                  s.id === subChapterId ? {...s, ...updates} : s,
-                ),
-              }
-            : c,
-        ),
-      );
-    }
-  };
-
-  // Record mode helpers
-  const startRecording = (chapterId: string, subChapterId: string) => {
-    setRecordingSubChapter(`${chapterId}:${subChapterId}`);
-  };
-
-  const cancelRecording = () => {
-    setRecordingSubChapter(null);
-  };
-
-  const saveRecording = (actions: any[]) => {
-    if (!recordingSubChapter || !editingChapters) return;
-    const [chapterId, subChapterId] = recordingSubChapter.split(":");
-    updateSubChapter(chapterId, subChapterId, {requiredActions: actions});
-    setRecordingSubChapter(null);
-  };
-
-  const recordingChapterId = recordingSubChapter?.split(":")[0];
-  const recordingSubChapterId = recordingSubChapter?.split(":")[1];
-  const recordingChapter = editingChapters?.find(
-    (c: any) => c.id === recordingChapterId,
-  );
-  const recordingSubChapterData = recordingChapter?.subChapters?.find(
-    (s: any) => s.id === recordingSubChapterId,
-  );
 
   if (!station) {
     return (
@@ -682,9 +86,7 @@ const AdvancedTrainingConfig: React.FC = () => {
         <Button color="secondary" size="sm" onClick={goBack}>
           &larr; Back
         </Button>
-        <h4 style={{margin: 0}}>
-          Advanced Training &mdash; {stationName}
-        </h4>
+        <h4 style={{margin: 0}}>Advanced Training &mdash; {stationName}</h4>
       </div>
 
       <Label
@@ -712,10 +114,10 @@ const AdvancedTrainingConfig: React.FC = () => {
             borderRadius: "4px",
             padding: "16px",
             overflowY: "auto",
-            height: "85vh"
+            height: "85vh",
           }}
         >
-          {!isEditing ? (
+          {!editor.isEditing ? (
             <>
               <div style={{marginBottom: "8px"}}>
                 <strong>{chapters.length}</strong> chapter
@@ -730,6 +132,12 @@ const AdvancedTrainingConfig: React.FC = () => {
                     + completion chapter
                   </span>
                 )}
+                {inFlightChapters.length > 0 && (
+                  <span style={{marginLeft: "8px", color: "#80deea"}}>
+                    + {inFlightChapters.length} in-flight help chapter
+                    {inFlightChapters.length !== 1 ? "s" : ""}
+                  </span>
+                )}
               </div>
               {chapters.map((ch: any, idx: number) => (
                 <div
@@ -738,265 +146,44 @@ const AdvancedTrainingConfig: React.FC = () => {
                 >
                   {idx + 1}. {ch.name}{" "}
                   <span style={{color: "#888"}}>
-                    ({ch.cardComponent}, {ch.subChapters?.length || 0} sub-tasks)
+                    ({ch.cardComponent}, {ch.subChapters?.length || 0}{" "}
+                    sub-tasks)
+                  </span>
+                </div>
+              ))}
+              {inFlightChapters.map((ch: any) => (
+                <div
+                  key={ch.id}
+                  style={{padding: "4px 8px", fontSize: "13px", color: "#ccc"}}
+                >
+                  <span style={{color: "#80deea"}}>⚑ {ch.name}</span>{" "}
+                  <span style={{color: "#888"}}>
+                    ({ch.cardComponent}, {ch.subChapters?.length || 0}{" "}
+                    sub-tasks)
                   </span>
                 </div>
               ))}
               <Button
                 size="sm"
                 color="info"
-                onClick={startEditing}
+                onClick={editor.startEditing}
                 style={{marginTop: "8px"}}
               >
                 Edit Chapters
               </Button>
             </>
           ) : (
-            <>
-              <FormGroup style={{marginBottom: "12px", display: "flex", gap: "24px", flexWrap: "wrap"}}>
-                <Label check style={{display: "flex", gap: "8px", fontWeight: 500}}>
-                  <input
-                    type="checkbox"
-                    checked={editingSequential ?? sequentialChapters}
-                    onChange={e => setEditingSequential(e.target.checked)}
-                  />
-                  Sequential chapters (lock until previous complete)
-                </Label>
-                <div style={{display: "flex", alignItems: "center", gap: "8px", fontWeight: 500}}>
-                  Training bar:
-                  <Label check style={{display: "flex", gap: "4px", marginBottom: 0, fontWeight: 400}}>
-                    <input
-                      type="radio"
-                      checked={(editingStripPosition ?? "bottom") === "bottom"}
-                      onChange={() => setEditingStripPosition("bottom")}
-                    />
-                    Bottom
-                  </Label>
-                  <Label check style={{display: "flex", gap: "4px", marginBottom: 0, fontWeight: 400}}>
-                    <input
-                      type="radio"
-                      checked={(editingStripPosition ?? "bottom") === "top"}
-                      onChange={() => setEditingStripPosition("top")}
-                    />
-                    Top
-                  </Label>
-                </div>
-              </FormGroup>
-
-              {/* Login chapter */}
-              <div style={{marginBottom: "12px"}}>
-                <Label check style={{display: "flex", gap: "8px", fontWeight: 500, marginBottom: "6px"}}>
-                  <input
-                    type="checkbox"
-                    checked={!!editingLogin}
-                    onChange={e => {
-                      if (e.target.checked) {
-                        setEditingLoginChapter(emptyChapter(`login-${Date.now()}`, "Login Chapter"));
-                      } else {
-                        setEditingLoginChapter(null);
-                        if (expandedChapter === editingLogin?.id) setExpandedChapter(null);
-                      }
-                    }}
-                  />
-                  Login Chapter (shown on login screen before training starts)
-                </Label>
-                {editingLogin && (
-                  <>
-                    <div style={{paddingLeft: "24px", marginBottom: "8px", fontSize: "13px"}}>
-                      <div style={{fontWeight: 500, marginBottom: "4px"}}>Station Login</div>
-                      {(["none", "immediate", "on-complete"] as const).map(opt => (
-                        <Label key={opt} check style={{display: "flex", gap: "6px", marginBottom: "3px", fontWeight: 400}}>
-                          <input
-                            type="radio"
-                            name={`autoLogin-${editingLogin.id}`}
-                            value={opt}
-                            checked={(editingLogin.autoLogin ?? "none") === opt}
-                            onChange={() =>
-                              setEditingLoginChapter((prev: any) => ({...prev, autoLogin: opt}))
-                            }
-                          />
-                          {opt === "none" && "None (crew logs in manually)"}
-                          {opt === "immediate" && "Auto-login when training starts"}
-                          {opt === "on-complete" && "Auto-login after login chapter completes"}
-                        </Label>
-                      ))}
-                    </div>
-                    <ChapterEditor
-                      chapter={editingLogin}
-                      index={-1}
-                      label={`Login: ${editingLogin.name}`}
-                      stationCards={stationCards}
-                      isExpanded={expandedChapter === editingLogin.id}
-                      onToggleExpand={() =>
-                        setExpandedChapter(
-                          expandedChapter === editingLogin.id ? null : editingLogin.id,
-                        )
-                      }
-                      onUpdate={updates =>
-                        setEditingLoginChapter((prev: any) => ({...prev, ...updates}))
-                      }
-                      onAddSubChapter={() => addSubChapter(editingLogin.id, "login")}
-                      onRemoveSubChapter={subId => removeSubChapter(editingLogin.id, subId, "login")}
-                      onUpdateSubChapter={(subId, updates) =>
-                        updateSubChapter(editingLogin.id, subId, updates, "login")
-                      }
-                      onStartRecording={subId => startRecording(editingLogin.id, subId)}
-                      onSetMediaPicker={() => setMediaPickerChapter(`login:${editingLogin.id}`)}
-                      showCardSelector={false}
-                      isLoginChapter
-                    />
-                  </>
-                )}
-              </div>
-
-              {/* Regular chapters */}
-              {displayChapters?.map((chapter: any, chIdx: number) => (
-                <ChapterEditor
-                  key={chapter.id}
-                  chapter={chapter}
-                  index={chIdx}
-                  stationCards={stationCards}
-                  isExpanded={expandedChapter === chapter.id}
-                  onToggleExpand={() =>
-                    setExpandedChapter(
-                      expandedChapter === chapter.id ? null : chapter.id,
-                    )
-                  }
-                  onUpdate={updates => updateChapter(chapter.id, updates)}
-                  onRemove={() => removeChapter(chapter.id)}
-                  onAddSubChapter={() => addSubChapter(chapter.id)}
-                  onRemoveSubChapter={subId => removeSubChapter(chapter.id, subId)}
-                  onUpdateSubChapter={(subId, updates) =>
-                    updateSubChapter(chapter.id, subId, updates)
-                  }
-                  onStartRecording={subId => startRecording(chapter.id, subId)}
-                  onSetMediaPicker={() => setMediaPickerChapter(chapter.id)}
-                />
-              ))}
-
-              {/* Completion chapter */}
-              <div style={{marginTop: "8px", marginBottom: "12px"}}>
-                <Label check style={{display: "flex", gap: "8px", fontWeight: 500, marginBottom: "6px"}}>
-                  <input
-                    type="checkbox"
-                    checked={!!editingCompletion}
-                    onChange={e => {
-                      if (e.target.checked) {
-                        setEditingCompletionChapter(
-                          emptyChapter(`completion-${Date.now()}`, "Training Complete"),
-                        );
-                      } else {
-                        setEditingCompletionChapter(null);
-                        if (expandedChapter === editingCompletion?.id)
-                          setExpandedChapter(null);
-                      }
-                    }}
-                  />
-                  Completion Chapter (shown after all chapters are finished)
-                </Label>
-                {editingCompletion && (
-                  <ChapterEditor
-                    chapter={editingCompletion}
-                    index={displayChapters?.length || 0}
-                    label={`Completion: ${editingCompletion.name}`}
-                    stationCards={stationCards}
-                    isExpanded={expandedChapter === editingCompletion.id}
-                    onToggleExpand={() =>
-                      setExpandedChapter(
-                        expandedChapter === editingCompletion.id
-                          ? null
-                          : editingCompletion.id,
-                      )
-                    }
-                    onUpdate={updates =>
-                      setEditingCompletionChapter((prev: any) => ({...prev, ...updates}))
-                    }
-                    onAddSubChapter={() =>
-                      addSubChapter(editingCompletion.id, "completion")
-                    }
-                    onRemoveSubChapter={subId =>
-                      removeSubChapter(editingCompletion.id, subId, "completion")
-                    }
-                    onUpdateSubChapter={(subId, updates) =>
-                      updateSubChapter(editingCompletion.id, subId, updates, "completion")
-                    }
-                    onStartRecording={subId => startRecording(editingCompletion.id, subId)}
-                    onSetMediaPicker={() =>
-                      setMediaPickerChapter(`completion:${editingCompletion.id}`)
-                    }
-                    showCardSelector={false}
-                  />
-                )}
-              </div>
-
-              <div style={{display: "flex", gap: "8px", marginTop: "8px"}}>
-                <Button size="sm" color="success" outline onClick={addChapter}>
-                  + Add Chapter
-                </Button>
-                <Button size="sm" color="primary" onClick={saveEditing}>
-                  Save
-                </Button>
-                <Button size="sm" color="secondary" outline onClick={cancelEditing}>
-                  Cancel
-                </Button>
-              </div>
-            </>
+            <AdvancedTrainingEditor
+              editor={editor}
+              stationCards={stationCards}
+              sequentialChapters={sequentialChapters}
+              simulatorId={simulatorId || ""}
+              stationSetId={stationSetId || ""}
+              stationName={stationName}
+            />
           )}
         </div>
       )}
-
-      {/* Media picker modal */}
-      <Modal
-        isOpen={!!mediaPickerChapter}
-        toggle={() => setMediaPickerChapter(null)}
-      >
-        <ModalHeader toggle={() => setMediaPickerChapter(null)}>
-          Select Training Media
-        </ModalHeader>
-        <ModalBody>
-          <FileExplorer
-            directory="/Training"
-            selectedFiles={[]}
-            onClick={(_evt: any, container: any) => {
-              if (mediaPickerChapter) {
-                const isLogin = mediaPickerChapter.startsWith("login:");
-                const isCompletion = mediaPickerChapter.startsWith("completion:");
-                if (isLogin) {
-                  setEditingLoginChapter((prev: any) => ({
-                    ...prev,
-                    mediaAsset: container.fullPath,
-                  }));
-                } else if (isCompletion) {
-                  setEditingCompletionChapter((prev: any) => ({
-                    ...prev,
-                    mediaAsset: container.fullPath,
-                  }));
-                } else {
-                  updateChapter(mediaPickerChapter, {mediaAsset: container.fullPath});
-                }
-              }
-              setMediaPickerChapter(null);
-            }}
-          />
-        </ModalBody>
-        <ModalFooter>
-          <Button color="secondary" onClick={() => setMediaPickerChapter(null)}>
-            Cancel
-          </Button>
-        </ModalFooter>
-      </Modal>
-
-      {/* Record actions modal */}
-      <RecordActionsModal
-        isOpen={!!recordingSubChapter}
-        chapter={recordingChapter}
-        existingActions={recordingSubChapterData?.requiredActions || []}
-        simulatorId={simulatorId || ""}
-        stationSetId={stationSetId || ""}
-        stationName={stationName}
-        onSave={saveRecording}
-        onCancel={cancelRecording}
-      />
     </Container>
   );
 };

--- a/src/containers/FlightDirector/SimulatorConfig/config/Stations/AdvancedTrainingConfig.tsx
+++ b/src/containers/FlightDirector/SimulatorConfig/config/Stations/AdvancedTrainingConfig.tsx
@@ -23,7 +23,7 @@ import {
   SET_STATION_ADVANCED_TRAINING,
   TOGGLE_ADVANCED_TRAINING_MODE,
 } from "components/training/queries";
-import {getActionLabel} from "components/training/actionRegistry";
+import {getActionLabel, VIDEO_COMPLETE_EVENT} from "components/training/actionRegistry";
 import RecordActionsModal from "./RecordActionsModal";
 
 const MEDIA_POSITIONS = [
@@ -325,6 +325,38 @@ const ChapterEditor: React.FC<ChapterEditorProps> = ({
                     X
                   </Button>
                 </div>
+                {chapter.mediaAsset && (
+                  <div style={{paddingLeft: "28px"}}>
+                    <Label check style={{display: "flex", gap: "6px", fontSize: "12px", color: "#aaa"}}>
+                      <input
+                        type="checkbox"
+                        checked={(sub.requiredActions || []).some(
+                          (ra: any) => ra.eventName === VIDEO_COMPLETE_EVENT,
+                        )}
+                        onChange={e => {
+                          const current = sub.requiredActions || [];
+                          if (e.target.checked) {
+                            if (!current.some((ra: any) => ra.eventName === VIDEO_COMPLETE_EVENT)) {
+                              onUpdateSubChapter(sub.id, {
+                                requiredActions: [
+                                  ...current,
+                                  {id: `vc-${sub.id}`, eventName: VIDEO_COMPLETE_EVENT},
+                                ],
+                              });
+                            }
+                          } else {
+                            onUpdateSubChapter(sub.id, {
+                              requiredActions: current.filter(
+                                (ra: any) => ra.eventName !== VIDEO_COMPLETE_EVENT,
+                              ),
+                            });
+                          }
+                        }}
+                      />
+                      Require video to finish
+                    </Label>
+                  </div>
+                )}
                 {sub.requiredActions?.length > 0 && (
                   <div style={{paddingLeft: "28px", fontSize: "12px", color: "#aaa"}}>
                     Required:{" "}
@@ -370,6 +402,7 @@ const AdvancedTrainingConfig: React.FC = () => {
   // Local editing state
   const [editingChapters, setEditingChapters] = useState<any[] | null>(null);
   const [editingSequential, setEditingSequential] = useState<boolean | null>(null);
+  const [editingStripPosition, setEditingStripPosition] = useState<"top" | "bottom" | null>(null);
   const [editingLoginChapter, setEditingLoginChapter] = useState<any | null | undefined>(undefined);
   const [editingCompletionChapter, setEditingCompletionChapter] = useState<any | null | undefined>(undefined);
   const [expandedChapter, setExpandedChapter] = useState<string | null>(null);
@@ -401,6 +434,7 @@ const AdvancedTrainingConfig: React.FC = () => {
   const startEditing = () => {
     setEditingChapters(JSON.parse(JSON.stringify(chapters)));
     setEditingSequential(sequentialChapters);
+    setEditingStripPosition(advancedTraining?.stripPosition || "bottom");
     setEditingLoginChapter(
       advancedTraining?.loginChapter
         ? JSON.parse(JSON.stringify(advancedTraining.loginChapter))
@@ -416,6 +450,7 @@ const AdvancedTrainingConfig: React.FC = () => {
   const cancelEditing = () => {
     setEditingChapters(null);
     setEditingSequential(null);
+    setEditingStripPosition(null);
     setEditingLoginChapter(undefined);
     setEditingCompletionChapter(undefined);
     setExpandedChapter(null);
@@ -430,6 +465,7 @@ const AdvancedTrainingConfig: React.FC = () => {
         config: {
           enabled,
           sequentialChapters: editingSequential ?? sequentialChapters,
+          stripPosition: editingStripPosition ?? advancedTraining?.stripPosition ?? "bottom",
           chapters: editingChapters.map(serializeChapter),
           loginChapter: editingLogin ? serializeChapter(editingLogin) : null,
           completionChapter: editingCompletion
@@ -639,6 +675,8 @@ const AdvancedTrainingConfig: React.FC = () => {
             border: "1px solid rgba(0,188,212,0.3)",
             borderRadius: "4px",
             padding: "16px",
+            overflowY: "auto",
+            height: "85vh"
           }}
         >
           {!isEditing ? (
@@ -679,7 +717,7 @@ const AdvancedTrainingConfig: React.FC = () => {
             </>
           ) : (
             <>
-              <FormGroup style={{marginBottom: "12px"}}>
+              <FormGroup style={{marginBottom: "12px", display: "flex", gap: "24px", flexWrap: "wrap"}}>
                 <Label check style={{display: "flex", gap: "8px", fontWeight: 500}}>
                   <input
                     type="checkbox"
@@ -688,6 +726,25 @@ const AdvancedTrainingConfig: React.FC = () => {
                   />
                   Sequential chapters (lock until previous complete)
                 </Label>
+                <div style={{display: "flex", alignItems: "center", gap: "8px", fontWeight: 500}}>
+                  Training bar:
+                  <Label check style={{display: "flex", gap: "4px", marginBottom: 0, fontWeight: 400}}>
+                    <input
+                      type="radio"
+                      checked={(editingStripPosition ?? "bottom") === "bottom"}
+                      onChange={() => setEditingStripPosition("bottom")}
+                    />
+                    Bottom
+                  </Label>
+                  <Label check style={{display: "flex", gap: "4px", marginBottom: 0, fontWeight: 400}}>
+                    <input
+                      type="radio"
+                      checked={(editingStripPosition ?? "bottom") === "top"}
+                      onChange={() => setEditingStripPosition("top")}
+                    />
+                    Top
+                  </Label>
+                </div>
               </FormGroup>
 
               {/* Login chapter */}

--- a/src/containers/FlightDirector/SimulatorConfig/config/Stations/AdvancedTrainingEditor.tsx
+++ b/src/containers/FlightDirector/SimulatorConfig/config/Stations/AdvancedTrainingEditor.tsx
@@ -1,0 +1,425 @@
+import React from "react";
+import {
+  Button,
+  Input,
+  Label,
+  FormGroup,
+  Modal,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+} from "helpers/reactstrap";
+import FileExplorer from "components/views/TacticalMap/fileExplorer";
+import {ChapterEditor, emptyChapter} from "./ChapterEditor";
+import InFlightChaptersSection from "./InFlightChaptersSection";
+import RecordActionsModal from "./RecordActionsModal";
+import type {useAdvancedTrainingConfigEditor} from "./useAdvancedTrainingConfigEditor";
+
+interface AdvancedTrainingEditorProps {
+  editor: ReturnType<typeof useAdvancedTrainingConfigEditor>;
+  stationCards: any[];
+  sequentialChapters: boolean;
+  simulatorId: string;
+  stationSetId: string;
+  stationName: string;
+}
+
+// The "edit chapters" UI for the Advanced Training config page: training-wide
+// settings, the optional login/completion chapters, the regular chapter list,
+// the in-flight help section, and the media-picker / action-recording modals.
+// All state and handlers come from the editor hook passed in as a prop.
+const AdvancedTrainingEditor: React.FC<AdvancedTrainingEditorProps> = ({
+  editor,
+  stationCards,
+  sequentialChapters,
+  simulatorId,
+  stationSetId,
+  stationName,
+}) => {
+  const {
+    displayChapters,
+    editingInFlightChapters,
+    editingSequential,
+    setEditingSequential,
+    editingStripPosition,
+    setEditingStripPosition,
+    editingLogin,
+    setEditingLoginChapter,
+    editingCompletion,
+    setEditingCompletionChapter,
+    expandedChapter,
+    toggleExpand,
+    setExpandedChapter,
+    mediaPickerChapter,
+    setMediaPickerChapter,
+    saveEditing,
+    cancelEditing,
+    addChapter,
+    removeChapter,
+    updateChapter,
+    addInFlightChapter,
+    removeInFlightChapter,
+    updateInFlightChapter,
+    addSubChapter,
+    removeSubChapter,
+    updateSubChapter,
+    recordingSubChapter,
+    recordingChapter,
+    recordingSubChapterData,
+    startRecording,
+    cancelRecording,
+    saveRecording,
+  } = editor;
+
+  return (
+    <>
+      <FormGroup
+        style={{
+          marginBottom: "12px",
+          display: "flex",
+          gap: "24px",
+          flexWrap: "wrap",
+        }}
+      >
+        <Label check style={{display: "flex", gap: "8px", fontWeight: 500}}>
+          <input
+            type="checkbox"
+            checked={editingSequential ?? sequentialChapters}
+            onChange={e => setEditingSequential(e.target.checked)}
+          />
+          Sequential chapters (lock until previous complete)
+        </Label>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "8px",
+            fontWeight: 500,
+          }}
+        >
+          Training bar:
+          <Label
+            check
+            style={{
+              display: "flex",
+              gap: "4px",
+              marginBottom: 0,
+              fontWeight: 400,
+            }}
+          >
+            <input
+              type="radio"
+              checked={(editingStripPosition ?? "bottom") === "bottom"}
+              onChange={() => setEditingStripPosition("bottom")}
+            />
+            Bottom
+          </Label>
+          <Label
+            check
+            style={{
+              display: "flex",
+              gap: "4px",
+              marginBottom: 0,
+              fontWeight: 400,
+            }}
+          >
+            <input
+              type="radio"
+              checked={(editingStripPosition ?? "bottom") === "top"}
+              onChange={() => setEditingStripPosition("top")}
+            />
+            Top
+          </Label>
+        </div>
+      </FormGroup>
+
+      {/* Login chapter */}
+      <div style={{marginBottom: "12px"}}>
+        <Label
+          check
+          style={{
+            display: "flex",
+            gap: "8px",
+            fontWeight: 500,
+            marginBottom: "6px",
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={!!editingLogin}
+            onChange={e => {
+              if (e.target.checked) {
+                setEditingLoginChapter(
+                  emptyChapter(`login-${Date.now()}`, "Login Chapter"),
+                );
+              } else {
+                setEditingLoginChapter(null);
+                if (expandedChapter === editingLogin?.id) {
+                  setExpandedChapter(null);
+                }
+              }
+            }}
+          />
+          Login Chapter (shown on login screen before training starts)
+        </Label>
+        {editingLogin && (
+          <>
+            <div
+              style={{
+                paddingLeft: "24px",
+                marginBottom: "8px",
+                fontSize: "13px",
+              }}
+            >
+              <div style={{fontWeight: 500, marginBottom: "4px"}}>
+                Station Login
+              </div>
+              {(["none", "immediate", "on-complete"] as const).map(opt => (
+                <Label
+                  key={opt}
+                  check
+                  style={{
+                    display: "flex",
+                    gap: "6px",
+                    marginBottom: "3px",
+                    fontWeight: 400,
+                  }}
+                >
+                  <input
+                    type="radio"
+                    name={`autoLogin-${editingLogin.id}`}
+                    value={opt}
+                    checked={(editingLogin.autoLogin ?? "none") === opt}
+                    onChange={() =>
+                      setEditingLoginChapter((prev: any) => ({
+                        ...prev,
+                        autoLogin: opt,
+                      }))
+                    }
+                  />
+                  {opt === "none" && "None (crew logs in manually)"}
+                  {opt === "immediate" && "Auto-login when training starts"}
+                  {opt === "on-complete" &&
+                    "Auto-login after login chapter completes"}
+                </Label>
+              ))}
+            </div>
+            <ChapterEditor
+              chapter={editingLogin}
+              index={-1}
+              label={`Login: ${editingLogin.name}`}
+              stationCards={stationCards}
+              isExpanded={expandedChapter === editingLogin.id}
+              onToggleExpand={() => toggleExpand(editingLogin.id)}
+              onUpdate={updates =>
+                setEditingLoginChapter((prev: any) => ({...prev, ...updates}))
+              }
+              onAddSubChapter={() => addSubChapter(editingLogin.id, "login")}
+              onRemoveSubChapter={subId =>
+                removeSubChapter(editingLogin.id, subId, "login")
+              }
+              onUpdateSubChapter={(subId, updates) =>
+                updateSubChapter(editingLogin.id, subId, updates, "login")
+              }
+              onStartRecording={subId => startRecording(editingLogin.id, subId)}
+              onSetMediaPicker={() =>
+                setMediaPickerChapter(`login:${editingLogin.id}`)
+              }
+              showCardSelector={false}
+              isLoginChapter
+            />
+          </>
+        )}
+      </div>
+
+      {/* Regular chapters */}
+      {displayChapters?.map((chapter: any, chIdx: number) => (
+        <ChapterEditor
+          key={chapter.id}
+          chapter={chapter}
+          index={chIdx}
+          stationCards={stationCards}
+          isExpanded={expandedChapter === chapter.id}
+          onToggleExpand={() => toggleExpand(chapter.id)}
+          onUpdate={updates => updateChapter(chapter.id, updates)}
+          onRemove={() => removeChapter(chapter.id)}
+          onAddSubChapter={() => addSubChapter(chapter.id)}
+          onRemoveSubChapter={subId => removeSubChapter(chapter.id, subId)}
+          onUpdateSubChapter={(subId, updates) =>
+            updateSubChapter(chapter.id, subId, updates)
+          }
+          onStartRecording={subId => startRecording(chapter.id, subId)}
+          onSetMediaPicker={() => setMediaPickerChapter(chapter.id)}
+        />
+      ))}
+
+      {/* In-flight help chapters */}
+      <InFlightChaptersSection
+        chapters={editingInFlightChapters || []}
+        stationCards={stationCards}
+        expandedChapter={expandedChapter}
+        onToggleExpand={toggleExpand}
+        onAdd={addInFlightChapter}
+        onRemove={removeInFlightChapter}
+        onUpdate={updateInFlightChapter}
+        onAddSubChapter={chapterId => addSubChapter(chapterId, "inflight")}
+        onRemoveSubChapter={(chapterId, subId) =>
+          removeSubChapter(chapterId, subId, "inflight")
+        }
+        onUpdateSubChapter={(chapterId, subId, updates) =>
+          updateSubChapter(chapterId, subId, updates, "inflight")
+        }
+        onStartRecording={(chapterId, subId) =>
+          startRecording(chapterId, subId)
+        }
+        onSetMediaPicker={chapterId =>
+          setMediaPickerChapter(`inflight:${chapterId}`)
+        }
+      />
+
+      {/* Completion chapter */}
+      <div style={{marginTop: "8px", marginBottom: "12px"}}>
+        <Label
+          check
+          style={{
+            display: "flex",
+            gap: "8px",
+            fontWeight: 500,
+            marginBottom: "6px",
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={!!editingCompletion}
+            onChange={e => {
+              if (e.target.checked) {
+                setEditingCompletionChapter(
+                  emptyChapter(`completion-${Date.now()}`, "Training Complete"),
+                );
+              } else {
+                setEditingCompletionChapter(null);
+                if (expandedChapter === editingCompletion?.id) {
+                  setExpandedChapter(null);
+                }
+              }
+            }}
+          />
+          Completion Chapter (shown after all chapters are finished)
+        </Label>
+        {editingCompletion && (
+          <ChapterEditor
+            chapter={editingCompletion}
+            index={displayChapters?.length || 0}
+            label={`Completion: ${editingCompletion.name}`}
+            stationCards={stationCards}
+            isExpanded={expandedChapter === editingCompletion.id}
+            onToggleExpand={() => toggleExpand(editingCompletion.id)}
+            onUpdate={updates =>
+              setEditingCompletionChapter((prev: any) => ({
+                ...prev,
+                ...updates,
+              }))
+            }
+            onAddSubChapter={() =>
+              addSubChapter(editingCompletion.id, "completion")
+            }
+            onRemoveSubChapter={subId =>
+              removeSubChapter(editingCompletion.id, subId, "completion")
+            }
+            onUpdateSubChapter={(subId, updates) =>
+              updateSubChapter(
+                editingCompletion.id,
+                subId,
+                updates,
+                "completion",
+              )
+            }
+            onStartRecording={subId =>
+              startRecording(editingCompletion.id, subId)
+            }
+            onSetMediaPicker={() =>
+              setMediaPickerChapter(`completion:${editingCompletion.id}`)
+            }
+            showCardSelector={false}
+          />
+        )}
+      </div>
+
+      <div style={{display: "flex", gap: "8px", marginTop: "8px"}}>
+        <Button size="sm" color="success" outline onClick={addChapter}>
+          + Add Chapter
+        </Button>
+        <Button size="sm" color="primary" onClick={saveEditing}>
+          Save
+        </Button>
+        <Button size="sm" color="secondary" outline onClick={cancelEditing}>
+          Cancel
+        </Button>
+      </div>
+
+      {/* Media picker modal */}
+      <Modal
+        isOpen={!!mediaPickerChapter}
+        toggle={() => setMediaPickerChapter(null)}
+      >
+        <ModalHeader toggle={() => setMediaPickerChapter(null)}>
+          Select Training Media
+        </ModalHeader>
+        <ModalBody>
+          <FileExplorer
+            directory="/Training"
+            selectedFiles={[]}
+            onClick={(_evt: any, container: any) => {
+              if (mediaPickerChapter) {
+                const isLogin = mediaPickerChapter.startsWith("login:");
+                const isCompletion =
+                  mediaPickerChapter.startsWith("completion:");
+                const isInFlight = mediaPickerChapter.startsWith("inflight:");
+                if (isLogin) {
+                  setEditingLoginChapter((prev: any) => ({
+                    ...prev,
+                    mediaAsset: container.fullPath,
+                  }));
+                } else if (isCompletion) {
+                  setEditingCompletionChapter((prev: any) => ({
+                    ...prev,
+                    mediaAsset: container.fullPath,
+                  }));
+                } else if (isInFlight) {
+                  updateInFlightChapter(
+                    mediaPickerChapter.slice("inflight:".length),
+                    {mediaAsset: container.fullPath},
+                  );
+                } else {
+                  updateChapter(mediaPickerChapter, {
+                    mediaAsset: container.fullPath,
+                  });
+                }
+              }
+              setMediaPickerChapter(null);
+            }}
+          />
+        </ModalBody>
+        <ModalFooter>
+          <Button color="secondary" onClick={() => setMediaPickerChapter(null)}>
+            Cancel
+          </Button>
+        </ModalFooter>
+      </Modal>
+
+      {/* Record actions modal */}
+      <RecordActionsModal
+        isOpen={!!recordingSubChapter}
+        chapter={recordingChapter}
+        existingActions={recordingSubChapterData?.requiredActions || []}
+        simulatorId={simulatorId}
+        stationSetId={stationSetId}
+        stationName={stationName}
+        onSave={saveRecording}
+        onCancel={cancelRecording}
+      />
+    </>
+  );
+};
+
+export default AdvancedTrainingEditor;

--- a/src/containers/FlightDirector/SimulatorConfig/config/Stations/CardPreviewErrorBoundary.tsx
+++ b/src/containers/FlightDirector/SimulatorConfig/config/Stations/CardPreviewErrorBoundary.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+
+// Error boundary around the live card preview in the Record Actions modal.
+// A card component can throw when rendered outside a real flight; this shows the
+// error instead of crashing the modal, and reminds the FD they can still pick
+// actions from the list.
+class CardPreviewErrorBoundary extends React.Component<
+  {children: React.ReactNode; cardName: string},
+  {error: Error | null}
+> {
+  state = {error: null as Error | null};
+
+  static getDerivedStateFromError(error: Error) {
+    return {error};
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            height: "100%",
+            color: "#f44336",
+            padding: "20px",
+            textAlign: "center",
+          }}
+        >
+          <p>Unable to render card preview for "{this.props.cardName}".</p>
+          <p style={{fontSize: "12px", color: "#888", marginTop: "8px"}}>
+            {this.state.error.message}
+          </p>
+          <p style={{fontSize: "12px", color: "#666", marginTop: "4px"}}>
+            You can still select actions from the list on the right.
+          </p>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export default CardPreviewErrorBoundary;

--- a/src/containers/FlightDirector/SimulatorConfig/config/Stations/ChapterEditor.tsx
+++ b/src/containers/FlightDirector/SimulatorConfig/config/Stations/ChapterEditor.tsx
@@ -1,0 +1,443 @@
+import React from "react";
+import {
+  Button,
+  Input,
+  Label,
+  FormGroup,
+  Card,
+  CardBody,
+  CardHeader,
+  Collapse,
+} from "helpers/reactstrap";
+import {
+  getActionLabel,
+  VIDEO_COMPLETE_EVENT,
+  LOGIN_EVENT,
+} from "components/training/actionRegistry";
+
+// 3x3 grid of anchor points for positioning a chapter's media overlay.
+const MEDIA_POSITIONS = [
+  "top-left",
+  "top-center",
+  "top-right",
+  "middle-left",
+  "middle-center",
+  "middle-right",
+  "bottom-left",
+  "bottom-center",
+  "bottom-right",
+];
+
+// A blank chapter, used when the FD adds a new chapter of any kind.
+export function emptyChapter(id: string, name: string) {
+  return {
+    id,
+    name,
+    cardComponent: "",
+    mediaAsset: null,
+    autoOpenMedia: false,
+    autoAdvance: false,
+    autoLogin: "none",
+    cardSwitchBehavior: "manual",
+    mediaSize: "small",
+    mediaPosition: "bottom-right",
+    subChapters: [],
+  };
+}
+
+// Normalize a chapter (and its nested sub-chapters/actions) into the exact shape
+// the server mutation expects, dropping any extra client-only fields.
+export function serializeChapter(ch: any) {
+  return {
+    id: ch.id,
+    name: ch.name,
+    cardComponent: ch.cardComponent || "",
+    mediaAsset: ch.mediaAsset || null,
+    autoOpenMedia: ch.autoOpenMedia ?? false,
+    autoAdvance: ch.autoAdvance ?? false,
+    autoLogin: ch.autoLogin ?? "none",
+    cardSwitchBehavior: ch.cardSwitchBehavior || "manual",
+    mediaSize: ch.mediaSize || "small",
+    mediaPosition: ch.mediaPosition || "bottom-right",
+    subChapters: (ch.subChapters || []).map((sc: any) => ({
+      id: sc.id,
+      name: sc.name,
+      requiredActions: (sc.requiredActions || []).map((ra: any) => ({
+        id: ra.id,
+        eventName: ra.eventName,
+        args: ra.args || null,
+      })),
+    })),
+  };
+}
+
+interface SyntheticActionToggleProps {
+  sub: any;
+  eventName: string;
+  idPrefix: string;
+  label: string;
+  onUpdateSubChapter: (subId: string, updates: any) => void;
+}
+
+// Checkbox that adds/removes a single synthetic required action (e.g. "media
+// finished" or "logged in") on a sub-chapter. These actions have no card UI to
+// click, so the FD toggles them directly.
+const SyntheticActionToggle: React.FC<SyntheticActionToggleProps> = ({
+  sub,
+  eventName,
+  idPrefix,
+  label,
+  onUpdateSubChapter,
+}) => {
+  const current = sub.requiredActions || [];
+  const checked = current.some((ra: any) => ra.eventName === eventName);
+  return (
+    <div style={{paddingLeft: "28px"}}>
+      <Label
+        check
+        style={{display: "flex", gap: "6px", fontSize: "12px", color: "#aaa"}}
+      >
+        <input
+          type="checkbox"
+          checked={checked}
+          onChange={e => {
+            if (e.target.checked) {
+              if (!checked) {
+                onUpdateSubChapter(sub.id, {
+                  requiredActions: [
+                    ...current,
+                    {id: `${idPrefix}-${sub.id}`, eventName},
+                  ],
+                });
+              }
+            } else {
+              onUpdateSubChapter(sub.id, {
+                requiredActions: current.filter(
+                  (ra: any) => ra.eventName !== eventName,
+                ),
+              });
+            }
+          }}
+        />
+        {label}
+      </Label>
+    </div>
+  );
+};
+
+interface ChapterEditorProps {
+  chapter: any;
+  index: number;
+  label?: string;
+  stationCards: any[];
+  // When provided, the Card selector uses this explicit list instead of the
+  // station's cards (e.g. in-flight chapters that can target any card component,
+  // including ones not on this station). Each entry is {value, label}.
+  cardOptions?: {value: string; label: string}[];
+  isExpanded: boolean;
+  onToggleExpand: () => void;
+  onUpdate: (updates: any) => void;
+  onRemove?: () => void;
+  onAddSubChapter: () => void;
+  onRemoveSubChapter: (subId: string) => void;
+  onUpdateSubChapter: (subId: string, updates: any) => void;
+  onStartRecording: (subId: string) => void;
+  onSetMediaPicker: () => void;
+  showCardSelector?: boolean;
+  isLoginChapter?: boolean;
+}
+
+export const ChapterEditor: React.FC<ChapterEditorProps> = ({
+  chapter,
+  index,
+  label,
+  stationCards,
+  cardOptions,
+  isExpanded,
+  onToggleExpand,
+  onUpdate,
+  onRemove,
+  onAddSubChapter,
+  onRemoveSubChapter,
+  onUpdateSubChapter,
+  onStartRecording,
+  onSetMediaPicker,
+  showCardSelector = true,
+  isLoginChapter = false,
+}) => {
+  const cardSelectOptions =
+    cardOptions ||
+    stationCards.map((c: any) => ({
+      value: c.component,
+      label: `${c.name} (${c.component})`,
+    }));
+  return (
+    <Card style={{marginBottom: "8px", background: "rgba(0,0,0,0.2)"}}>
+      <CardHeader
+        onClick={onToggleExpand}
+        style={{
+          cursor: "pointer",
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          padding: "8px 12px",
+        }}
+      >
+        <span>
+          <strong>{label || `${index + 1}. ${chapter.name}`}</strong>
+          {showCardSelector && (
+            <small style={{marginLeft: "8px", color: "#888"}}>
+              {chapter.cardComponent}
+            </small>
+          )}
+        </span>
+        {onRemove && (
+          <Button
+            size="sm"
+            color="danger"
+            outline
+            onClick={(e: React.MouseEvent) => {
+              e.stopPropagation();
+              onRemove();
+            }}
+          >
+            Remove
+          </Button>
+        )}
+      </CardHeader>
+      <Collapse isOpen={isExpanded}>
+        <CardBody style={{padding: "12px"}}>
+          <FormGroup>
+            <Label>Chapter Name</Label>
+            <Input
+              value={chapter.name}
+              onChange={e => onUpdate({name: e.target.value})}
+            />
+          </FormGroup>
+          {showCardSelector && (
+            <FormGroup>
+              <Label>Card</Label>
+              <Input
+                type="select"
+                value={chapter.cardComponent}
+                onChange={e => onUpdate({cardComponent: e.target.value})}
+              >
+                <option value="">-- Select Card --</option>
+                {cardSelectOptions.map((c: {value: string; label: string}) => (
+                  <option key={c.value} value={c.value}>
+                    {c.label}
+                  </option>
+                ))}
+              </Input>
+            </FormGroup>
+          )}
+          <FormGroup>
+            <Label>Media Asset: {chapter.mediaAsset || <em>None</em>}</Label>
+            <div style={{display: "flex", gap: "4px"}}>
+              <Button size="sm" color="secondary" onClick={onSetMediaPicker}>
+                Browse
+              </Button>
+              {chapter.mediaAsset && (
+                <Button
+                  size="sm"
+                  color="warning"
+                  onClick={() => onUpdate({mediaAsset: null})}
+                >
+                  Clear
+                </Button>
+              )}
+            </div>
+          </FormGroup>
+          {chapter.mediaAsset && (
+            <FormGroup
+              style={{
+                display: "flex",
+                gap: "16px",
+                alignItems: "flex-start",
+                flexWrap: "wrap",
+              }}
+            >
+              <div>
+                <Label style={{display: "block", marginBottom: "4px"}}>
+                  Media Size
+                </Label>
+                <Input
+                  type="select"
+                  bsSize="sm"
+                  style={{width: "auto"}}
+                  value={chapter.mediaSize || "small"}
+                  onChange={e => onUpdate({mediaSize: e.target.value})}
+                >
+                  <option value="small">Small (25%)</option>
+                  <option value="medium">Medium (40%)</option>
+                  <option value="large">Large (60%)</option>
+                </Input>
+              </div>
+              <div>
+                <Label style={{display: "block", marginBottom: "4px"}}>
+                  Media Position
+                </Label>
+                <div
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: "repeat(3, 28px)",
+                    gap: "3px",
+                  }}
+                >
+                  {MEDIA_POSITIONS.map(pos => (
+                    <button
+                      key={pos}
+                      title={pos}
+                      onClick={() => onUpdate({mediaPosition: pos})}
+                      style={{
+                        width: "28px",
+                        height: "28px",
+                        background:
+                          (chapter.mediaPosition || "bottom-right") === pos
+                            ? "#00bcd4"
+                            : "rgba(255,255,255,0.1)",
+                        border: "1px solid rgba(255,255,255,0.2)",
+                        borderRadius: "3px",
+                        cursor: "pointer",
+                        padding: 0,
+                      }}
+                    />
+                  ))}
+                </div>
+                <div
+                  style={{fontSize: "11px", color: "#78909c", marginTop: "2px"}}
+                >
+                  {chapter.mediaPosition || "bottom-right"}
+                </div>
+              </div>
+            </FormGroup>
+          )}
+          <FormGroup style={{display: "flex", gap: "16px", flexWrap: "wrap"}}>
+            <Label check style={{display: "flex", gap: "4px"}}>
+              <input
+                type="checkbox"
+                checked={chapter.autoOpenMedia ?? false}
+                onChange={e => onUpdate({autoOpenMedia: e.target.checked})}
+              />
+              Auto-open media
+            </Label>
+            <Label check style={{display: "flex", gap: "4px"}}>
+              <input
+                type="checkbox"
+                checked={chapter.autoAdvance ?? false}
+                onChange={e => onUpdate({autoAdvance: e.target.checked})}
+              />
+              Auto-advance
+            </Label>
+            {showCardSelector && (
+              <Label>
+                Card switch:{" "}
+                <Input
+                  type="select"
+                  bsSize="sm"
+                  style={{display: "inline-block", width: "auto"}}
+                  value={chapter.cardSwitchBehavior || "manual"}
+                  onChange={e => onUpdate({cardSwitchBehavior: e.target.value})}
+                >
+                  <option value="manual">Manual</option>
+                  <option value="auto">Auto</option>
+                </Input>
+              </Label>
+            )}
+          </FormGroup>
+
+          {/* Sub-chapters */}
+          <div style={{marginTop: "8px"}}>
+            <Label style={{fontWeight: 600}}>Sub-Chapters</Label>
+            {(chapter.subChapters || []).map((sub: any, sIdx: number) => (
+              <div
+                key={sub.id}
+                style={{
+                  border: "1px solid rgba(255,255,255,0.1)",
+                  borderRadius: "4px",
+                  padding: "8px",
+                  marginBottom: "6px",
+                  background: "rgba(0,0,0,0.15)",
+                }}
+              >
+                <div
+                  style={{
+                    display: "flex",
+                    gap: "8px",
+                    alignItems: "center",
+                    marginBottom: "6px",
+                  }}
+                >
+                  <span style={{color: "#888", minWidth: "20px"}}>
+                    {index + 1}.{sIdx + 1}
+                  </span>
+                  <Input
+                    bsSize="sm"
+                    value={sub.name}
+                    onChange={e =>
+                      onUpdateSubChapter(sub.id, {name: e.target.value})
+                    }
+                    style={{flex: 1}}
+                  />
+                  <Button
+                    size="sm"
+                    color="info"
+                    outline
+                    onClick={() => onStartRecording(sub.id)}
+                  >
+                    Record Actions
+                  </Button>
+                  <Button
+                    size="sm"
+                    color="danger"
+                    outline
+                    onClick={() => onRemoveSubChapter(sub.id)}
+                  >
+                    X
+                  </Button>
+                </div>
+                {chapter.mediaAsset && (
+                  <SyntheticActionToggle
+                    sub={sub}
+                    eventName={VIDEO_COMPLETE_EVENT}
+                    idPrefix="vc"
+                    label="Require media to finish"
+                    onUpdateSubChapter={onUpdateSubChapter}
+                  />
+                )}
+                {isLoginChapter && (
+                  <SyntheticActionToggle
+                    sub={sub}
+                    eventName={LOGIN_EVENT}
+                    idPrefix="li"
+                    label="Require login to proceed"
+                    onUpdateSubChapter={onUpdateSubChapter}
+                  />
+                )}
+                {sub.requiredActions?.length > 0 && (
+                  <div
+                    style={{
+                      paddingLeft: "28px",
+                      fontSize: "12px",
+                      color: "#aaa",
+                    }}
+                  >
+                    Required:{" "}
+                    {sub.requiredActions
+                      .map((ra: any) =>
+                        getActionLabel(ra.eventName, chapter.cardComponent),
+                      )
+                      .join(", ")}
+                  </div>
+                )}
+              </div>
+            ))}
+            <Button size="sm" color="success" outline onClick={onAddSubChapter}>
+              + Add Sub-Chapter
+            </Button>
+          </div>
+        </CardBody>
+      </Collapse>
+    </Card>
+  );
+};

--- a/src/containers/FlightDirector/SimulatorConfig/config/Stations/InFlightChaptersSection.tsx
+++ b/src/containers/FlightDirector/SimulatorConfig/config/Stations/InFlightChaptersSection.tsx
@@ -1,0 +1,116 @@
+import React from "react";
+import {Button} from "helpers/reactstrap";
+import Views from "components/views/index";
+import {ChapterEditor} from "./ChapterEditor";
+
+/**
+ * In-flight help chapters are tied to a card component and reached mid-flight
+ * via the question-mark help widget (rather than the normal sequential flow).
+ * Unlike regular chapters, they may target ANY card component — including cards
+ * not currently on this station — so an FD can pre-author help for a card or
+ * system added later in the flight. The card picker is therefore built from the
+ * full set of known card views, not just the station's cards.
+ */
+
+interface InFlightChaptersSectionProps {
+  chapters: any[];
+  stationCards: any[];
+  expandedChapter: string | null;
+  onToggleExpand: (chapterId: string) => void;
+  onAdd: () => void;
+  onRemove: (chapterId: string) => void;
+  onUpdate: (chapterId: string, updates: any) => void;
+  onAddSubChapter: (chapterId: string) => void;
+  onRemoveSubChapter: (chapterId: string, subId: string) => void;
+  onUpdateSubChapter: (chapterId: string, subId: string, updates: any) => void;
+  onStartRecording: (chapterId: string, subId: string) => void;
+  onSetMediaPicker: (chapterId: string) => void;
+}
+
+// Mirrors CardsTable's view list: every known card component, minus the ones
+// that aren't selectable as a station card.
+function buildCardOptions(
+  stationCards: any[],
+): {value: string; label: string}[] {
+  const onStation = new Set(
+    (stationCards || []).map((c: any) => c.component).filter(Boolean),
+  );
+  return Object.keys(Views)
+    .filter(v => v !== "Offline" && v !== "Login" && v !== "Viewscreen")
+    .sort()
+    .map(component => ({
+      value: component,
+      // ✅ marks components already present on this station (same cue as the
+      // Add-Card picker), while still allowing off-station components.
+      label: `${onStation.has(component) ? "✅ " : ""}${component}`,
+    }));
+}
+
+const InFlightChaptersSection: React.FC<InFlightChaptersSectionProps> = ({
+  chapters,
+  stationCards,
+  expandedChapter,
+  onToggleExpand,
+  onAdd,
+  onRemove,
+  onUpdate,
+  onAddSubChapter,
+  onRemoveSubChapter,
+  onUpdateSubChapter,
+  onStartRecording,
+  onSetMediaPicker,
+}) => {
+  const cardOptions = React.useMemo(
+    () => buildCardOptions(stationCards),
+    [stationCards],
+  );
+
+  return (
+    <div
+      style={{
+        marginTop: "16px",
+        marginBottom: "12px",
+        borderTop: "1px solid rgba(128,222,234,0.25)",
+        paddingTop: "12px",
+      }}
+    >
+      <div style={{fontWeight: 600, marginBottom: "4px"}}>
+        In-Flight Help Chapters
+      </div>
+      <div style={{fontSize: "12px", color: "#90a4ae", marginBottom: "8px"}}>
+        Reached mid-flight by pressing the help (question-mark) widget while on
+        the chapter&apos;s card. Excluded from the normal sequence and from the
+        overall progress bar. Can target any card, including ones not on this
+        station.
+      </div>
+
+      {chapters.map((chapter: any, idx: number) => (
+        <ChapterEditor
+          key={chapter.id}
+          chapter={chapter}
+          index={idx}
+          label={`⚑ ${chapter.name}`}
+          stationCards={stationCards}
+          cardOptions={cardOptions}
+          isExpanded={expandedChapter === chapter.id}
+          onToggleExpand={() => onToggleExpand(chapter.id)}
+          onUpdate={updates => onUpdate(chapter.id, updates)}
+          onRemove={() => onRemove(chapter.id)}
+          onAddSubChapter={() => onAddSubChapter(chapter.id)}
+          onRemoveSubChapter={subId => onRemoveSubChapter(chapter.id, subId)}
+          onUpdateSubChapter={(subId, updates) =>
+            onUpdateSubChapter(chapter.id, subId, updates)
+          }
+          onStartRecording={subId => onStartRecording(chapter.id, subId)}
+          onSetMediaPicker={() => onSetMediaPicker(chapter.id)}
+        />
+      ))}
+
+      <Button size="sm" color="info" outline onClick={onAdd}>
+        + Add In-Flight Help Chapter
+      </Button>
+    </div>
+  );
+};
+
+export default InFlightChaptersSection;

--- a/src/containers/FlightDirector/SimulatorConfig/config/Stations/RecordActionsModal.tsx
+++ b/src/containers/FlightDirector/SimulatorConfig/config/Stations/RecordActionsModal.tsx
@@ -1,0 +1,553 @@
+import React, {useState, useCallback, Suspense, useEffect, useRef} from "react";
+import {
+  Modal,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  Button,
+  Label,
+} from "helpers/reactstrap";
+import Views from "components/views";
+import {
+  getActionsForCard,
+  getActionLabel,
+} from "components/training/actionRegistry";
+import {
+  START_SANDBOX_FLIGHT,
+  DELETE_SANDBOX_FLIGHT,
+  SANDBOX_FLIGHT_SIMULATORS,
+} from "components/training/queries";
+import {useSimulatorUpdateSubscription} from "generated/graphql";
+import {useMutation} from "react-apollo";
+import {useApolloClient} from "@apollo/client";
+import {subscribe} from "helpers/pubsub";
+
+interface RecordActionsModalProps {
+  isOpen: boolean;
+  chapter: any;
+  existingActions: any[];
+  simulatorId: string;
+  stationSetId: string;
+  stationName: string;
+  onSave: (actions: any[]) => void;
+  onCancel: () => void;
+}
+
+// Error boundary that shows the actual error for debugging
+class CardPreviewErrorBoundary extends React.Component<
+  {children: React.ReactNode; cardName: string},
+  {error: Error | null}
+> {
+  state = {error: null as Error | null};
+
+  static getDerivedStateFromError(error: Error) {
+    return {error};
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            height: "100%",
+            color: "#f44336",
+            padding: "20px",
+            textAlign: "center",
+          }}
+        >
+          <p>Unable to render card preview for "{this.props.cardName}".</p>
+          <p style={{fontSize: "12px", color: "#888", marginTop: "8px"}}>
+            {this.state.error.message}
+          </p>
+          <p style={{fontSize: "12px", color: "#666", marginTop: "4px"}}>
+            You can still select actions from the list on the right.
+          </p>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+const RecordActionsModal: React.FC<RecordActionsModalProps> = ({
+  isOpen,
+  chapter,
+  existingActions,
+  simulatorId,
+  stationSetId,
+  stationName,
+  onSave,
+  onCancel,
+}) => {
+  const [recordedActions, setRecordedActions] = useState<any[]>(existingActions);
+  const [lastCaptured, setLastCaptured] = useState<string | null>(null);
+  const lastCapturedTimeout = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+
+  // Sandbox flight state
+  const client = useApolloClient();
+  const [sandboxFlightId, setSandboxFlightId] = useState<string | null>(null);
+  const [sandboxSimulatorId, setSandboxSimulatorId] = useState<string | null>(
+    null,
+  );
+  const [sandboxReady, setSandboxReady] = useState(false);
+  const sandboxFlightIdRef = useRef<string | null>(null);
+
+  const [startFlightMutation] = useMutation(START_SANDBOX_FLIGHT);
+  const [deleteFlightMutation] = useMutation(DELETE_SANDBOX_FLIGHT);
+
+  // Subscribe to the sandbox simulator's data for the card preview
+  const {data: simData} = useSimulatorUpdateSubscription({
+    variables: {simulatorId: sandboxSimulatorId || ""},
+    skip: !sandboxSimulatorId,
+  });
+  const simulator = simData?.simulatorsUpdate?.[0];
+
+  // Create sandbox flight when modal opens
+  useEffect(() => {
+    if (!isOpen) return;
+
+    setRecordedActions(existingActions);
+    setLastCaptured(null);
+    setSandboxReady(false);
+
+    let cancelled = false;
+
+    startFlightMutation({
+      variables: {
+        name: `__sandbox_${Date.now()}`,
+        simulators: [{simulatorId, stationSet: stationSetId}],
+      },
+    })
+      .then(({data}: any) => {
+        if (cancelled) {
+          // Modal closed before flight was created — clean up
+          if (data?.startFlight) {
+            deleteFlightMutation({
+              variables: {flightId: data.startFlight},
+            });
+          }
+          return;
+        }
+        const flightId = data?.startFlight;
+        if (!flightId) return;
+        setSandboxFlightId(flightId);
+        sandboxFlightIdRef.current = flightId;
+
+        // Query for the sandbox simulator ID
+        return client.query({
+          query: SANDBOX_FLIGHT_SIMULATORS,
+          variables: {flightId},
+          fetchPolicy: "network-only",
+        });
+      })
+      .then((result: any) => {
+        if (cancelled || !result) return;
+        const simId = result.data?.flights?.[0]?.simulators?.[0]?.id;
+        if (simId) {
+          setSandboxSimulatorId(simId);
+          setSandboxReady(true);
+        }
+      })
+      .catch((err: any) => {
+        console.error("Failed to create sandbox flight:", err);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Cleanup sandbox on unmount (handles unexpected navigation)
+  useEffect(() => {
+    return () => {
+      const flightId = sandboxFlightIdRef.current;
+      if (flightId) {
+        deleteFlightMutation({
+          variables: {flightId},
+        }).catch(() => {});
+        sandboxFlightIdRef.current = null;
+      }
+    };
+  }, [deleteFlightMutation]);
+
+  const cleanupSandbox = useCallback(() => {
+    const flightId = sandboxFlightIdRef.current;
+    if (flightId) {
+      deleteFlightMutation({
+        variables: {flightId},
+      }).catch(err =>
+        console.error("Failed to delete sandbox flight:", err),
+      );
+      sandboxFlightIdRef.current = null;
+      setSandboxFlightId(null);
+      setSandboxSimulatorId(null);
+      setSandboxReady(false);
+    }
+  }, [deleteFlightMutation]);
+
+  const handleSave = useCallback(() => {
+    cleanupSandbox();
+    onSave(recordedActions);
+  }, [cleanupSandbox, onSave, recordedActions]);
+
+  const handleCancel = useCallback(() => {
+    cleanupSandbox();
+    onCancel();
+  }, [cleanupSandbox, onCancel]);
+
+  const cardComponentName = chapter?.cardComponent;
+  const availableActions = cardComponentName
+    ? getActionsForCard(cardComponentName)
+    : [];
+
+  // Subscribe to ALL mutation-events to capture card interactions
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const unsubscribe = subscribe(
+      "mutation-event",
+      ({event, args}: {event: string; args: any}) => {
+        if (event === "clockSync" || event === "startFlight" || event === "deleteFlight") return;
+        setRecordedActions(prev => {
+          if (prev.find((a: any) => a.eventName === event)) return prev;
+          return [
+            ...prev,
+            {id: `ra-${Date.now()}`, eventName: event, args: args || null},
+          ];
+        });
+
+        // Flash indicator
+        setLastCaptured(event);
+        if (lastCapturedTimeout.current) {
+          clearTimeout(lastCapturedTimeout.current);
+        }
+        lastCapturedTimeout.current = setTimeout(
+          () => setLastCaptured(null),
+          1500,
+        );
+      },
+    );
+
+    return () => {
+      unsubscribe();
+      if (lastCapturedTimeout.current) {
+        clearTimeout(lastCapturedTimeout.current);
+      }
+    };
+  }, [isOpen]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Click handler — captures click events as recordable actions
+  const handlePreviewClick = (e: React.MouseEvent) => {
+    const target = e.target as HTMLElement;
+
+    // Walk up to find the closest interactive element
+    const interactive = target.closest(
+      "button, a, [role='button'], input, select, .btn",
+    ) as HTMLElement | null;
+    const el = interactive || target;
+
+    const tag = el.tagName.toLowerCase();
+    // Ignore clicks on generic containers
+    if (["div", "span", "col", "row", "container", "section"].includes(tag) && !interactive) {
+      return;
+    }
+
+    const text =
+      el.textContent?.trim().replace(/\s+/g, " ").substring(0, 60) ||
+      el.getAttribute("aria-label") ||
+      el.getAttribute("title") ||
+      "";
+
+    if (!text) return;
+
+    // Build a stable identifier and args for this click target
+    const clickEventName = `click:${text}`;
+    const clickArgs = {
+      text,
+      tag,
+      className: el.className
+        ? String(el.className).split(" ").filter(Boolean).slice(0, 3).join(" ")
+        : null,
+    };
+
+    // Add to recorded actions (skip duplicates)
+    setRecordedActions(prev => {
+      if (prev.find((a: any) => a.eventName === clickEventName)) return prev;
+      return [
+        ...prev,
+        {id: `ra-${Date.now()}`, eventName: clickEventName, args: clickArgs},
+      ];
+    });
+
+    // Flash indicator
+    setLastCaptured(clickEventName);
+    if (lastCapturedTimeout.current) clearTimeout(lastCapturedTimeout.current);
+    lastCapturedTimeout.current = setTimeout(
+      () => setLastCaptured(null),
+      1500,
+    );
+  };
+
+  const CardComponent = cardComponentName
+    ? (Views as any)[cardComponentName]
+    : null;
+
+  const addAction = (eventName: string) => {
+    if (recordedActions.find((a: any) => a.eventName === eventName)) return;
+    setRecordedActions(prev => [
+      ...prev,
+      {id: `ra-${Date.now()}`, eventName, args: null},
+    ]);
+  };
+
+  const removeAction = (actionId: string) => {
+    setRecordedActions(prev => prev.filter((a: any) => a.id !== actionId));
+  };
+
+  // Build preview props using the sandbox simulator
+  const effectiveSimId = sandboxSimulatorId || simulatorId;
+  const previewProps = {
+    simulator: simulator || {id: effectiveSimId, name: "Preview", alertlevel: "5"},
+    station: {name: stationName, cards: []},
+    flight: {id: sandboxFlightId || "preview"},
+    clientObj: {
+      id: "preview-client",
+      simulatorId: effectiveSimId,
+      station: stationName,
+      training: false,
+      offlineState: null,
+    },
+    cardName: cardComponentName,
+    changeCard: () => {},
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      toggle={handleCancel}
+      size="xl"
+      style={{maxWidth: "90vw"}}
+    >
+      <ModalHeader toggle={handleCancel}>
+        <span
+          style={{
+            color: "#f44336",
+            marginRight: "8px",
+            animation: "pulse 1.5s infinite",
+          }}
+        >
+          &#x25CF; REC
+        </span>
+        Record Required Actions
+        {chapter && (
+          <small
+            style={{display: "block", fontWeight: "normal", color: "#888"}}
+          >
+            Card: {cardComponentName}
+          </small>
+        )}
+      </ModalHeader>
+      <ModalBody>
+        <div style={{display: "flex", gap: "16px", minHeight: "500px"}}>
+          {/* Left: Card Preview — interactive for recording */}
+          {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
+          <div
+            className="record-card-preview"
+            onClick={handlePreviewClick}
+            style={{
+              flex: 2,
+              border: "2px solid #f44336",
+              borderRadius: "4px",
+              position: "relative",
+              overflow: "hidden",
+              background: "#1a1a2e",
+            }}
+          >
+            {/* Recording flash overlay */}
+            {lastCaptured && (
+              <div
+                style={{
+                  position: "absolute",
+                  top: "8px",
+                  left: "8px",
+                  right: "8px",
+                  zIndex: 1000,
+                  padding: "6px 12px",
+                  background: "rgba(0,188,212,0.9)",
+                  borderRadius: "4px",
+                  color: "#fff",
+                  fontSize: "13px",
+                  textAlign: "center",
+                  pointerEvents: "none",
+                }}
+              >
+                Captured: {getActionLabel(lastCaptured, cardComponentName)}
+              </div>
+            )}
+
+            {!sandboxReady ? (
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  height: "100%",
+                  color: "#888",
+                }}
+              >
+                Initializing sandbox environment...
+              </div>
+            ) : CardComponent ? (
+              <Suspense
+                fallback={
+                  <div
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      height: "100%",
+                      color: "#888",
+                    }}
+                  >
+                    Loading card preview...
+                  </div>
+                }
+              >
+                <CardPreviewErrorBoundary cardName={cardComponentName}>
+                  <div
+                    style={{
+                      width: "100%",
+                      height: "100%",
+                      minHeight: "500px",
+                      position: "relative",
+                    }}
+                  >
+                    <CardComponent {...previewProps} />
+                  </div>
+                </CardPreviewErrorBoundary>
+              </Suspense>
+            ) : (
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  height: "100%",
+                  color: "#888",
+                }}
+              >
+                No card component selected for this chapter.
+              </div>
+            )}
+          </div>
+
+          {/* Right: Action Picker */}
+          <div style={{flex: 1, minWidth: "280px"}}>
+            <p style={{fontSize: "13px", color: "#aaa", marginBottom: "8px"}}>
+              Interact with the card on the left to automatically record
+              actions, or manually select them below.
+            </p>
+
+            <div style={{marginBottom: "16px"}}>
+              <Label style={{fontWeight: 600}}>Available Actions</Label>
+              <div
+                style={{display: "flex", flexDirection: "column", gap: "4px"}}
+              >
+                {availableActions.length === 0 && (
+                  <span style={{color: "#888", fontSize: "13px"}}>
+                    No actions registered for this card component.
+                  </span>
+                )}
+                {availableActions.map(action => {
+                  const isSelected = recordedActions.some(
+                    (ra: any) => ra.eventName === action.eventName,
+                  );
+                  return (
+                    <Button
+                      key={action.eventName}
+                      size="sm"
+                      color={isSelected ? "info" : "secondary"}
+                      outline={!isSelected}
+                      style={{textAlign: "left"}}
+                      onClick={() => {
+                        if (isSelected) {
+                          const existing = recordedActions.find(
+                            (ra: any) => ra.eventName === action.eventName,
+                          );
+                          if (existing) removeAction(existing.id);
+                        } else {
+                          addAction(action.eventName);
+                        }
+                      }}
+                    >
+                      {action.label}
+                    </Button>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div>
+              <Label style={{fontWeight: 600}}>
+                Required Actions ({recordedActions.length})
+              </Label>
+              {recordedActions.length === 0 && (
+                <p style={{color: "#888", fontSize: "13px"}}>
+                  No actions recorded yet. Click buttons on the card or select
+                  actions above.
+                </p>
+              )}
+              {recordedActions.map((action: any) => (
+                <div
+                  key={action.id}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "8px",
+                    padding: "6px 8px",
+                    marginBottom: "4px",
+                    background: "rgba(0,188,212,0.1)",
+                    borderRadius: "4px",
+                  }}
+                >
+                  <span style={{flex: 1}}>
+                    {getActionLabel(action.eventName, cardComponentName)}
+                  </span>
+                  <Button
+                    size="sm"
+                    color="danger"
+                    outline
+                    onClick={() => removeAction(action.id)}
+                  >
+                    X
+                  </Button>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </ModalBody>
+      <ModalFooter>
+        <Button color="primary" onClick={handleSave}>
+          Save Actions
+        </Button>
+        <Button color="secondary" onClick={handleCancel}>
+          Cancel
+        </Button>
+      </ModalFooter>
+      <style>{`
+        .record-card-preview * {
+          pointer-events: auto !important;
+        }
+      `}</style>
+    </Modal>
+  );
+};
+
+export default RecordActionsModal;

--- a/src/containers/FlightDirector/SimulatorConfig/config/Stations/RecordActionsModal.tsx
+++ b/src/containers/FlightDirector/SimulatorConfig/config/Stations/RecordActionsModal.tsx
@@ -10,6 +10,7 @@ import {
 import Views from "components/views";
 import {
   getActionsForCard,
+  getGlobalActions,
   getActionLabel,
 } from "components/training/actionRegistry";
 import {
@@ -202,9 +203,10 @@ const RecordActionsModal: React.FC<RecordActionsModalProps> = ({
   }, [cleanupSandbox, onCancel]);
 
   const cardComponentName = chapter?.cardComponent;
-  const availableActions = cardComponentName
-    ? getActionsForCard(cardComponentName)
-    : [];
+  const availableActions = [
+    ...getGlobalActions(),
+    ...(cardComponentName ? getActionsForCard(cardComponentName) : []),
+  ];
 
   // Subscribe to ALL mutation-events to capture card interactions
   useEffect(() => {
@@ -391,7 +393,7 @@ const RecordActionsModal: React.FC<RecordActionsModalProps> = ({
               </div>
             )}
 
-            {!sandboxReady ? (
+            {!sandboxReady || !simulator ? (
               <div
                 style={{
                   display: "flex",

--- a/src/containers/FlightDirector/SimulatorConfig/config/Stations/RecordActionsModal.tsx
+++ b/src/containers/FlightDirector/SimulatorConfig/config/Stations/RecordActionsModal.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useCallback, Suspense, useEffect, useRef} from "react";
+import React, {useCallback, Suspense} from "react";
 import {
   Modal,
   ModalHeader,
@@ -13,15 +13,9 @@ import {
   getGlobalActions,
   getActionLabel,
 } from "components/training/actionRegistry";
-import {
-  START_SANDBOX_FLIGHT,
-  DELETE_SANDBOX_FLIGHT,
-  SANDBOX_FLIGHT_SIMULATORS,
-} from "components/training/queries";
-import {useSimulatorUpdateSubscription} from "generated/graphql";
-import {useMutation} from "react-apollo";
-import {useApolloClient} from "@apollo/client";
-import {subscribe} from "helpers/pubsub";
+import CardPreviewErrorBoundary from "./CardPreviewErrorBoundary";
+import {useSandboxFlight} from "./useSandboxFlight";
+import {useActionRecorder} from "./useActionRecorder";
 
 interface RecordActionsModalProps {
   isOpen: boolean;
@@ -34,45 +28,14 @@ interface RecordActionsModalProps {
   onCancel: () => void;
 }
 
-// Error boundary that shows the actual error for debugging
-class CardPreviewErrorBoundary extends React.Component<
-  {children: React.ReactNode; cardName: string},
-  {error: Error | null}
-> {
-  state = {error: null as Error | null};
-
-  static getDerivedStateFromError(error: Error) {
-    return {error};
-  }
-
-  render() {
-    if (this.state.error) {
-      return (
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            justifyContent: "center",
-            height: "100%",
-            color: "#f44336",
-            padding: "20px",
-            textAlign: "center",
-          }}
-        >
-          <p>Unable to render card preview for "{this.props.cardName}".</p>
-          <p style={{fontSize: "12px", color: "#888", marginTop: "8px"}}>
-            {this.state.error.message}
-          </p>
-          <p style={{fontSize: "12px", color: "#666", marginTop: "4px"}}>
-            You can still select actions from the list on the right.
-          </p>
-        </div>
-      );
-    }
-    return this.props.children;
-  }
-}
+// Shared style for the centered status messages inside the preview pane.
+const previewMessageStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  height: "100%",
+  color: "#888",
+};
 
 const RecordActionsModal: React.FC<RecordActionsModalProps> = ({
   isOpen,
@@ -84,113 +47,16 @@ const RecordActionsModal: React.FC<RecordActionsModalProps> = ({
   onSave,
   onCancel,
 }) => {
-  const [recordedActions, setRecordedActions] = useState<any[]>(existingActions);
-  const [lastCaptured, setLastCaptured] = useState<string | null>(null);
-  const lastCapturedTimeout = useRef<ReturnType<typeof setTimeout> | null>(
-    null,
-  );
+  const {
+    sandboxFlightId,
+    sandboxSimulatorId,
+    sandboxReady,
+    simulator,
+    cleanupSandbox,
+  } = useSandboxFlight({isOpen, simulatorId, stationSetId});
 
-  // Sandbox flight state
-  const client = useApolloClient();
-  const [sandboxFlightId, setSandboxFlightId] = useState<string | null>(null);
-  const [sandboxSimulatorId, setSandboxSimulatorId] = useState<string | null>(
-    null,
-  );
-  const [sandboxReady, setSandboxReady] = useState(false);
-  const sandboxFlightIdRef = useRef<string | null>(null);
-
-  const [startFlightMutation] = useMutation(START_SANDBOX_FLIGHT);
-  const [deleteFlightMutation] = useMutation(DELETE_SANDBOX_FLIGHT);
-
-  // Subscribe to the sandbox simulator's data for the card preview
-  const {data: simData} = useSimulatorUpdateSubscription({
-    variables: {simulatorId: sandboxSimulatorId || ""},
-    skip: !sandboxSimulatorId,
-  });
-  const simulator = simData?.simulatorsUpdate?.[0];
-
-  // Create sandbox flight when modal opens
-  useEffect(() => {
-    if (!isOpen) return;
-
-    setRecordedActions(existingActions);
-    setLastCaptured(null);
-    setSandboxReady(false);
-
-    let cancelled = false;
-
-    startFlightMutation({
-      variables: {
-        name: `__sandbox_${Date.now()}`,
-        simulators: [{simulatorId, stationSet: stationSetId}],
-      },
-    })
-      .then(({data}: any) => {
-        if (cancelled) {
-          // Modal closed before flight was created — clean up
-          if (data?.startFlight) {
-            deleteFlightMutation({
-              variables: {flightId: data.startFlight},
-            });
-          }
-          return;
-        }
-        const flightId = data?.startFlight;
-        if (!flightId) return;
-        setSandboxFlightId(flightId);
-        sandboxFlightIdRef.current = flightId;
-
-        // Query for the sandbox simulator ID
-        return client.query({
-          query: SANDBOX_FLIGHT_SIMULATORS,
-          variables: {flightId},
-          fetchPolicy: "network-only",
-        });
-      })
-      .then((result: any) => {
-        if (cancelled || !result) return;
-        const simId = result.data?.flights?.[0]?.simulators?.[0]?.id;
-        if (simId) {
-          setSandboxSimulatorId(simId);
-          setSandboxReady(true);
-        }
-      })
-      .catch((err: any) => {
-        console.error("Failed to create sandbox flight:", err);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [isOpen]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  // Cleanup sandbox on unmount (handles unexpected navigation)
-  useEffect(() => {
-    return () => {
-      const flightId = sandboxFlightIdRef.current;
-      if (flightId) {
-        deleteFlightMutation({
-          variables: {flightId},
-        }).catch(() => {});
-        sandboxFlightIdRef.current = null;
-      }
-    };
-  }, [deleteFlightMutation]);
-
-  const cleanupSandbox = useCallback(() => {
-    const flightId = sandboxFlightIdRef.current;
-    if (flightId) {
-      deleteFlightMutation({
-        variables: {flightId},
-      }).catch(err =>
-        console.error("Failed to delete sandbox flight:", err),
-      );
-      sandboxFlightIdRef.current = null;
-      setSandboxFlightId(null);
-      setSandboxSimulatorId(null);
-      setSandboxReady(false);
-    }
-  }, [deleteFlightMutation]);
+  const {recordedActions, lastCaptured, captureClick, addAction, removeAction} =
+    useActionRecorder({isOpen, existingActions});
 
   const handleSave = useCallback(() => {
     cleanupSandbox();
@@ -208,114 +74,18 @@ const RecordActionsModal: React.FC<RecordActionsModalProps> = ({
     ...(cardComponentName ? getActionsForCard(cardComponentName) : []),
   ];
 
-  // Subscribe to ALL mutation-events to capture card interactions
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const unsubscribe = subscribe(
-      "mutation-event",
-      ({event, args}: {event: string; args: any}) => {
-        if (event === "clockSync" || event === "startFlight" || event === "deleteFlight") return;
-        setRecordedActions(prev => {
-          if (prev.find((a: any) => a.eventName === event)) return prev;
-          return [
-            ...prev,
-            {id: `ra-${Date.now()}`, eventName: event, args: args || null},
-          ];
-        });
-
-        // Flash indicator
-        setLastCaptured(event);
-        if (lastCapturedTimeout.current) {
-          clearTimeout(lastCapturedTimeout.current);
-        }
-        lastCapturedTimeout.current = setTimeout(
-          () => setLastCaptured(null),
-          1500,
-        );
-      },
-    );
-
-    return () => {
-      unsubscribe();
-      if (lastCapturedTimeout.current) {
-        clearTimeout(lastCapturedTimeout.current);
-      }
-    };
-  }, [isOpen]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  // Click handler — captures click events as recordable actions
-  const handlePreviewClick = (e: React.MouseEvent) => {
-    const target = e.target as HTMLElement;
-
-    // Walk up to find the closest interactive element
-    const interactive = target.closest(
-      "button, a, [role='button'], input, select, .btn",
-    ) as HTMLElement | null;
-    const el = interactive || target;
-
-    const tag = el.tagName.toLowerCase();
-    // Ignore clicks on generic containers
-    if (["div", "span", "col", "row", "container", "section"].includes(tag) && !interactive) {
-      return;
-    }
-
-    const text =
-      el.textContent?.trim().replace(/\s+/g, " ").substring(0, 60) ||
-      el.getAttribute("aria-label") ||
-      el.getAttribute("title") ||
-      "";
-
-    if (!text) return;
-
-    // Build a stable identifier and args for this click target
-    const clickEventName = `click:${text}`;
-    const clickArgs = {
-      text,
-      tag,
-      className: el.className
-        ? String(el.className).split(" ").filter(Boolean).slice(0, 3).join(" ")
-        : null,
-    };
-
-    // Add to recorded actions (skip duplicates)
-    setRecordedActions(prev => {
-      if (prev.find((a: any) => a.eventName === clickEventName)) return prev;
-      return [
-        ...prev,
-        {id: `ra-${Date.now()}`, eventName: clickEventName, args: clickArgs},
-      ];
-    });
-
-    // Flash indicator
-    setLastCaptured(clickEventName);
-    if (lastCapturedTimeout.current) clearTimeout(lastCapturedTimeout.current);
-    lastCapturedTimeout.current = setTimeout(
-      () => setLastCaptured(null),
-      1500,
-    );
-  };
-
   const CardComponent = cardComponentName
     ? (Views as any)[cardComponentName]
     : null;
 
-  const addAction = (eventName: string) => {
-    if (recordedActions.find((a: any) => a.eventName === eventName)) return;
-    setRecordedActions(prev => [
-      ...prev,
-      {id: `ra-${Date.now()}`, eventName, args: null},
-    ]);
-  };
-
-  const removeAction = (actionId: string) => {
-    setRecordedActions(prev => prev.filter((a: any) => a.id !== actionId));
-  };
-
   // Build preview props using the sandbox simulator
   const effectiveSimId = sandboxSimulatorId || simulatorId;
   const previewProps = {
-    simulator: simulator || {id: effectiveSimId, name: "Preview", alertlevel: "5"},
+    simulator: simulator || {
+      id: effectiveSimId,
+      name: "Preview",
+      alertlevel: "5",
+    },
     station: {name: stationName, cards: []},
     flight: {id: sandboxFlightId || "preview"},
     clientObj: {
@@ -361,7 +131,7 @@ const RecordActionsModal: React.FC<RecordActionsModalProps> = ({
           {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
           <div
             className="record-card-preview"
-            onClick={handlePreviewClick}
+            onClick={captureClick}
             style={{
               flex: 2,
               border: "2px solid #f44336",
@@ -394,31 +164,13 @@ const RecordActionsModal: React.FC<RecordActionsModalProps> = ({
             )}
 
             {!sandboxReady || !simulator ? (
-              <div
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  height: "100%",
-                  color: "#888",
-                }}
-              >
+              <div style={previewMessageStyle}>
                 Initializing sandbox environment...
               </div>
             ) : CardComponent ? (
               <Suspense
                 fallback={
-                  <div
-                    style={{
-                      display: "flex",
-                      alignItems: "center",
-                      justifyContent: "center",
-                      height: "100%",
-                      color: "#888",
-                    }}
-                  >
-                    Loading card preview...
-                  </div>
+                  <div style={previewMessageStyle}>Loading card preview...</div>
                 }
               >
                 <CardPreviewErrorBoundary cardName={cardComponentName}>
@@ -435,15 +187,7 @@ const RecordActionsModal: React.FC<RecordActionsModalProps> = ({
                 </CardPreviewErrorBoundary>
               </Suspense>
             ) : (
-              <div
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  height: "100%",
-                  color: "#888",
-                }}
-              >
+              <div style={previewMessageStyle}>
                 No card component selected for this chapter.
               </div>
             )}
@@ -467,9 +211,10 @@ const RecordActionsModal: React.FC<RecordActionsModalProps> = ({
                   </span>
                 )}
                 {availableActions.map(action => {
-                  const isSelected = recordedActions.some(
+                  const existing = recordedActions.find(
                     (ra: any) => ra.eventName === action.eventName,
                   );
+                  const isSelected = !!existing;
                   return (
                     <Button
                       key={action.eventName}
@@ -477,16 +222,11 @@ const RecordActionsModal: React.FC<RecordActionsModalProps> = ({
                       color={isSelected ? "info" : "secondary"}
                       outline={!isSelected}
                       style={{textAlign: "left"}}
-                      onClick={() => {
-                        if (isSelected) {
-                          const existing = recordedActions.find(
-                            (ra: any) => ra.eventName === action.eventName,
-                          );
-                          if (existing) removeAction(existing.id);
-                        } else {
-                          addAction(action.eventName);
-                        }
-                      }}
+                      onClick={() =>
+                        isSelected
+                          ? removeAction(existing.id)
+                          : addAction(action.eventName)
+                      }
                     >
                       {action.label}
                     </Button>

--- a/src/containers/FlightDirector/SimulatorConfig/config/Stations/StationConfig.tsx
+++ b/src/containers/FlightDirector/SimulatorConfig/config/Stations/StationConfig.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import {Container, Row, Col} from "helpers/reactstrap";
+import {Container, Row, Col, Button} from "helpers/reactstrap";
 import {Widgets} from "components/views/index";
 import ExtraMessageGroups from "./messageGroups";
 import {capitalCase} from "change-case";
@@ -16,6 +16,7 @@ import {
   useReorderStationWidgetsMutation,
 } from "generated/graphql";
 import {useParams} from "react-router";
+import {Link} from "react-router-dom";
 import CardsTable from "./CardsTable";
 
 const Layouts = Object.keys(LayoutList).filter(
@@ -154,6 +155,18 @@ const ConfigStation: React.FC<ConfigStationProps> = ({simulator, station}) => {
             </Col>
           </Row>
           <TrainingConfig station={station} />
+          <div style={{margin: "10px 0"}}>
+            <Button
+              tag={Link}
+              to={`/config/simulator/${simulator.id}/advancedTraining/${selectedStationSet}/${encodeURI(
+                station.name || "",
+              )}`}
+              size="sm"
+              color="info"
+            >
+              Configure Advanced Training
+            </Button>
+          </div>
           <AmbianceConfig station={station} />
           <div>
             <label>Layout:</label>

--- a/src/containers/FlightDirector/SimulatorConfig/config/Stations/StationConfig.tsx
+++ b/src/containers/FlightDirector/SimulatorConfig/config/Stations/StationConfig.tsx
@@ -158,7 +158,9 @@ const ConfigStation: React.FC<ConfigStationProps> = ({simulator, station}) => {
           <div style={{margin: "10px 0"}}>
             <Button
               tag={Link}
-              to={`/config/simulator/${simulator.id}/advancedTraining/${selectedStationSet}/${encodeURI(
+              to={`/config/simulator/${
+                simulator.id
+              }/advancedTraining/${selectedStationSet}/${encodeURI(
                 station.name || "",
               )}`}
               size="sm"

--- a/src/containers/FlightDirector/SimulatorConfig/config/Stations/useActionRecorder.ts
+++ b/src/containers/FlightDirector/SimulatorConfig/config/Stations/useActionRecorder.ts
@@ -1,0 +1,154 @@
+import React, {useState, useEffect, useRef, useCallback} from "react";
+import {subscribe} from "helpers/pubsub";
+
+interface UseActionRecorderParams {
+  isOpen: boolean;
+  existingActions: any[];
+}
+
+// How long the "Captured: …" flash stays on screen, in ms.
+const FLASH_DURATION = 1500;
+
+// Owns the list of recorded required actions for the Record Actions modal.
+// Captures actions two ways: by subscribing to every server mutation-event
+// while open, and via captureClick for direct clicks on the card preview.
+// Exposes manual add/remove plus a transient "lastCaptured" flash value.
+export function useActionRecorder({
+  isOpen,
+  existingActions,
+}: UseActionRecorderParams) {
+  const [recordedActions, setRecordedActions] =
+    useState<any[]>(existingActions);
+  const [lastCaptured, setLastCaptured] = useState<string | null>(null);
+  const lastCapturedTimeout = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+
+  // Flash the just-captured action, replacing any pending flash.
+  const flash = useCallback((eventName: string) => {
+    setLastCaptured(eventName);
+    if (lastCapturedTimeout.current) {
+      clearTimeout(lastCapturedTimeout.current);
+    }
+    lastCapturedTimeout.current = setTimeout(
+      () => setLastCaptured(null),
+      FLASH_DURATION,
+    );
+  }, []);
+
+  // Append an action unless one with the same eventName is already recorded.
+  const recordUnique = useCallback((eventName: string, args: any) => {
+    setRecordedActions(prev => {
+      if (prev.find((a: any) => a.eventName === eventName)) {
+        return prev;
+      }
+      return [...prev, {id: `ra-${Date.now()}`, eventName, args: args || null}];
+    });
+  }, []);
+
+  // Reset to the chapter's existing actions each time the modal opens.
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    setRecordedActions(existingActions);
+    setLastCaptured(null);
+  }, [isOpen]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Capture every server mutation-event as a recordable action while open.
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const unsubscribe = subscribe(
+      "mutation-event",
+      ({event, args}: {event: string; args: any}) => {
+        if (
+          event === "clockSync" ||
+          event === "startFlight" ||
+          event === "deleteFlight"
+        ) {
+          return;
+        }
+        recordUnique(event, args);
+        flash(event);
+      },
+    );
+
+    return () => {
+      unsubscribe();
+      if (lastCapturedTimeout.current) {
+        clearTimeout(lastCapturedTimeout.current);
+      }
+    };
+  }, [isOpen, recordUnique, flash]);
+
+  // Capture a click on the card preview as a recordable action.
+  const captureClick = useCallback(
+    (e: React.MouseEvent) => {
+      const target = e.target as HTMLElement;
+
+      // Walk up to find the closest interactive element
+      const interactive = target.closest(
+        "button, a, [role='button'], input, select, .btn",
+      ) as HTMLElement | null;
+      const el = interactive || target;
+
+      const tag = el.tagName.toLowerCase();
+      // Ignore clicks on generic containers
+      if (
+        ["div", "span", "col", "row", "container", "section"].includes(tag) &&
+        !interactive
+      ) {
+        return;
+      }
+
+      const text =
+        el.textContent?.trim().replace(/\s+/g, " ").substring(0, 60) ||
+        el.getAttribute("aria-label") ||
+        el.getAttribute("title") ||
+        "";
+
+      if (!text) {
+        return;
+      }
+
+      const clickEventName = `click:${text}`;
+      const clickArgs = {
+        text,
+        tag,
+        className: el.className
+          ? String(el.className)
+              .split(" ")
+              .filter(Boolean)
+              .slice(0, 3)
+              .join(" ")
+          : null,
+      };
+
+      recordUnique(clickEventName, clickArgs);
+      flash(clickEventName);
+    },
+    [recordUnique, flash],
+  );
+
+  const addAction = useCallback(
+    (eventName: string) => {
+      recordUnique(eventName, null);
+    },
+    [recordUnique],
+  );
+
+  const removeAction = useCallback((actionId: string) => {
+    setRecordedActions(prev => prev.filter((a: any) => a.id !== actionId));
+  }, []);
+
+  return {
+    recordedActions,
+    lastCaptured,
+    captureClick,
+    addAction,
+    removeAction,
+  };
+}

--- a/src/containers/FlightDirector/SimulatorConfig/config/Stations/useAdvancedTrainingConfigEditor.ts
+++ b/src/containers/FlightDirector/SimulatorConfig/config/Stations/useAdvancedTrainingConfigEditor.ts
@@ -1,0 +1,358 @@
+import {useState, useCallback} from "react";
+import {useMutation} from "react-apollo";
+import {SET_STATION_ADVANCED_TRAINING} from "components/training/queries";
+import {emptyChapter, serializeChapter} from "./ChapterEditor";
+
+// Which collection a sub-chapter edit targets. `undefined` means a regular
+// chapter in the main sequence.
+type SpecialKind = "login" | "completion" | "inflight";
+
+interface UseAdvancedTrainingConfigEditorParams {
+  advancedTraining: any;
+  chapters: any[];
+  inFlightChapters: any[];
+  sequentialChapters: boolean;
+  enabled: boolean;
+  stationCards: any[];
+  stationSetId?: string;
+  stationName: string;
+}
+
+// Owns the entire "edit chapters" state machine for the Advanced Training config
+// page: the working copies of every chapter collection, expansion/recording UI
+// state, and all the add/remove/update handlers. Kept out of the page component
+// so the JSX stays readable. Editing works on deep clones; nothing is persisted
+// until saveEditing fires the mutation.
+export function useAdvancedTrainingConfigEditor({
+  advancedTraining,
+  chapters,
+  inFlightChapters,
+  sequentialChapters,
+  enabled,
+  stationCards,
+  stationSetId,
+  stationName,
+}: UseAdvancedTrainingConfigEditorParams) {
+  const [saveConfig] = useMutation(SET_STATION_ADVANCED_TRAINING);
+
+  // Local editing state
+  const [editingChapters, setEditingChapters] = useState<any[] | null>(null);
+  const [editingInFlightChapters, setEditingInFlightChapters] = useState<
+    any[] | null
+  >(null);
+  const [editingSequential, setEditingSequential] = useState<boolean | null>(
+    null,
+  );
+  const [editingStripPosition, setEditingStripPosition] = useState<
+    "top" | "bottom" | null
+  >(null);
+  const [editingLoginChapter, setEditingLoginChapter] = useState<
+    any | null | undefined
+  >(undefined);
+  const [editingCompletionChapter, setEditingCompletionChapter] = useState<
+    any | null | undefined
+  >(undefined);
+  const [expandedChapter, setExpandedChapter] = useState<string | null>(null);
+  const [recordingSubChapter, setRecordingSubChapter] = useState<string | null>(
+    null,
+  );
+  const [mediaPickerChapter, setMediaPickerChapter] = useState<string | null>(
+    null,
+  );
+
+  const isEditing = editingChapters !== null;
+  const displayChapters = isEditing ? editingChapters : chapters;
+
+  // undefined = not editing; null = editing with no special chapter; object = editing with chapter
+  const editingLogin =
+    editingLoginChapter !== undefined
+      ? editingLoginChapter
+      : advancedTraining?.loginChapter ?? null;
+  const editingCompletion =
+    editingCompletionChapter !== undefined
+      ? editingCompletionChapter
+      : advancedTraining?.completionChapter ?? null;
+
+  // Expand the given chapter, or collapse it if it's already expanded.
+  const toggleExpand = useCallback((chapterId: string) => {
+    setExpandedChapter(prev => (prev === chapterId ? null : chapterId));
+  }, []);
+
+  const startEditing = () => {
+    setEditingChapters(JSON.parse(JSON.stringify(chapters)));
+    setEditingInFlightChapters(JSON.parse(JSON.stringify(inFlightChapters)));
+    setEditingSequential(sequentialChapters);
+    setEditingStripPosition(advancedTraining?.stripPosition || "bottom");
+    setEditingLoginChapter(
+      advancedTraining?.loginChapter
+        ? JSON.parse(JSON.stringify(advancedTraining.loginChapter))
+        : null,
+    );
+    setEditingCompletionChapter(
+      advancedTraining?.completionChapter
+        ? JSON.parse(JSON.stringify(advancedTraining.completionChapter))
+        : null,
+    );
+  };
+
+  const cancelEditing = () => {
+    setEditingChapters(null);
+    setEditingInFlightChapters(null);
+    setEditingSequential(null);
+    setEditingStripPosition(null);
+    setEditingLoginChapter(undefined);
+    setEditingCompletionChapter(undefined);
+    setExpandedChapter(null);
+  };
+
+  const saveEditing = () => {
+    if (!stationSetId || !stationName || !editingChapters) {
+      return;
+    }
+    saveConfig({
+      variables: {
+        stationSetID: stationSetId,
+        stationName,
+        config: {
+          enabled,
+          sequentialChapters: editingSequential ?? sequentialChapters,
+          stripPosition:
+            editingStripPosition ?? advancedTraining?.stripPosition ?? "bottom",
+          chapters: editingChapters.map(serializeChapter),
+          inFlightChapters: (editingInFlightChapters || []).map(
+            serializeChapter,
+          ),
+          loginChapter: editingLogin ? serializeChapter(editingLogin) : null,
+          completionChapter: editingCompletion
+            ? serializeChapter(editingCompletion)
+            : null,
+        },
+      },
+    });
+    setEditingChapters(null);
+    setEditingInFlightChapters(null);
+    setEditingLoginChapter(undefined);
+    setEditingCompletionChapter(undefined);
+    setExpandedChapter(null);
+  };
+
+  // --- Regular chapter list handlers ---
+  const addChapter = () => {
+    if (!editingChapters) {
+      return;
+    }
+    const newChapter = emptyChapter(`ch-${Date.now()}`, "New Chapter");
+    (newChapter as any).cardComponent = stationCards[0]?.component || "";
+    setEditingChapters([...editingChapters, newChapter]);
+    setExpandedChapter(newChapter.id);
+  };
+
+  const removeChapter = (chapterId: string) => {
+    if (!editingChapters) {
+      return;
+    }
+    setEditingChapters(editingChapters.filter((c: any) => c.id !== chapterId));
+    if (expandedChapter === chapterId) {
+      setExpandedChapter(null);
+    }
+  };
+
+  const updateChapter = useCallback(
+    (chapterId: string, updates: any) => {
+      if (!editingChapters) {
+        return;
+      }
+      setEditingChapters(
+        editingChapters.map((c: any) =>
+          c.id === chapterId ? {...c, ...updates} : c,
+        ),
+      );
+    },
+    [editingChapters],
+  );
+
+  // --- In-flight help chapter list handlers ---
+  const addInFlightChapter = () => {
+    if (!editingInFlightChapters) {
+      return;
+    }
+    const newChapter = emptyChapter(`if-${Date.now()}`, "New Help Chapter");
+    (newChapter as any).cardComponent = stationCards[0]?.component || "";
+    setEditingInFlightChapters([...editingInFlightChapters, newChapter]);
+    setExpandedChapter(newChapter.id);
+  };
+
+  const removeInFlightChapter = (chapterId: string) => {
+    if (!editingInFlightChapters) {
+      return;
+    }
+    setEditingInFlightChapters(
+      editingInFlightChapters.filter((c: any) => c.id !== chapterId),
+    );
+    if (expandedChapter === chapterId) {
+      setExpandedChapter(null);
+    }
+  };
+
+  const updateInFlightChapter = (chapterId: string, updates: any) => {
+    if (!editingInFlightChapters) {
+      return;
+    }
+    setEditingInFlightChapters(
+      editingInFlightChapters.map((c: any) =>
+        c.id === chapterId ? {...c, ...updates} : c,
+      ),
+    );
+  };
+
+  // Apply an updater to a chapter's subChapters within whichever collection the
+  // chapter lives in. Centralizes the login/completion/inflight/regular routing
+  // shared by the add/remove/update sub-chapter handlers below.
+  const mutateSubChapters = (
+    chapterId: string,
+    isSpecial: SpecialKind | undefined,
+    updateSubs: (subs: any[]) => any[],
+  ) => {
+    if (isSpecial === "login") {
+      setEditingLoginChapter((prev: any) => ({
+        ...prev,
+        subChapters: updateSubs(prev?.subChapters || []),
+      }));
+      return;
+    }
+    if (isSpecial === "completion") {
+      setEditingCompletionChapter((prev: any) => ({
+        ...prev,
+        subChapters: updateSubs(prev?.subChapters || []),
+      }));
+      return;
+    }
+    if (isSpecial === "inflight") {
+      setEditingInFlightChapters(prev =>
+        prev
+          ? prev.map((c: any) =>
+              c.id === chapterId
+                ? {...c, subChapters: updateSubs(c.subChapters || [])}
+                : c,
+            )
+          : prev,
+      );
+      return;
+    }
+    setEditingChapters(prev =>
+      prev
+        ? prev.map((c: any) =>
+            c.id === chapterId
+              ? {...c, subChapters: updateSubs(c.subChapters || [])}
+              : c,
+          )
+        : prev,
+    );
+  };
+
+  const addSubChapter = (chapterId: string, isSpecial?: SpecialKind) => {
+    const newSub = {
+      id: `sc-${Date.now()}`,
+      name: "New Sub-Chapter",
+      requiredActions: [],
+    };
+    mutateSubChapters(chapterId, isSpecial, subs => [...subs, newSub]);
+  };
+
+  const removeSubChapter = (
+    chapterId: string,
+    subChapterId: string,
+    isSpecial?: SpecialKind,
+  ) => {
+    mutateSubChapters(chapterId, isSpecial, subs =>
+      subs.filter((s: any) => s.id !== subChapterId),
+    );
+  };
+
+  const updateSubChapter = (
+    chapterId: string,
+    subChapterId: string,
+    updates: any,
+    isSpecial?: SpecialKind,
+  ) => {
+    mutateSubChapters(chapterId, isSpecial, subs =>
+      subs.map((s: any) => (s.id === subChapterId ? {...s, ...updates} : s)),
+    );
+  };
+
+  // --- Record mode helpers ---
+  const startRecording = (chapterId: string, subChapterId: string) => {
+    setRecordingSubChapter(`${chapterId}:${subChapterId}`);
+  };
+
+  const cancelRecording = () => {
+    setRecordingSubChapter(null);
+  };
+
+  const saveRecording = (actions: any[]) => {
+    if (!recordingSubChapter) {
+      return;
+    }
+    const [chapterId, subChapterId] = recordingSubChapter.split(":");
+    const isInFlight = editingInFlightChapters?.some(
+      (c: any) => c.id === chapterId,
+    );
+    updateSubChapter(
+      chapterId,
+      subChapterId,
+      {requiredActions: actions},
+      isInFlight ? "inflight" : undefined,
+    );
+    setRecordingSubChapter(null);
+  };
+
+  const recordingChapterId = recordingSubChapter?.split(":")[0];
+  const recordingSubChapterId = recordingSubChapter?.split(":")[1];
+  const recordingChapter =
+    editingChapters?.find((c: any) => c.id === recordingChapterId) ||
+    editingInFlightChapters?.find((c: any) => c.id === recordingChapterId);
+  const recordingSubChapterData = recordingChapter?.subChapters?.find(
+    (s: any) => s.id === recordingSubChapterId,
+  );
+
+  return {
+    // State
+    isEditing,
+    displayChapters,
+    editingInFlightChapters,
+    editingSequential,
+    setEditingSequential,
+    editingStripPosition,
+    setEditingStripPosition,
+    editingLogin,
+    setEditingLoginChapter,
+    editingCompletion,
+    setEditingCompletionChapter,
+    expandedChapter,
+    toggleExpand,
+    setExpandedChapter,
+    mediaPickerChapter,
+    setMediaPickerChapter,
+    // Lifecycle
+    startEditing,
+    cancelEditing,
+    saveEditing,
+    // Chapter handlers
+    addChapter,
+    removeChapter,
+    updateChapter,
+    addInFlightChapter,
+    removeInFlightChapter,
+    updateInFlightChapter,
+    addSubChapter,
+    removeSubChapter,
+    updateSubChapter,
+    // Recording
+    recordingSubChapter,
+    recordingChapter,
+    recordingSubChapterData,
+    startRecording,
+    cancelRecording,
+    saveRecording,
+  };
+}

--- a/src/containers/FlightDirector/SimulatorConfig/config/Stations/useSandboxFlight.ts
+++ b/src/containers/FlightDirector/SimulatorConfig/config/Stations/useSandboxFlight.ts
@@ -1,0 +1,132 @@
+import {useState, useEffect, useRef, useCallback} from "react";
+import {useMutation} from "react-apollo";
+import {useApolloClient} from "@apollo/client";
+import {useSimulatorUpdateSubscription} from "generated/graphql";
+import {
+  START_SANDBOX_FLIGHT,
+  DELETE_SANDBOX_FLIGHT,
+  SANDBOX_FLIGHT_SIMULATORS,
+} from "components/training/queries";
+
+interface UseSandboxFlightParams {
+  isOpen: boolean;
+  simulatorId: string;
+  stationSetId: string;
+}
+
+// Manages the throwaway "sandbox" flight that backs the Record Actions card
+// preview: starts a flight when the modal opens, resolves its simulator id,
+// subscribes to that simulator's data, and tears the flight down again on
+// close/unmount. Returns everything the modal needs to render the live preview.
+export function useSandboxFlight({
+  isOpen,
+  simulatorId,
+  stationSetId,
+}: UseSandboxFlightParams) {
+  const client = useApolloClient();
+  const [sandboxFlightId, setSandboxFlightId] = useState<string | null>(null);
+  const [sandboxSimulatorId, setSandboxSimulatorId] = useState<string | null>(
+    null,
+  );
+  const [sandboxReady, setSandboxReady] = useState(false);
+  const sandboxFlightIdRef = useRef<string | null>(null);
+
+  const [startFlightMutation] = useMutation(START_SANDBOX_FLIGHT);
+  const [deleteFlightMutation] = useMutation(DELETE_SANDBOX_FLIGHT);
+
+  // Subscribe to the sandbox simulator's data for the card preview
+  const {data: simData} = useSimulatorUpdateSubscription({
+    variables: {simulatorId: sandboxSimulatorId || ""},
+    skip: !sandboxSimulatorId,
+  });
+  const simulator = simData?.simulatorsUpdate?.[0];
+
+  // Create sandbox flight when the modal opens
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    setSandboxReady(false);
+
+    let cancelled = false;
+
+    startFlightMutation({
+      variables: {
+        name: `__sandbox_${Date.now()}`,
+        simulators: [{simulatorId, stationSet: stationSetId}],
+      },
+    })
+      .then(({data}: any) => {
+        if (cancelled) {
+          // Modal closed before flight was created — clean up
+          if (data?.startFlight) {
+            deleteFlightMutation({variables: {flightId: data.startFlight}});
+          }
+          return;
+        }
+        const flightId = data?.startFlight;
+        if (!flightId) {
+          return;
+        }
+        setSandboxFlightId(flightId);
+        sandboxFlightIdRef.current = flightId;
+
+        // Query for the sandbox simulator ID
+        return client.query({
+          query: SANDBOX_FLIGHT_SIMULATORS,
+          variables: {flightId},
+          fetchPolicy: "network-only",
+        });
+      })
+      .then((result: any) => {
+        if (cancelled || !result) {
+          return;
+        }
+        const simId = result.data?.flights?.[0]?.simulators?.[0]?.id;
+        if (simId) {
+          setSandboxSimulatorId(simId);
+          setSandboxReady(true);
+        }
+      })
+      .catch((err: any) => {
+        console.error("Failed to create sandbox flight:", err);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Cleanup sandbox on unmount (handles unexpected navigation)
+  useEffect(() => {
+    return () => {
+      const flightId = sandboxFlightIdRef.current;
+      if (flightId) {
+        deleteFlightMutation({variables: {flightId}}).catch(() => {});
+        sandboxFlightIdRef.current = null;
+      }
+    };
+  }, [deleteFlightMutation]);
+
+  const cleanupSandbox = useCallback(() => {
+    const flightId = sandboxFlightIdRef.current;
+    if (flightId) {
+      deleteFlightMutation({variables: {flightId}}).catch(err =>
+        console.error("Failed to delete sandbox flight:", err),
+      );
+      sandboxFlightIdRef.current = null;
+      setSandboxFlightId(null);
+      setSandboxSimulatorId(null);
+      setSandboxReady(false);
+    }
+  }, [deleteFlightMutation]);
+
+  return {
+    sandboxFlightId,
+    sandboxSimulatorId,
+    sandboxReady,
+    simulator,
+    cleanupSandbox,
+  };
+}

--- a/src/containers/FlightDirector/SimulatorConfig/index.tsx
+++ b/src/containers/FlightDirector/SimulatorConfig/index.tsx
@@ -3,6 +3,7 @@ import {Col, Row, Container, Button} from "helpers/reactstrap";
 
 import SimulatorProperties from "./SimulatorProperties";
 import * as Config from "./config";
+import AdvancedTrainingConfig from "./config/Stations/AdvancedTrainingConfig";
 import {
   useRemoveSimulatorMutation,
   useSimulatorsConfigSubscription,
@@ -88,6 +89,10 @@ const SimulatorConfigRoutes = () => {
     <Routes>
       <Route path="/" element={<SimulatorConfig />} />
       <Route path="Simulator/*" element={<SimulatorConfig />} />
+      <Route
+        path="advancedTraining/:stationSetId/:stationName"
+        element={<AdvancedTrainingConfig />}
+      />
       <Route path=":selectedProperty" element={<SimulatorConfig />} />
       <Route path=":selectedProperty/:subPath1" element={<SimulatorConfig />} />
       <Route

--- a/src/containers/FlightDirector/SimulatorConfig/queries/stationSetQuery.graphql
+++ b/src/containers/FlightDirector/SimulatorConfig/queries/stationSetQuery.graphql
@@ -32,6 +32,7 @@ subscription StationSetConfig {
           mediaAsset
           autoOpenMedia
           autoAdvance
+          autoLogin
           cardSwitchBehavior
           mediaSize
           mediaPosition
@@ -52,6 +53,7 @@ subscription StationSetConfig {
           mediaAsset
           autoOpenMedia
           autoAdvance
+          autoLogin
           cardSwitchBehavior
           mediaSize
           mediaPosition
@@ -72,6 +74,7 @@ subscription StationSetConfig {
           mediaAsset
           autoOpenMedia
           autoAdvance
+          autoLogin
           cardSwitchBehavior
           mediaSize
           mediaPosition

--- a/src/containers/FlightDirector/SimulatorConfig/queries/stationSetQuery.graphql
+++ b/src/containers/FlightDirector/SimulatorConfig/queries/stationSetQuery.graphql
@@ -24,6 +24,7 @@ subscription StationSetConfig {
       advancedTraining {
         enabled
         sequentialChapters
+        stripPosition
         chapters {
           id
           name

--- a/src/containers/FlightDirector/SimulatorConfig/queries/stationSetQuery.graphql
+++ b/src/containers/FlightDirector/SimulatorConfig/queries/stationSetQuery.graphql
@@ -46,6 +46,27 @@ subscription StationSetConfig {
             }
           }
         }
+        inFlightChapters {
+          id
+          name
+          cardComponent
+          mediaAsset
+          autoOpenMedia
+          autoAdvance
+          autoLogin
+          cardSwitchBehavior
+          mediaSize
+          mediaPosition
+          subChapters {
+            id
+            name
+            requiredActions {
+              id
+              eventName
+              args
+            }
+          }
+        }
         loginChapter {
           id
           name

--- a/src/containers/FlightDirector/SimulatorConfig/queries/stationSetQuery.graphql
+++ b/src/containers/FlightDirector/SimulatorConfig/queries/stationSetQuery.graphql
@@ -21,6 +21,70 @@ subscription StationSetConfig {
         name
         component
       }
+      advancedTraining {
+        enabled
+        sequentialChapters
+        chapters {
+          id
+          name
+          cardComponent
+          mediaAsset
+          autoOpenMedia
+          autoAdvance
+          cardSwitchBehavior
+          mediaSize
+          mediaPosition
+          subChapters {
+            id
+            name
+            requiredActions {
+              id
+              eventName
+              args
+            }
+          }
+        }
+        loginChapter {
+          id
+          name
+          cardComponent
+          mediaAsset
+          autoOpenMedia
+          autoAdvance
+          cardSwitchBehavior
+          mediaSize
+          mediaPosition
+          subChapters {
+            id
+            name
+            requiredActions {
+              id
+              eventName
+              args
+            }
+          }
+        }
+        completionChapter {
+          id
+          name
+          cardComponent
+          mediaAsset
+          autoOpenMedia
+          autoAdvance
+          cardSwitchBehavior
+          mediaSize
+          mediaPosition
+          subChapters {
+            id
+            name
+            requiredActions {
+              id
+              eventName
+              args
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -85,6 +85,7 @@ export type AdvancedTrainingChapter = {
   mediaAsset?: Maybe<Scalars['String']>;
   autoOpenMedia: Scalars['Boolean'];
   autoAdvance: Scalars['Boolean'];
+  autoLogin: Scalars['String'];
   cardSwitchBehavior: Scalars['String'];
   mediaSize: Scalars['String'];
   mediaPosition: Scalars['String'];
@@ -98,6 +99,7 @@ export type AdvancedTrainingChapterInput = {
   mediaAsset?: Maybe<Scalars['String']>;
   autoOpenMedia?: Maybe<Scalars['Boolean']>;
   autoAdvance?: Maybe<Scalars['Boolean']>;
+  autoLogin?: Maybe<Scalars['String']>;
   cardSwitchBehavior?: Maybe<Scalars['String']>;
   mediaSize?: Maybe<Scalars['String']>;
   mediaPosition?: Maybe<Scalars['String']>;
@@ -108,6 +110,7 @@ export type AdvancedTrainingConfig = {
   __typename?: 'AdvancedTrainingConfig';
   enabled: Scalars['Boolean'];
   sequentialChapters: Scalars['Boolean'];
+  stripPosition: Scalars['String'];
   chapters: Array<AdvancedTrainingChapter>;
   loginChapter?: Maybe<AdvancedTrainingChapter>;
   completionChapter?: Maybe<AdvancedTrainingChapter>;
@@ -116,6 +119,7 @@ export type AdvancedTrainingConfig = {
 export type AdvancedTrainingConfigInput = {
   enabled?: Maybe<Scalars['Boolean']>;
   sequentialChapters?: Maybe<Scalars['Boolean']>;
+  stripPosition?: Maybe<Scalars['String']>;
   chapters?: Maybe<Array<AdvancedTrainingChapterInput>>;
   loginChapter?: Maybe<AdvancedTrainingChapterInput>;
   completionChapter?: Maybe<AdvancedTrainingChapterInput>;
@@ -132,6 +136,7 @@ export type AdvancedTrainingProgress = {
   completedChapterIds: Array<Scalars['ID']>;
   completedSubChapterIds: Array<Scalars['ID']>;
   observedActions?: Maybe<Scalars['JSON']>;
+  globalObservedEvents: Array<Scalars['String']>;
   mediaViewerOpen: Scalars['Boolean'];
   chapterListOpen: Scalars['Boolean'];
 };
@@ -12274,10 +12279,10 @@ export type SimulatorDataFragment = (
       & Pick<Card, 'name' | 'component' | 'hidden' | 'assigned' | 'newStation'>
     )>>, advancedTraining?: Maybe<(
       { __typename?: 'AdvancedTrainingConfig' }
-      & Pick<AdvancedTrainingConfig, 'enabled' | 'sequentialChapters'>
+      & Pick<AdvancedTrainingConfig, 'enabled' | 'sequentialChapters' | 'stripPosition'>
       & { chapters: Array<(
         { __typename?: 'AdvancedTrainingChapter' }
-        & Pick<AdvancedTrainingChapter, 'id' | 'name' | 'cardComponent' | 'mediaAsset' | 'autoOpenMedia' | 'autoAdvance' | 'cardSwitchBehavior' | 'mediaSize' | 'mediaPosition'>
+        & Pick<AdvancedTrainingChapter, 'id' | 'name' | 'cardComponent' | 'mediaAsset' | 'autoOpenMedia' | 'autoAdvance' | 'autoLogin' | 'cardSwitchBehavior' | 'mediaSize' | 'mediaPosition'>
         & { subChapters: Array<(
           { __typename?: 'AdvancedTrainingSubChapter' }
           & Pick<AdvancedTrainingSubChapter, 'id' | 'name'>
@@ -12288,7 +12293,7 @@ export type SimulatorDataFragment = (
         )> }
       )>, loginChapter?: Maybe<(
         { __typename?: 'AdvancedTrainingChapter' }
-        & Pick<AdvancedTrainingChapter, 'id' | 'name' | 'cardComponent' | 'mediaAsset' | 'autoOpenMedia' | 'autoAdvance' | 'cardSwitchBehavior' | 'mediaSize' | 'mediaPosition'>
+        & Pick<AdvancedTrainingChapter, 'id' | 'name' | 'cardComponent' | 'mediaAsset' | 'autoOpenMedia' | 'autoAdvance' | 'autoLogin' | 'cardSwitchBehavior' | 'mediaSize' | 'mediaPosition'>
         & { subChapters: Array<(
           { __typename?: 'AdvancedTrainingSubChapter' }
           & Pick<AdvancedTrainingSubChapter, 'id' | 'name'>
@@ -12299,7 +12304,7 @@ export type SimulatorDataFragment = (
         )> }
       )>, completionChapter?: Maybe<(
         { __typename?: 'AdvancedTrainingChapter' }
-        & Pick<AdvancedTrainingChapter, 'id' | 'name' | 'cardComponent' | 'mediaAsset' | 'autoOpenMedia' | 'autoAdvance' | 'cardSwitchBehavior' | 'mediaSize' | 'mediaPosition'>
+        & Pick<AdvancedTrainingChapter, 'id' | 'name' | 'cardComponent' | 'mediaAsset' | 'autoOpenMedia' | 'autoAdvance' | 'autoLogin' | 'cardSwitchBehavior' | 'mediaSize' | 'mediaPosition'>
         & { subChapters: Array<(
           { __typename?: 'AdvancedTrainingSubChapter' }
           & Pick<AdvancedTrainingSubChapter, 'id' | 'name'>
@@ -15712,10 +15717,10 @@ export type StationSetConfigSubscription = (
         & Pick<Card, 'name' | 'component'>
       )>>, advancedTraining?: Maybe<(
         { __typename?: 'AdvancedTrainingConfig' }
-        & Pick<AdvancedTrainingConfig, 'enabled' | 'sequentialChapters'>
+        & Pick<AdvancedTrainingConfig, 'enabled' | 'sequentialChapters' | 'stripPosition'>
         & { chapters: Array<(
           { __typename?: 'AdvancedTrainingChapter' }
-          & Pick<AdvancedTrainingChapter, 'id' | 'name' | 'cardComponent' | 'mediaAsset' | 'autoOpenMedia' | 'autoAdvance' | 'cardSwitchBehavior' | 'mediaSize' | 'mediaPosition'>
+          & Pick<AdvancedTrainingChapter, 'id' | 'name' | 'cardComponent' | 'mediaAsset' | 'autoOpenMedia' | 'autoAdvance' | 'autoLogin' | 'cardSwitchBehavior' | 'mediaSize' | 'mediaPosition'>
           & { subChapters: Array<(
             { __typename?: 'AdvancedTrainingSubChapter' }
             & Pick<AdvancedTrainingSubChapter, 'id' | 'name'>
@@ -15726,7 +15731,7 @@ export type StationSetConfigSubscription = (
           )> }
         )>, loginChapter?: Maybe<(
           { __typename?: 'AdvancedTrainingChapter' }
-          & Pick<AdvancedTrainingChapter, 'id' | 'name' | 'cardComponent' | 'mediaAsset' | 'autoOpenMedia' | 'autoAdvance' | 'cardSwitchBehavior' | 'mediaSize' | 'mediaPosition'>
+          & Pick<AdvancedTrainingChapter, 'id' | 'name' | 'cardComponent' | 'mediaAsset' | 'autoOpenMedia' | 'autoAdvance' | 'autoLogin' | 'cardSwitchBehavior' | 'mediaSize' | 'mediaPosition'>
           & { subChapters: Array<(
             { __typename?: 'AdvancedTrainingSubChapter' }
             & Pick<AdvancedTrainingSubChapter, 'id' | 'name'>
@@ -15737,7 +15742,7 @@ export type StationSetConfigSubscription = (
           )> }
         )>, completionChapter?: Maybe<(
           { __typename?: 'AdvancedTrainingChapter' }
-          & Pick<AdvancedTrainingChapter, 'id' | 'name' | 'cardComponent' | 'mediaAsset' | 'autoOpenMedia' | 'autoAdvance' | 'cardSwitchBehavior' | 'mediaSize' | 'mediaPosition'>
+          & Pick<AdvancedTrainingChapter, 'id' | 'name' | 'cardComponent' | 'mediaAsset' | 'autoOpenMedia' | 'autoAdvance' | 'autoLogin' | 'cardSwitchBehavior' | 'mediaSize' | 'mediaPosition'>
           & { subChapters: Array<(
             { __typename?: 'AdvancedTrainingSubChapter' }
             & Pick<AdvancedTrainingSubChapter, 'id' | 'name'>
@@ -16579,6 +16584,7 @@ export const SimulatorDataFragmentDoc = gql`
     advancedTraining {
       enabled
       sequentialChapters
+      stripPosition
       chapters {
         id
         name
@@ -16586,7 +16592,52 @@ export const SimulatorDataFragmentDoc = gql`
         mediaAsset
         autoOpenMedia
         autoAdvance
+        autoLogin
         cardSwitchBehavior
+        mediaSize
+        mediaPosition
+        subChapters {
+          id
+          name
+          requiredActions {
+            id
+            eventName
+            args
+          }
+        }
+      }
+      loginChapter {
+        id
+        name
+        cardComponent
+        mediaAsset
+        autoOpenMedia
+        autoAdvance
+        autoLogin
+        cardSwitchBehavior
+        mediaSize
+        mediaPosition
+        subChapters {
+          id
+          name
+          requiredActions {
+            id
+            eventName
+            args
+          }
+        }
+      }
+      completionChapter {
+        id
+        name
+        cardComponent
+        mediaAsset
+        autoOpenMedia
+        autoAdvance
+        autoLogin
+        cardSwitchBehavior
+        mediaSize
+        mediaPosition
         subChapters {
           id
           name
@@ -20461,6 +20512,7 @@ export const StationSetConfigDocument = gql`
       advancedTraining {
         enabled
         sequentialChapters
+        stripPosition
         chapters {
           id
           name
@@ -20468,7 +20520,52 @@ export const StationSetConfigDocument = gql`
           mediaAsset
           autoOpenMedia
           autoAdvance
+          autoLogin
           cardSwitchBehavior
+          mediaSize
+          mediaPosition
+          subChapters {
+            id
+            name
+            requiredActions {
+              id
+              eventName
+              args
+            }
+          }
+        }
+        loginChapter {
+          id
+          name
+          cardComponent
+          mediaAsset
+          autoOpenMedia
+          autoAdvance
+          autoLogin
+          cardSwitchBehavior
+          mediaSize
+          mediaPosition
+          subChapters {
+            id
+            name
+            requiredActions {
+              id
+              eventName
+              args
+            }
+          }
+        }
+        completionChapter {
+          id
+          name
+          cardComponent
+          mediaAsset
+          autoOpenMedia
+          autoAdvance
+          autoLogin
+          cardSwitchBehavior
+          mediaSize
+          mediaPosition
           subChapters {
             id
             name

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -77,6 +77,91 @@ export type AdvancedNavigationAndAstrometrics = SystemInterface & {
   probeAssignments: Scalars['String'];
 };
 
+export type AdvancedTrainingChapter = {
+  __typename?: 'AdvancedTrainingChapter';
+  id: Scalars['ID'];
+  name: Scalars['String'];
+  cardComponent: Scalars['String'];
+  mediaAsset?: Maybe<Scalars['String']>;
+  autoOpenMedia: Scalars['Boolean'];
+  autoAdvance: Scalars['Boolean'];
+  cardSwitchBehavior: Scalars['String'];
+  mediaSize: Scalars['String'];
+  mediaPosition: Scalars['String'];
+  subChapters: Array<AdvancedTrainingSubChapter>;
+};
+
+export type AdvancedTrainingChapterInput = {
+  id?: Maybe<Scalars['ID']>;
+  name: Scalars['String'];
+  cardComponent: Scalars['String'];
+  mediaAsset?: Maybe<Scalars['String']>;
+  autoOpenMedia?: Maybe<Scalars['Boolean']>;
+  autoAdvance?: Maybe<Scalars['Boolean']>;
+  cardSwitchBehavior?: Maybe<Scalars['String']>;
+  mediaSize?: Maybe<Scalars['String']>;
+  mediaPosition?: Maybe<Scalars['String']>;
+  subChapters?: Maybe<Array<AdvancedTrainingSubChapterInput>>;
+};
+
+export type AdvancedTrainingConfig = {
+  __typename?: 'AdvancedTrainingConfig';
+  enabled: Scalars['Boolean'];
+  sequentialChapters: Scalars['Boolean'];
+  chapters: Array<AdvancedTrainingChapter>;
+  loginChapter?: Maybe<AdvancedTrainingChapter>;
+  completionChapter?: Maybe<AdvancedTrainingChapter>;
+};
+
+export type AdvancedTrainingConfigInput = {
+  enabled?: Maybe<Scalars['Boolean']>;
+  sequentialChapters?: Maybe<Scalars['Boolean']>;
+  chapters?: Maybe<Array<AdvancedTrainingChapterInput>>;
+  loginChapter?: Maybe<AdvancedTrainingChapterInput>;
+  completionChapter?: Maybe<AdvancedTrainingChapterInput>;
+};
+
+export type AdvancedTrainingProgress = {
+  __typename?: 'AdvancedTrainingProgress';
+  id: Scalars['ID'];
+  clientId: Scalars['ID'];
+  simulatorId: Scalars['ID'];
+  stationName: Scalars['String'];
+  activeChapterId?: Maybe<Scalars['ID']>;
+  activeSubChapterId?: Maybe<Scalars['ID']>;
+  completedChapterIds: Array<Scalars['ID']>;
+  completedSubChapterIds: Array<Scalars['ID']>;
+  observedActions?: Maybe<Scalars['JSON']>;
+  mediaViewerOpen: Scalars['Boolean'];
+  chapterListOpen: Scalars['Boolean'];
+};
+
+export type AdvancedTrainingRequiredAction = {
+  __typename?: 'AdvancedTrainingRequiredAction';
+  id: Scalars['ID'];
+  eventName: Scalars['String'];
+  args?: Maybe<Scalars['JSON']>;
+};
+
+export type AdvancedTrainingRequiredActionInput = {
+  id?: Maybe<Scalars['ID']>;
+  eventName: Scalars['String'];
+  args?: Maybe<Scalars['JSON']>;
+};
+
+export type AdvancedTrainingSubChapter = {
+  __typename?: 'AdvancedTrainingSubChapter';
+  id: Scalars['ID'];
+  name: Scalars['String'];
+  requiredActions: Array<AdvancedTrainingRequiredAction>;
+};
+
+export type AdvancedTrainingSubChapterInput = {
+  id?: Maybe<Scalars['ID']>;
+  name: Scalars['String'];
+  requiredActions?: Maybe<Array<AdvancedTrainingRequiredActionInput>>;
+};
+
 export type Ambiance = {
   __typename?: 'Ambiance';
   id: Scalars['ID'];
@@ -243,6 +328,7 @@ export type Client = {
   mobile?: Maybe<Scalars['Boolean']>;
   cards?: Maybe<Array<Maybe<Scalars['String']>>>;
   keypad?: Maybe<Keypad>;
+  advancedTrainingProgress?: Maybe<AdvancedTrainingProgress>;
 };
 
 export type ColoredCoordinate = {
@@ -1487,6 +1573,7 @@ export type InternalComm = SystemInterface & {
   damage?: Maybe<Damage>;
   stealthFactor?: Maybe<Scalars['Float']>;
   locations?: Maybe<Array<Maybe<Room>>>;
+  log?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 export type InventoryCount = {
@@ -3167,6 +3254,32 @@ export type Mutation = {
   /** Macro: Tasks: Activate Task Flow */
   taskFlowActivate?: Maybe<Scalars['String']>;
   taskFlowAdvance?: Maybe<Scalars['String']>;
+  /** Save the full advanced training configuration for a station. */
+  setStationAdvancedTraining?: Maybe<Scalars['String']>;
+  /** Toggle advanced training mode on a station set. */
+  toggleAdvancedTrainingMode?: Maybe<Scalars['String']>;
+  /**
+   * Start an advanced training session for a client.
+   * Sets up progress tracking and activates the first chapter.
+   */
+  clientStartAdvancedTraining?: Maybe<Scalars['String']>;
+  /** Stop advanced training for a client. */
+  clientStopAdvancedTraining?: Maybe<Scalars['String']>;
+  /**
+   * Record a crew action during advanced training.
+   * Checks against required actions and may trigger sub-chapter/chapter completion.
+   */
+  clientAdvancedTrainingAction?: Maybe<Scalars['String']>;
+  /** Set the active chapter for a client (crew navigation or FD override). */
+  advancedTrainingSetActiveChapter?: Maybe<Scalars['String']>;
+  /** FD force-complete a sub-chapter for a client. */
+  fdCompleteTrainingSubChapter?: Maybe<Scalars['String']>;
+  /** FD reset all training progress for a client. */
+  fdResetTrainingProgress?: Maybe<Scalars['String']>;
+  /** Toggle the media viewer open/close for a client. */
+  advancedTrainingToggleMediaViewer?: Maybe<Scalars['String']>;
+  /** Toggle the chapter list open/close for a client. */
+  advancedTrainingToggleChapterList?: Maybe<Scalars['String']>;
   entitySetAppearance?: Maybe<Scalars['String']>;
   entityRemoveAppearance?: Maybe<Scalars['String']>;
   entitySetBehavior?: Maybe<Scalars['String']>;
@@ -8058,6 +8171,66 @@ export type MutationTaskFlowAdvanceArgs = {
 };
 
 
+export type MutationSetStationAdvancedTrainingArgs = {
+  stationSetID: Scalars['ID'];
+  stationName: Scalars['String'];
+  config: AdvancedTrainingConfigInput;
+};
+
+
+export type MutationToggleAdvancedTrainingModeArgs = {
+  stationSetID: Scalars['ID'];
+  stationName: Scalars['String'];
+  enabled: Scalars['Boolean'];
+};
+
+
+export type MutationClientStartAdvancedTrainingArgs = {
+  clientId: Scalars['ID'];
+};
+
+
+export type MutationClientStopAdvancedTrainingArgs = {
+  clientId: Scalars['ID'];
+};
+
+
+export type MutationClientAdvancedTrainingActionArgs = {
+  clientId: Scalars['ID'];
+  eventName: Scalars['String'];
+  args?: Maybe<Scalars['JSON']>;
+};
+
+
+export type MutationAdvancedTrainingSetActiveChapterArgs = {
+  clientId: Scalars['ID'];
+  chapterId: Scalars['ID'];
+};
+
+
+export type MutationFdCompleteTrainingSubChapterArgs = {
+  clientId: Scalars['ID'];
+  subChapterId: Scalars['ID'];
+};
+
+
+export type MutationFdResetTrainingProgressArgs = {
+  clientId: Scalars['ID'];
+};
+
+
+export type MutationAdvancedTrainingToggleMediaViewerArgs = {
+  clientId: Scalars['ID'];
+  open: Scalars['Boolean'];
+};
+
+
+export type MutationAdvancedTrainingToggleChapterListArgs = {
+  clientId: Scalars['ID'];
+  open: Scalars['Boolean'];
+};
+
+
 export type MutationEntitySetAppearanceArgs = {
   id?: Maybe<Scalars['ID']>;
   color?: Maybe<Scalars['String']>;
@@ -8965,6 +9138,7 @@ export type Query = {
   dmxConfig?: Maybe<DmxConfig>;
   dmxConfigs: Array<DmxConfig>;
   taskFlows: Array<TaskFlow>;
+  advancedTrainingProgress: Array<AdvancedTrainingProgress>;
 };
 
 
@@ -9548,6 +9722,12 @@ export type QueryDmxConfigArgs = {
 
 
 export type QueryTaskFlowsArgs = {
+  simulatorId?: Maybe<Scalars['ID']>;
+};
+
+
+export type QueryAdvancedTrainingProgressArgs = {
+  clientId?: Maybe<Scalars['ID']>;
   simulatorId?: Maybe<Scalars['ID']>;
 };
 
@@ -10281,6 +10461,7 @@ export type Station = {
   widgets?: Maybe<Array<Maybe<Scalars['String']>>>;
   cards?: Maybe<Array<Card>>;
   ambiance?: Maybe<Scalars['String']>;
+  advancedTraining?: Maybe<AdvancedTrainingConfig>;
 };
 
 
@@ -10458,6 +10639,8 @@ export type Subscription = {
   dmxFixtures: Array<DmxFixture>;
   dmxConfigs: Array<DmxConfig>;
   taskFlows: Array<TaskFlow>;
+  advancedTrainingProgressUpdate: Array<AdvancedTrainingProgress>;
+  advancedTrainingConfigUpdate: Array<StationSet>;
 };
 
 
@@ -11017,6 +11200,16 @@ export type SubscriptionDmxFixturesArgs = {
 
 export type SubscriptionTaskFlowsArgs = {
   simulatorId?: Maybe<Scalars['ID']>;
+};
+
+
+export type SubscriptionAdvancedTrainingProgressUpdateArgs = {
+  simulatorId?: Maybe<Scalars['ID']>;
+};
+
+
+export type SubscriptionAdvancedTrainingConfigUpdateArgs = {
+  stationSetID?: Maybe<Scalars['ID']>;
 };
 
 export type SubspaceField = SystemInterface & {
@@ -12079,7 +12272,44 @@ export type SimulatorDataFragment = (
     & { cards?: Maybe<Array<(
       { __typename?: 'Card' }
       & Pick<Card, 'name' | 'component' | 'hidden' | 'assigned' | 'newStation'>
-    )>> }
+    )>>, advancedTraining?: Maybe<(
+      { __typename?: 'AdvancedTrainingConfig' }
+      & Pick<AdvancedTrainingConfig, 'enabled' | 'sequentialChapters'>
+      & { chapters: Array<(
+        { __typename?: 'AdvancedTrainingChapter' }
+        & Pick<AdvancedTrainingChapter, 'id' | 'name' | 'cardComponent' | 'mediaAsset' | 'autoOpenMedia' | 'autoAdvance' | 'cardSwitchBehavior' | 'mediaSize' | 'mediaPosition'>
+        & { subChapters: Array<(
+          { __typename?: 'AdvancedTrainingSubChapter' }
+          & Pick<AdvancedTrainingSubChapter, 'id' | 'name'>
+          & { requiredActions: Array<(
+            { __typename?: 'AdvancedTrainingRequiredAction' }
+            & Pick<AdvancedTrainingRequiredAction, 'id' | 'eventName' | 'args'>
+          )> }
+        )> }
+      )>, loginChapter?: Maybe<(
+        { __typename?: 'AdvancedTrainingChapter' }
+        & Pick<AdvancedTrainingChapter, 'id' | 'name' | 'cardComponent' | 'mediaAsset' | 'autoOpenMedia' | 'autoAdvance' | 'cardSwitchBehavior' | 'mediaSize' | 'mediaPosition'>
+        & { subChapters: Array<(
+          { __typename?: 'AdvancedTrainingSubChapter' }
+          & Pick<AdvancedTrainingSubChapter, 'id' | 'name'>
+          & { requiredActions: Array<(
+            { __typename?: 'AdvancedTrainingRequiredAction' }
+            & Pick<AdvancedTrainingRequiredAction, 'id' | 'eventName' | 'args'>
+          )> }
+        )> }
+      )>, completionChapter?: Maybe<(
+        { __typename?: 'AdvancedTrainingChapter' }
+        & Pick<AdvancedTrainingChapter, 'id' | 'name' | 'cardComponent' | 'mediaAsset' | 'autoOpenMedia' | 'autoAdvance' | 'cardSwitchBehavior' | 'mediaSize' | 'mediaPosition'>
+        & { subChapters: Array<(
+          { __typename?: 'AdvancedTrainingSubChapter' }
+          & Pick<AdvancedTrainingSubChapter, 'id' | 'name'>
+          & { requiredActions: Array<(
+            { __typename?: 'AdvancedTrainingRequiredAction' }
+            & Pick<AdvancedTrainingRequiredAction, 'id' | 'eventName' | 'args'>
+          )> }
+        )> }
+      )> }
+    )> }
   )>> }
 );
 
@@ -15480,7 +15710,44 @@ export type StationSetConfigSubscription = (
       & { cards?: Maybe<Array<(
         { __typename?: 'Card' }
         & Pick<Card, 'name' | 'component'>
-      )>> }
+      )>>, advancedTraining?: Maybe<(
+        { __typename?: 'AdvancedTrainingConfig' }
+        & Pick<AdvancedTrainingConfig, 'enabled' | 'sequentialChapters'>
+        & { chapters: Array<(
+          { __typename?: 'AdvancedTrainingChapter' }
+          & Pick<AdvancedTrainingChapter, 'id' | 'name' | 'cardComponent' | 'mediaAsset' | 'autoOpenMedia' | 'autoAdvance' | 'cardSwitchBehavior' | 'mediaSize' | 'mediaPosition'>
+          & { subChapters: Array<(
+            { __typename?: 'AdvancedTrainingSubChapter' }
+            & Pick<AdvancedTrainingSubChapter, 'id' | 'name'>
+            & { requiredActions: Array<(
+              { __typename?: 'AdvancedTrainingRequiredAction' }
+              & Pick<AdvancedTrainingRequiredAction, 'id' | 'eventName' | 'args'>
+            )> }
+          )> }
+        )>, loginChapter?: Maybe<(
+          { __typename?: 'AdvancedTrainingChapter' }
+          & Pick<AdvancedTrainingChapter, 'id' | 'name' | 'cardComponent' | 'mediaAsset' | 'autoOpenMedia' | 'autoAdvance' | 'cardSwitchBehavior' | 'mediaSize' | 'mediaPosition'>
+          & { subChapters: Array<(
+            { __typename?: 'AdvancedTrainingSubChapter' }
+            & Pick<AdvancedTrainingSubChapter, 'id' | 'name'>
+            & { requiredActions: Array<(
+              { __typename?: 'AdvancedTrainingRequiredAction' }
+              & Pick<AdvancedTrainingRequiredAction, 'id' | 'eventName' | 'args'>
+            )> }
+          )> }
+        )>, completionChapter?: Maybe<(
+          { __typename?: 'AdvancedTrainingChapter' }
+          & Pick<AdvancedTrainingChapter, 'id' | 'name' | 'cardComponent' | 'mediaAsset' | 'autoOpenMedia' | 'autoAdvance' | 'cardSwitchBehavior' | 'mediaSize' | 'mediaPosition'>
+          & { subChapters: Array<(
+            { __typename?: 'AdvancedTrainingSubChapter' }
+            & Pick<AdvancedTrainingSubChapter, 'id' | 'name'>
+            & { requiredActions: Array<(
+              { __typename?: 'AdvancedTrainingRequiredAction' }
+              & Pick<AdvancedTrainingRequiredAction, 'id' | 'eventName' | 'args'>
+            )> }
+          )> }
+        )> }
+      )> }
     )> }
   )>>> }
 );
@@ -16308,6 +16575,28 @@ export const SimulatorDataFragmentDoc = gql`
       hidden
       assigned
       newStation
+    }
+    advancedTraining {
+      enabled
+      sequentialChapters
+      chapters {
+        id
+        name
+        cardComponent
+        mediaAsset
+        autoOpenMedia
+        autoAdvance
+        cardSwitchBehavior
+        subChapters {
+          id
+          name
+          requiredActions {
+            id
+            eventName
+            args
+          }
+        }
+      }
     }
   }
 }
@@ -20168,6 +20457,28 @@ export const StationSetConfigDocument = gql`
       cards {
         name
         component
+      }
+      advancedTraining {
+        enabled
+        sequentialChapters
+        chapters {
+          id
+          name
+          cardComponent
+          mediaAsset
+          autoOpenMedia
+          autoAdvance
+          cardSwitchBehavior
+          subChapters {
+            id
+            name
+            requiredActions {
+              id
+              eventName
+              args
+            }
+          }
+        }
       }
     }
   }

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -112,6 +112,7 @@ export type AdvancedTrainingConfig = {
   sequentialChapters: Scalars['Boolean'];
   stripPosition: Scalars['String'];
   chapters: Array<AdvancedTrainingChapter>;
+  inFlightChapters: Array<AdvancedTrainingChapter>;
   loginChapter?: Maybe<AdvancedTrainingChapter>;
   completionChapter?: Maybe<AdvancedTrainingChapter>;
 };
@@ -121,6 +122,7 @@ export type AdvancedTrainingConfigInput = {
   sequentialChapters?: Maybe<Scalars['Boolean']>;
   stripPosition?: Maybe<Scalars['String']>;
   chapters?: Maybe<Array<AdvancedTrainingChapterInput>>;
+  inFlightChapters?: Maybe<Array<AdvancedTrainingChapterInput>>;
   loginChapter?: Maybe<AdvancedTrainingChapterInput>;
   completionChapter?: Maybe<AdvancedTrainingChapterInput>;
 };
@@ -3270,6 +3272,12 @@ export type Mutation = {
   clientStartAdvancedTraining?: Maybe<Scalars['String']>;
   /** Stop advanced training for a client. */
   clientStopAdvancedTraining?: Maybe<Scalars['String']>;
+  /**
+   * Crew pressed the help/question-mark widget. Resolves the crew's current card
+   * and jumps to the in-flight help chapter for that card (or the regular chapter
+   * for it), falling back to the default begin-training behavior if neither exists.
+   */
+  clientRequestTrainingHelp?: Maybe<Scalars['String']>;
   /**
    * Record a crew action during advanced training.
    * Checks against required actions and may trigger sub-chapter/chapter completion.
@@ -8200,6 +8208,11 @@ export type MutationClientStopAdvancedTrainingArgs = {
 };
 
 
+export type MutationClientRequestTrainingHelpArgs = {
+  clientId: Scalars['ID'];
+};
+
+
 export type MutationClientAdvancedTrainingActionArgs = {
   clientId: Scalars['ID'];
   eventName: Scalars['String'];
@@ -12291,6 +12304,17 @@ export type SimulatorDataFragment = (
             & Pick<AdvancedTrainingRequiredAction, 'id' | 'eventName' | 'args'>
           )> }
         )> }
+      )>, inFlightChapters: Array<(
+        { __typename?: 'AdvancedTrainingChapter' }
+        & Pick<AdvancedTrainingChapter, 'id' | 'name' | 'cardComponent' | 'mediaAsset' | 'autoOpenMedia' | 'autoAdvance' | 'autoLogin' | 'cardSwitchBehavior' | 'mediaSize' | 'mediaPosition'>
+        & { subChapters: Array<(
+          { __typename?: 'AdvancedTrainingSubChapter' }
+          & Pick<AdvancedTrainingSubChapter, 'id' | 'name'>
+          & { requiredActions: Array<(
+            { __typename?: 'AdvancedTrainingRequiredAction' }
+            & Pick<AdvancedTrainingRequiredAction, 'id' | 'eventName' | 'args'>
+          )> }
+        )> }
       )>, loginChapter?: Maybe<(
         { __typename?: 'AdvancedTrainingChapter' }
         & Pick<AdvancedTrainingChapter, 'id' | 'name' | 'cardComponent' | 'mediaAsset' | 'autoOpenMedia' | 'autoAdvance' | 'autoLogin' | 'cardSwitchBehavior' | 'mediaSize' | 'mediaPosition'>
@@ -15729,6 +15753,17 @@ export type StationSetConfigSubscription = (
               & Pick<AdvancedTrainingRequiredAction, 'id' | 'eventName' | 'args'>
             )> }
           )> }
+        )>, inFlightChapters: Array<(
+          { __typename?: 'AdvancedTrainingChapter' }
+          & Pick<AdvancedTrainingChapter, 'id' | 'name' | 'cardComponent' | 'mediaAsset' | 'autoOpenMedia' | 'autoAdvance' | 'autoLogin' | 'cardSwitchBehavior' | 'mediaSize' | 'mediaPosition'>
+          & { subChapters: Array<(
+            { __typename?: 'AdvancedTrainingSubChapter' }
+            & Pick<AdvancedTrainingSubChapter, 'id' | 'name'>
+            & { requiredActions: Array<(
+              { __typename?: 'AdvancedTrainingRequiredAction' }
+              & Pick<AdvancedTrainingRequiredAction, 'id' | 'eventName' | 'args'>
+            )> }
+          )> }
         )>, loginChapter?: Maybe<(
           { __typename?: 'AdvancedTrainingChapter' }
           & Pick<AdvancedTrainingChapter, 'id' | 'name' | 'cardComponent' | 'mediaAsset' | 'autoOpenMedia' | 'autoAdvance' | 'autoLogin' | 'cardSwitchBehavior' | 'mediaSize' | 'mediaPosition'>
@@ -16586,6 +16621,27 @@ export const SimulatorDataFragmentDoc = gql`
       sequentialChapters
       stripPosition
       chapters {
+        id
+        name
+        cardComponent
+        mediaAsset
+        autoOpenMedia
+        autoAdvance
+        autoLogin
+        cardSwitchBehavior
+        mediaSize
+        mediaPosition
+        subChapters {
+          id
+          name
+          requiredActions {
+            id
+            eventName
+            args
+          }
+        }
+      }
+      inFlightChapters {
         id
         name
         cardComponent
@@ -20514,6 +20570,27 @@ export const StationSetConfigDocument = gql`
         sequentialChapters
         stripPosition
         chapters {
+          id
+          name
+          cardComponent
+          mediaAsset
+          autoOpenMedia
+          autoAdvance
+          autoLogin
+          cardSwitchBehavior
+          mediaSize
+          mediaPosition
+          subChapters {
+            id
+            name
+            requiredActions {
+              id
+              eventName
+              args
+            }
+          }
+        }
+        inFlightChapters {
           id
           name
           cardComponent

--- a/src/helpers/tourHelper.jsx
+++ b/src/helpers/tourHelper.jsx
@@ -60,6 +60,8 @@ const TourHelper = ({
   // If we are in training mode and the station has audio or video training, don't show the tour.
   if (station.training && isMedia(station.training) && simulator.training)
     return null;
+  // If advanced training is enabled, suppress the legacy tour entirely.
+  if (station.advancedTraining?.enabled) return null;
   if (!steps) return null;
   return (
     <Tour

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -61,6 +61,86 @@ type AdvancedNavStarsData {
   activating: Boolean!
 }
 
+type AdvancedTrainingChapter {
+  id: ID!
+  name: String!
+  cardComponent: String!
+  mediaAsset: String
+  autoOpenMedia: Boolean!
+  autoAdvance: Boolean!
+  cardSwitchBehavior: String!
+  mediaSize: String!
+  mediaPosition: String!
+  subChapters: [AdvancedTrainingSubChapter!]!
+}
+
+input AdvancedTrainingChapterInput {
+  id: ID
+  name: String!
+  cardComponent: String!
+  mediaAsset: String
+  autoOpenMedia: Boolean
+  autoAdvance: Boolean
+  cardSwitchBehavior: String
+  mediaSize: String
+  mediaPosition: String
+  subChapters: [AdvancedTrainingSubChapterInput!]
+}
+
+type AdvancedTrainingConfig {
+  enabled: Boolean!
+  sequentialChapters: Boolean!
+  chapters: [AdvancedTrainingChapter!]!
+  loginChapter: AdvancedTrainingChapter
+  completionChapter: AdvancedTrainingChapter
+}
+
+input AdvancedTrainingConfigInput {
+  enabled: Boolean
+  sequentialChapters: Boolean
+  chapters: [AdvancedTrainingChapterInput!]
+  loginChapter: AdvancedTrainingChapterInput
+  completionChapter: AdvancedTrainingChapterInput
+}
+
+type AdvancedTrainingProgress {
+  id: ID!
+  clientId: ID!
+  simulatorId: ID!
+  stationName: String!
+  activeChapterId: ID
+  activeSubChapterId: ID
+  completedChapterIds: [ID!]!
+  completedSubChapterIds: [ID!]!
+  observedActions: JSON
+  mediaViewerOpen: Boolean!
+  chapterListOpen: Boolean!
+}
+
+type AdvancedTrainingRequiredAction {
+  id: ID!
+  eventName: String!
+  args: JSON
+}
+
+input AdvancedTrainingRequiredActionInput {
+  id: ID
+  eventName: String!
+  args: JSON
+}
+
+type AdvancedTrainingSubChapter {
+  id: ID!
+  name: String!
+  requiredActions: [AdvancedTrainingRequiredAction!]!
+}
+
+input AdvancedTrainingSubChapterInput {
+  id: ID
+  name: String!
+  requiredActions: [AdvancedTrainingRequiredActionInput!]
+}
+
 type Ambiance {
   id: ID!
   name: String!
@@ -222,6 +302,7 @@ type Client {
   mobile: Boolean
   cards: [String]
   keypad: Keypad
+  advancedTrainingProgress: AdvancedTrainingProgress
 }
 
 type ColoredCoordinate {
@@ -1372,6 +1453,7 @@ type InternalComm implements SystemInterface {
   damage: Damage
   stealthFactor: Float
   locations: [Room]
+  log: [String]
 }
 
 input InventoryCount {
@@ -3203,6 +3285,42 @@ type Mutation {
   """Macro: Tasks: Activate Task Flow"""
   taskFlowActivate(id: ID!, simulatorId: ID!): String
   taskFlowAdvance(simulatorId: ID!): String
+
+  """Save the full advanced training configuration for a station."""
+  setStationAdvancedTraining(stationSetID: ID!, stationName: String!, config: AdvancedTrainingConfigInput!): String
+
+  """Toggle advanced training mode on a station set."""
+  toggleAdvancedTrainingMode(stationSetID: ID!, stationName: String!, enabled: Boolean!): String
+
+  """
+  Start an advanced training session for a client.
+  Sets up progress tracking and activates the first chapter.
+  """
+  clientStartAdvancedTraining(clientId: ID!): String
+
+  """Stop advanced training for a client."""
+  clientStopAdvancedTraining(clientId: ID!): String
+
+  """
+  Record a crew action during advanced training.
+  Checks against required actions and may trigger sub-chapter/chapter completion.
+  """
+  clientAdvancedTrainingAction(clientId: ID!, eventName: String!, args: JSON): String
+
+  """Set the active chapter for a client (crew navigation or FD override)."""
+  advancedTrainingSetActiveChapter(clientId: ID!, chapterId: ID!): String
+
+  """FD force-complete a sub-chapter for a client."""
+  fdCompleteTrainingSubChapter(clientId: ID!, subChapterId: ID!): String
+
+  """FD reset all training progress for a client."""
+  fdResetTrainingProgress(clientId: ID!): String
+
+  """Toggle the media viewer open/close for a client."""
+  advancedTrainingToggleMediaViewer(clientId: ID!, open: Boolean!): String
+
+  """Toggle the chapter list open/close for a client."""
+  advancedTrainingToggleChapterList(clientId: ID!, open: Boolean!): String
   entitySetAppearance(id: ID, color: String, meshType: MeshTypeEnum, modelAsset: String, materialMapAsset: String, ringMapAsset: String, cloudMapAsset: String, emissiveColor: String, emissiveIntensity: Float, scale: Float): String
   entityRemoveAppearance(id: ID!): String
   entitySetBehavior(id: ID!, behavior: Behaviors!, targetId: ID, destination: EntityCoordinatesInput): String
@@ -3938,6 +4056,7 @@ type Query {
   dmxConfig(id: ID!): DMXConfig
   dmxConfigs: [DMXConfig!]!
   taskFlows(simulatorId: ID): [TaskFlow!]!
+  advancedTrainingProgress(clientId: ID, simulatorId: ID): [AdvancedTrainingProgress!]!
 }
 
 type Railgun implements SystemInterface {
@@ -4630,6 +4749,7 @@ type Station {
   widgets: [String]
   cards(showHidden: Boolean): [Card!]
   ambiance: String
+  advancedTraining: AdvancedTrainingConfig
 }
 
 type StationSet {
@@ -4797,6 +4917,8 @@ type Subscription {
   dmxFixtures(simulatorId: ID, clientId: ID): [DMXFixture!]!
   dmxConfigs: [DMXConfig!]!
   taskFlows(simulatorId: ID): [TaskFlow!]!
+  advancedTrainingProgressUpdate(simulatorId: ID): [AdvancedTrainingProgress!]!
+  advancedTrainingConfigUpdate(stationSetID: ID): [StationSet!]!
 }
 
 type SubspaceField implements SystemInterface {

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -68,6 +68,7 @@ type AdvancedTrainingChapter {
   mediaAsset: String
   autoOpenMedia: Boolean!
   autoAdvance: Boolean!
+  autoLogin: String!
   cardSwitchBehavior: String!
   mediaSize: String!
   mediaPosition: String!
@@ -81,6 +82,7 @@ input AdvancedTrainingChapterInput {
   mediaAsset: String
   autoOpenMedia: Boolean
   autoAdvance: Boolean
+  autoLogin: String
   cardSwitchBehavior: String
   mediaSize: String
   mediaPosition: String

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -92,7 +92,9 @@ input AdvancedTrainingChapterInput {
 type AdvancedTrainingConfig {
   enabled: Boolean!
   sequentialChapters: Boolean!
+  stripPosition: String!
   chapters: [AdvancedTrainingChapter!]!
+  inFlightChapters: [AdvancedTrainingChapter!]!
   loginChapter: AdvancedTrainingChapter
   completionChapter: AdvancedTrainingChapter
 }
@@ -100,7 +102,9 @@ type AdvancedTrainingConfig {
 input AdvancedTrainingConfigInput {
   enabled: Boolean
   sequentialChapters: Boolean
+  stripPosition: String
   chapters: [AdvancedTrainingChapterInput!]
+  inFlightChapters: [AdvancedTrainingChapterInput!]
   loginChapter: AdvancedTrainingChapterInput
   completionChapter: AdvancedTrainingChapterInput
 }
@@ -115,6 +119,7 @@ type AdvancedTrainingProgress {
   completedChapterIds: [ID!]!
   completedSubChapterIds: [ID!]!
   observedActions: JSON
+  globalObservedEvents: [String!]!
   mediaViewerOpen: Boolean!
   chapterListOpen: Boolean!
 }
@@ -3302,6 +3307,13 @@ type Mutation {
 
   """Stop advanced training for a client."""
   clientStopAdvancedTraining(clientId: ID!): String
+
+  """
+  Crew pressed the help/question-mark widget. Resolves the crew's current card
+  and jumps to the in-flight help chapter for that card (or the regular chapter
+  for it), falling back to the default begin-training behavior if neither exists.
+  """
+  clientRequestTrainingHelp(clientId: ID!): String
 
   """
   Record a crew action during advanced training.


### PR DESCRIPTION
## Description

Adds a guided, multi-chapter in-app training system for crew stations, configured per-station by the Flight Director. It supersedes the legacy media-tour for any station where it's enabled, and adds a customizable "in-flight help" path that crew can invoke mid-mission.

## What it does

**For crew:** When a station has Advanced Training enabled, an unobtrusive training strip overlays the card (position configurable top/bottom). It walks the crew chapter-by-chapter through tasks, tracking real actions they take on the card and advancing when each sub-chapter's required actions are completed. A draggable media viewer can show training video/images, and a chapter list lets crew jump around (subject to locks made by the FD). 

**For the FD:** A full config UI (Simulator Config -> Stations -> Advanced Training) to author chapters, sub-chapters, and the exact required actions for each. Actions are captured by interacting with a live card preview running in a throwaway sandboxed flight. Supports a dedicated login chapter (with auto-login options), a completion chapter, per-chapter media/auto-advance/auto-card-switch behavior. It also allows FDs to configure in-flight help chapters (triggered from the ? button) tied to specific cards. These cards don't need to be attached to the current station that's being configured. This allows for additional training to be customized to a card that may be added part way through a mission. 

This feature is also opt-in, all training flows prior to this feature are maintained and unchanged. 

## Related Issue

This is part of the training flow modification effort by the CMSC. 

## Screenshots (if appropriate):

Core + Setup
<img width="1727" height="920" alt="Screenshot 2026-06-14 at 7 05 42 PM" src="https://github.com/user-attachments/assets/2e808dd0-7b28-4ffd-9a3b-fc19ee665246" />
<img width="1727" height="920" alt="Screenshot 2026-06-14 at 7 06 48 PM" src="https://github.com/user-attachments/assets/4e454b25-aac3-4bef-9a0a-b4ba4f7c87ac" />
<img width="1727" height="920" alt="Screenshot 2026-06-14 at 7 07 13 PM" src="https://github.com/user-attachments/assets/9545f1a8-13eb-481d-a5ef-e36170a12fe7" />
<img width="1727" height="908" alt="Screenshot 2026-06-14 at 7 07 32 PM" src="https://github.com/user-attachments/assets/aa7b15e5-550d-4dd4-ba0c-6dcf58cbde73" />

Actual Training UI
<img width="1727" height="920" alt="Screenshot 2026-06-14 at 7 06 11 PM" src="https://github.com/user-attachments/assets/4d30b013-76ac-4299-b7bf-121b25fe0375" />
<img width="1727" height="920" alt="Screenshot 2026-06-14 at 7 06 33 PM" src="https://github.com/user-attachments/assets/4710f9dd-84e8-4f0f-a39f-e9a83a8fb739" />
<img width="1727" height="908" alt="Screenshot 2026-06-14 at 7 08 56 PM" src="https://github.com/user-attachments/assets/1841269e-8cd4-421c-9d16-54a13828d6fb" />

Video: 
This video is old, and doesn't have all of the fixes / in-flight chapters code, but anything I reference in the video has been completed and included in this PR. 

https://drive.google.com/drive/folders/1QgVwmdVZo0O3aUCMrJMrS96VN2eul2-Q?usp=sharing

I also had claude go through and do a breakdown of the arch involved, here's what it came up with. 

## Architecture

  ### Server
  - New models: `AdvancedTrainingConfig` (+ `Chapter` / `SubChapter` /
    `RequiredAction`) on each station, and `AdvancedTrainingProgress` tracking a
    client's live position. Both are persisted in snapshots.
  - Event handlers (`server/events/advancedTraining*.ts`) drive the session
    lifecycle, action-matching, chapter advancement, navigation, in-flight help,
    and FD interventions. Card prerequisites gate chapter access.
  - GraphQL: new types, the `setStationAdvancedTraining` / `toggleAdvancedTrainingMode`
    config mutations, the `client*AdvancedTraining*` runtime mutations, and the
    `advancedTrainingProgressUpdate` subscription.
  - Integration: `clientSetTraining` delegates to Advanced Training when the
    station has it enabled; the legacy tour is suppressed in that case.

  ### Client
  - `AdvancedTrainingBorder` wraps each card (in `Card.tsx`) and renders the strip,
    media viewer, and chapter list; `useAdvancedTraining` is the data/mutation hook.
  - `actionRegistry` maps card components to human-readable recordable actions.
  - FD config UI: the config page, `ChapterEditor`, the sandbox-backed
    `RecordActionsModal`, the in-flight chapters section, and a progress dashboard.
