### PR TITLE
feat: Added ability to lock a tactical map object to screen

### DIFF
--- a/server/classes/tacticalMap.js
+++ b/server/classes/tacticalMap.js
@@ -41,6 +41,9 @@ class TacticalItem {
     this.flash = params.flash || false;
     this.icon = params.icon || null;
     this.size = params.size || 1;
+    this.iconWidth = params.iconWidth || 0;
+    this.iconHeight = params.iconHeight || 0;
+    this.keepOnScreen = params.keepOnScreen || false;
     this.speed = params.speed || 1000;
     this.velocity = params.velocity || {x: 0, y: 0, z: 0};
     this.location = params.location || {x: 0, y: 0, z: 0};
@@ -60,6 +63,9 @@ class TacticalItem {
     flash,
     icon,
     size,
+    iconWidth,
+    iconHeight,
+    keepOnScreen,
     speed,
     velocity,
     location,
@@ -79,6 +85,9 @@ class TacticalItem {
     if (flash || flash === false) this.flash = flash;
     if (icon || icon === "") this.icon = icon;
     if (size) this.size = size;
+    if (iconWidth) this.iconWidth = iconWidth;
+    if (iconHeight) this.iconHeight = iconHeight;
+    if (keepOnScreen || keepOnScreen === false) this.keepOnScreen = keepOnScreen;
     if (speed || speed === 0) this.speed = speed;
     if (velocity) this.velocity = velocity;
     if (location) this.location = location;

--- a/server/helpers/tacticalBounds.js
+++ b/server/helpers/tacticalBounds.js
@@ -1,0 +1,47 @@
+// Shared "keep on screen" clamp math for Tactical Map objects (server copy).
+//
+// Tactical items store their position as normalized {x, y, z} fractions where 0 is
+// the left/top edge and 1 is the right/bottom edge. When an item has `keepOnScreen`
+// enabled we constrain the position so the *entire* scaled icon stays within [0, 1].
+//
+// The footprint is computed against the canonical 1920x1080 viewscreen so the clamp is
+// identical on the server (authoritative) and on every client, regardless of the actual
+// canvas size.
+//
+// NOTE: This file is intentionally duplicated at
+// `src/components/views/TacticalMap/preview/layerComps/clampToBounds.js`. The client
+// (Vite, tsconfig include: src) and the server (tsconfig include: server) cannot import
+// across that boundary, so keep the two copies in sync.
+
+export const CANONICAL_WIDTH = 1920;
+export const CANONICAL_HEIGHT = 1080;
+
+export function getFootprint(
+  item,
+  canvasWidth = CANONICAL_WIDTH,
+  canvasHeight = CANONICAL_HEIGHT,
+) {
+  const size = item.size || 1;
+  const w = ((item.iconWidth || 0) * size) / canvasWidth;
+  const h = ((item.iconHeight || 0) * size) / canvasHeight;
+  return {w, h};
+}
+
+export function clampToBounds(position, footprint) {
+  const maxX = Math.max(0, 1 - footprint.w);
+  const maxY = Math.max(0, 1 - footprint.h);
+  return {
+    x: Math.min(Math.max(position.x, 0), maxX),
+    y: Math.min(Math.max(position.y, 0), maxY),
+    z: position.z,
+  };
+}
+
+export function clampItemPosition(
+  item,
+  position,
+  canvasWidth = CANONICAL_WIDTH,
+  canvasHeight = CANONICAL_HEIGHT,
+) {
+  return clampToBounds(position, getFootprint(item, canvasWidth, canvasHeight));
+}

--- a/server/processes/tacticalMapMove.js
+++ b/server/processes/tacticalMapMove.js
@@ -1,6 +1,7 @@
 import App from "../app";
 import * as THREE from "three";
 import {pubsub} from "../helpers/subscriptionManager";
+import {clampItemPosition} from "../helpers/tacticalBounds";
 
 const interval = 1000 / 5;
 let lastTime = Date.now();
@@ -42,15 +43,28 @@ const moveTacticalMap = () => {
   App.tacticalMaps.forEach(m => {
     m.layers.forEach(l => {
       l.items.forEach(i => {
-        i.update({
-          location: moveContact(
-            i.destination,
-            i.location,
-            i.speed,
-            m.frozen,
-            delta,
-          ),
-        });
+        let location = moveContact(
+          i.destination,
+          i.location,
+          i.speed,
+          m.frozen,
+          delta,
+        );
+        // Authoritative backstop: never let the animated location settle
+        // off screen when the contact is constrained. Also pull a (possibly
+        // newly-constrained) destination back on screen so the persisted value
+        // converges instead of drifting.
+        if (i.keepOnScreen) {
+          location = clampItemPosition(i, location);
+          const destination = clampItemPosition(i, i.destination);
+          if (
+            destination.x !== i.destination.x ||
+            destination.y !== i.destination.y
+          ) {
+            i.update({destination});
+          }
+        }
+        i.update({location});
       });
     });
     m.interval = interval;

--- a/server/processes/thrusters.js
+++ b/server/processes/thrusters.js
@@ -1,5 +1,6 @@
 import App from "../app";
 import {pubsub} from "../helpers/subscriptionManager";
+import {clampItemPosition} from "../helpers/tacticalBounds";
 
 function getMovementDirection(direction, movement) {
   if (movement === "up") return Math.abs(direction.z < 0 ? direction.z : 0);
@@ -189,6 +190,15 @@ const updateThrusters = () => {
                   item.destination.y += movement.y;
                   item.location.x += movement.x;
                   item.location.y += movement.y;
+                }
+                // Keep the icon on screen if requested. Clamping the stored
+                // values (rather than only the rendered position) cancels the
+                // "drift" at the edge: holding thrust into a wall no longer
+                // accumulates an off-screen position, so reversing thrust moves
+                // the contact immediately with no dead-zone.
+                if (item.keepOnScreen) {
+                  item.destination = clampItemPosition(item, item.destination);
+                  item.location = clampItemPosition(item, item.location);
                 }
               });
             });

--- a/server/typeDefs/tacticalMap.ts
+++ b/server/typeDefs/tacticalMap.ts
@@ -102,6 +102,10 @@ const schema = gql`
     icon: String
     size: Float
     opacity: Float
+    # Intrinsic pixel dimensions of the icon image, measured by the client.
+    # Used to compute the icon footprint for the keepOnScreen clamp.
+    iconWidth: Float
+    iconHeight: Float
 
     #Animation
     speed: Float
@@ -116,6 +120,8 @@ const schema = gql`
     thrusters: Boolean
     rotationMatch: Boolean
     thrusterControls: ThrusterControls
+    # When true, the object is constrained so its full icon stays on screen.
+    keepOnScreen: Boolean
   }
 
   input TacticalItemInput {
@@ -132,6 +138,8 @@ const schema = gql`
     icon: String
     size: Float
     opacity: Float
+    iconWidth: Float
+    iconHeight: Float
 
     #Animation
     speed: Float
@@ -145,6 +153,7 @@ const schema = gql`
     thrusters: Boolean
     rotationMatch: Boolean
     thrusterControls: ThrusterControlsInput
+    keepOnScreen: Boolean
   }
 
   type TacticalPath {

--- a/src/components/views/TacticalMap/objectConfig.jsx
+++ b/src/components/views/TacticalMap/objectConfig.jsx
@@ -331,6 +331,7 @@ const ObjectSettings = ({
   flash,
   ijkl,
   wasd,
+  keepOnScreen,
   opacity,
   updateObject,
   //thrusters,
@@ -439,6 +440,19 @@ const ObjectSettings = ({
               onChange={evt => updateObject("ijkl", evt.target.checked)}
             />
             IJKL Keys
+          </Label>
+        </FormGroup>
+        <FormGroup check>
+          <Label check>
+            <Input
+              type="checkbox"
+              checked={keepOnScreen}
+              onChange={evt =>
+                updateObject("keepOnScreen", evt.target.checked)
+              }
+            />
+            Keep on screen{" "}
+            <small>Stops the icon from moving off the edge of the screen.</small>
           </Label>
         </FormGroup>
         <Button size="sm" color="danger" onClick={() => removeObject()}>

--- a/src/components/views/TacticalMap/preview/index.jsx
+++ b/src/components/views/TacticalMap/preview/index.jsx
@@ -2,6 +2,7 @@ import React, {Component} from "react";
 import layerComps from "./layerComps";
 import {withApollo} from "react-apollo";
 import gql from "graphql-tag.macro";
+import {clampItemPosition} from "./layerComps/clampToBounds";
 class TacticalMapPreview extends Component {
   keypress = evt => {
     const distance = 0.005;
@@ -39,15 +40,15 @@ class TacticalMapPreview extends Component {
             (wasd.indexOf(evt.code) > -1 && i.wasd) ||
             (ijkl.indexOf(evt.code) > -1 && i.ijkl)
           ) {
-            this.props.updateObject(
-              "destination",
-              {
-                x: i.destination.x + movement.x,
-                y: i.destination.y + movement.y,
-                z: i.destination.z,
-              },
-              i,
-            );
+            let destination = {
+              x: i.destination.x + movement.x,
+              y: i.destination.y + movement.y,
+              z: i.destination.z,
+            };
+            if (i.keepOnScreen) {
+              destination = clampItemPosition(i, destination);
+            }
+            this.props.updateObject("destination", destination, i);
           }
         });
       }

--- a/src/components/views/TacticalMap/preview/layerComps/IconMarkup.jsx
+++ b/src/components/views/TacticalMap/preview/layerComps/IconMarkup.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import {clampItemPosition} from "./clampToBounds";
 
 const IconMarkup = ({
   mouseDown,
@@ -20,9 +21,29 @@ const IconMarkup = ({
   core,
   isSelected,
   interval,
+  keepOnScreen,
+  iconWidth,
+  iconHeight,
+  onIconLoad,
 }) => {
   if (core) {
     opacity = Math.max(0.5, opacity);
+  }
+  // Defensive render-time clamp: even if a stored position somehow drifted off
+  // screen, a keepOnScreen icon is never displayed clipping past the edge.
+  if (keepOnScreen) {
+    const footprintItem = {size, iconWidth, iconHeight};
+    if (location) {
+      location = clampItemPosition(footprintItem, location);
+    }
+    if (destination) {
+      destination = clampItemPosition(footprintItem, {
+        x: destination.x + movement.x,
+        y: destination.y + movement.y,
+        z: destination.z,
+      });
+      movement = {x: 0, y: 0, z: 0};
+    }
   }
   return [
     location ? (
@@ -49,6 +70,7 @@ const IconMarkup = ({
               draggable={false}
               src={src}
               style={{transform: `rotate(${rotation}deg)`}}
+              onLoad={onIconLoad ? evt => onIconLoad(evt.target) : undefined}
             />
           )}
           <pre

--- a/src/components/views/TacticalMap/preview/layerComps/TacticalIcon.jsx
+++ b/src/components/views/TacticalMap/preview/layerComps/TacticalIcon.jsx
@@ -1,5 +1,6 @@
 import React, {Component} from "react";
 import IconMarkup from "./IconMarkup";
+import {clampItemPosition} from "./clampToBounds";
 
 export default class TacticalIcon extends Component {
   constructor(props) {
@@ -38,7 +39,10 @@ export default class TacticalIcon extends Component {
     if (this.props.isSelected) {
       this.props.moveMultiple("cancel");
     } else {
-      const {x, y, z} = this.state.destination;
+      let {x, y, z} = this.state.destination;
+      if (this.props.keepOnScreen) {
+        ({x, y, z} = clampItemPosition(this.props, {x, y, z}));
+      }
       this.props.updateObject("destination", {x, y, z});
 
       this.dragging = false;
@@ -57,11 +61,27 @@ export default class TacticalIcon extends Component {
       this.props.moveMultiple(evt, bounds);
     } else {
       const {destination} = this.state;
-      const x = destination.x + evt.movementX / bounds.width;
-      const y = destination.y + evt.movementY / bounds.height;
+      let x = destination.x + evt.movementX / bounds.width;
+      let y = destination.y + evt.movementY / bounds.height;
+      if (this.props.keepOnScreen) {
+        ({x, y} = clampItemPosition(this.props, {x, y, z: destination.z}));
+      }
       this.setState({
         destination: Object.assign({}, this.state.destination, {x, y}),
       });
+    }
+  };
+  // Measure the icon's intrinsic dimensions once and persist them so the server
+  // (and every client) can compute the keepOnScreen footprint. Stored only when
+  // missing or changed, so this fires at most once per icon.
+  handleIconLoad = ({naturalWidth, naturalHeight}) => {
+    if (!naturalWidth || !naturalHeight) return;
+    const {id, layerId, iconWidth, iconHeight} = this.props;
+    if (iconWidth !== naturalWidth) {
+      this.props.updateObject("iconWidth", naturalWidth, {id, layerId});
+    }
+    if (iconHeight !== naturalHeight) {
+      this.props.updateObject("iconHeight", naturalHeight, {id, layerId});
     }
   };
   render() {
@@ -84,6 +104,9 @@ export default class TacticalIcon extends Component {
       interval,
       movement = {x: 0, y: 0, z: 0},
       isSelected,
+      keepOnScreen,
+      iconWidth,
+      iconHeight,
     } = this.props;
     if (icon) {
       return (
@@ -107,6 +130,10 @@ export default class TacticalIcon extends Component {
           fontSize={fontSize}
           label={label}
           core={core}
+          keepOnScreen={keepOnScreen}
+          iconWidth={iconWidth}
+          iconHeight={iconHeight}
+          onIconLoad={this.handleIconLoad}
         />
       );
     }

--- a/src/components/views/TacticalMap/preview/layerComps/clampToBounds.js
+++ b/src/components/views/TacticalMap/preview/layerComps/clampToBounds.js
@@ -1,0 +1,55 @@
+// Shared "keep on screen" clamp math for Tactical Map objects.
+//
+// Tactical items store their position as normalized {x, y, z} fractions where 0 is
+// the left/top edge and 1 is the right/bottom edge, rendered with
+// `translate(x*100%, y*100%)`. When an item has `keepOnScreen` enabled we constrain
+// the position so the *entire* scaled icon stays within [0, 1].
+//
+// The footprint is computed against the canonical 1920x1080 viewscreen so the clamp
+// is identical on the server (authoritative) and on every client, regardless of the
+// actual canvas size (the rendered position is normalized, so it is scale-invariant).
+//
+// NOTE: This file is intentionally duplicated at
+// `server/helpers/tacticalBounds.js`. The client (Vite, tsconfig include: src) and the
+// server (tsconfig include: server) cannot import across that boundary, so keep the two
+// copies in sync.
+
+export const CANONICAL_WIDTH = 1920;
+export const CANONICAL_HEIGHT = 1080;
+
+// Returns the normalized {w, h} footprint of the scaled icon. `iconWidth`/`iconHeight`
+// are the icon image's intrinsic pixel dimensions (measured once on the client).
+export function getFootprint(
+  item,
+  canvasWidth = CANONICAL_WIDTH,
+  canvasHeight = CANONICAL_HEIGHT,
+) {
+  const size = item.size || 1;
+  const w = ((item.iconWidth || 0) * size) / canvasWidth;
+  const h = ((item.iconHeight || 0) * size) / canvasHeight;
+  return {w, h};
+}
+
+// Clamps a normalized position so the icon's footprint stays fully on screen.
+export function clampToBounds(position, footprint) {
+  const maxX = Math.max(0, 1 - footprint.w);
+  const maxY = Math.max(0, 1 - footprint.h);
+  return {
+    x: Math.min(Math.max(position.x, 0), maxX),
+    y: Math.min(Math.max(position.y, 0), maxY),
+    z: position.z,
+  };
+}
+
+// Convenience: clamp a position for a given item using its stored footprint.
+export function clampItemPosition(
+  item,
+  position,
+  canvasWidth = CANONICAL_WIDTH,
+  canvasHeight = CANONICAL_HEIGHT,
+) {
+  return clampToBounds(
+    position,
+    getFootprint(item, canvasWidth, canvasHeight),
+  );
+}

--- a/src/components/views/TacticalMap/preview/layerComps/clampToBounds.test.js
+++ b/src/components/views/TacticalMap/preview/layerComps/clampToBounds.test.js
@@ -1,0 +1,72 @@
+import {describe, it, expect} from "vitest";
+import {getFootprint, clampToBounds, clampItemPosition} from "./clampToBounds";
+
+describe("getFootprint", () => {
+  it("normalizes the scaled icon against the canonical viewscreen", () => {
+    const fp = getFootprint({size: 1, iconWidth: 192, iconHeight: 108});
+    expect(fp.w).toBeCloseTo(0.1);
+    expect(fp.h).toBeCloseTo(0.1);
+  });
+
+  it("scales with the icon size", () => {
+    const fp = getFootprint({size: 2, iconWidth: 192, iconHeight: 108});
+    expect(fp.w).toBeCloseTo(0.2);
+    expect(fp.h).toBeCloseTo(0.2);
+  });
+
+  it("treats missing dimensions as zero footprint", () => {
+    const fp = getFootprint({size: 1});
+    expect(fp).toEqual({w: 0, h: 0});
+  });
+});
+
+describe("clampToBounds", () => {
+  const footprint = {w: 0.1, h: 0.1};
+
+  it("leaves an in-bounds position untouched", () => {
+    expect(clampToBounds({x: 0.5, y: 0.5, z: 0}, footprint)).toEqual({
+      x: 0.5,
+      y: 0.5,
+      z: 0,
+    });
+  });
+
+  it("clamps past the right/bottom edge to keep the full icon visible", () => {
+    expect(clampToBounds({x: 1.5, y: 2, z: 0}, footprint)).toEqual({
+      x: 0.9,
+      y: 0.9,
+      z: 0,
+    });
+  });
+
+  it("clamps past the left/top edge to zero", () => {
+    expect(clampToBounds({x: -1, y: -0.3, z: 0}, footprint)).toEqual({
+      x: 0,
+      y: 0,
+      z: 0,
+    });
+  });
+
+  it("pins an oversized icon (footprint > 1) to the top-left", () => {
+    expect(clampToBounds({x: 0.5, y: 0.5, z: 0}, {w: 1.5, h: 2})).toEqual({
+      x: 0,
+      y: 0,
+      z: 0,
+    });
+  });
+
+  it("preserves the z coordinate", () => {
+    expect(clampToBounds({x: 0.5, y: 0.5, z: 0.42}, footprint).z).toBe(0.42);
+  });
+});
+
+describe("clampItemPosition", () => {
+  it("clamps using the item's stored footprint", () => {
+    const item = {size: 1, iconWidth: 192, iconHeight: 108};
+    expect(clampItemPosition(item, {x: 1, y: 1, z: 0})).toEqual({
+      x: 0.9,
+      y: 0.9,
+      z: 0,
+    });
+  });
+});

--- a/src/components/views/TacticalMap/preview/layerComps/objects.jsx
+++ b/src/components/views/TacticalMap/preview/layerComps/objects.jsx
@@ -2,6 +2,12 @@ import React from "react";
 import TacticalIcon from "./TacticalIcon";
 import Selection from "./select";
 import useInterval from "helpers/hooks/useInterval";
+import {clampItemPosition} from "./clampToBounds";
+
+// Extra slack (in px) added to the off-screen deletion boundary so contacts that
+// sit right at the edge — especially keepOnScreen ones pinned against it — are not
+// deleted by accident during a multi-select drag.
+const DELETE_MARGIN = 40;
 
 const Objects = ({
   id,
@@ -40,16 +46,30 @@ const Objects = ({
         x = x + movement.x;
         y = y + movement.y;
 
+        // Constrained contacts are clamped back on screen instead of being
+        // dragged off and deleted.
+        if (item.keepOnScreen) {
+          updateObject(
+            "destination",
+            clampItemPosition(item, {x, y, z}),
+            item,
+            speed,
+          );
+          return;
+        }
+
         const el = document.getElementById(`tactical-icon-${item.id}`);
         const elBounds = el.getBoundingClientRect();
         const leftBound =
           (-1 * (elBounds.width / item.size + canvasBounds.left)) /
-          canvasBounds.width;
-        const rightBound = 1 + 20 / canvasBounds.width;
+            canvasBounds.width -
+          DELETE_MARGIN / canvasBounds.width;
+        const rightBound = 1 + DELETE_MARGIN / canvasBounds.width;
         const topBound =
           (-1 * (elBounds.height / item.size + canvasBounds.top)) /
-          canvasBounds.height;
-        const bottomBound = 1 + 20 / canvasBounds.height;
+            canvasBounds.height -
+          DELETE_MARGIN / canvasBounds.height;
+        const bottomBound = 1 + DELETE_MARGIN / canvasBounds.height;
         if (
           x > rightBound ||
           x < leftBound ||

--- a/src/components/views/TacticalMap/queries/tacticalMap.graphql
+++ b/src/components/views/TacticalMap/queries/tacticalMap.graphql
@@ -19,6 +19,9 @@ subscription TacticalMapUpdate($id: ID!) {
         fontColor
         icon
         size
+        iconWidth
+        iconHeight
+        keepOnScreen
         speed
         velocity {
           x

--- a/src/components/viewscreens/TacticalMap/index.jsx
+++ b/src/components/viewscreens/TacticalMap/index.jsx
@@ -26,6 +26,9 @@ const fragment = gql`
         fontColor
         icon
         size
+        iconWidth
+        iconHeight
+        keepOnScreen
         speed
         velocity {
           x

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -11553,6 +11553,8 @@ export type TacticalItem = {
   icon?: Maybe<Scalars['String']>;
   size?: Maybe<Scalars['Float']>;
   opacity?: Maybe<Scalars['Float']>;
+  iconWidth?: Maybe<Scalars['Float']>;
+  iconHeight?: Maybe<Scalars['Float']>;
   speed?: Maybe<Scalars['Float']>;
   velocity?: Maybe<Coordinates>;
   location?: Maybe<Coordinates>;
@@ -11564,6 +11566,7 @@ export type TacticalItem = {
   thrusters?: Maybe<Scalars['Boolean']>;
   rotationMatch?: Maybe<Scalars['Boolean']>;
   thrusterControls?: Maybe<ThrusterControls>;
+  keepOnScreen?: Maybe<Scalars['Boolean']>;
 };
 
 export type TacticalItemInput = {
@@ -11576,6 +11579,8 @@ export type TacticalItemInput = {
   icon?: Maybe<Scalars['String']>;
   size?: Maybe<Scalars['Float']>;
   opacity?: Maybe<Scalars['Float']>;
+  iconWidth?: Maybe<Scalars['Float']>;
+  iconHeight?: Maybe<Scalars['Float']>;
   speed?: Maybe<Scalars['Float']>;
   velocity?: Maybe<CoordinatesInput>;
   location?: Maybe<CoordinatesInput>;
@@ -11586,6 +11591,7 @@ export type TacticalItemInput = {
   thrusters?: Maybe<Scalars['Boolean']>;
   rotationMatch?: Maybe<Scalars['Boolean']>;
   thrusterControls?: Maybe<ThrusterControlsInput>;
+  keepOnScreen?: Maybe<Scalars['Boolean']>;
 };
 
 export type TacticalLayer = {
@@ -14336,7 +14342,7 @@ export type TacticalMapUpdateSubscription = (
       & Pick<TacticalLayer, 'id' | 'name' | 'type' | 'image' | 'color' | 'labels' | 'gridCols' | 'gridRows' | 'advance' | 'asset' | 'autoplay' | 'loop' | 'playbackSpeed' | 'opacity' | 'mute'>
       & { items?: Maybe<Array<Maybe<(
         { __typename?: 'TacticalItem' }
-        & Pick<TacticalItem, 'id' | 'layerId' | 'font' | 'label' | 'fontSize' | 'fontColor' | 'icon' | 'size' | 'speed' | 'rotation' | 'opacity' | 'flash' | 'ijkl' | 'wasd' | 'thrusters' | 'rotationMatch'>
+        & Pick<TacticalItem, 'id' | 'layerId' | 'font' | 'label' | 'fontSize' | 'fontColor' | 'icon' | 'size' | 'iconWidth' | 'iconHeight' | 'keepOnScreen' | 'speed' | 'rotation' | 'opacity' | 'flash' | 'ijkl' | 'wasd' | 'thrusters' | 'rotationMatch'>
         & { velocity?: Maybe<(
           { __typename?: 'Coordinates' }
           & Pick<Coordinates, 'x' | 'y'>
@@ -19219,6 +19225,9 @@ export const TacticalMapUpdateDocument = gql`
         fontColor
         icon
         size
+        iconWidth
+        iconHeight
+        keepOnScreen
         speed
         velocity {
           x

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -5118,6 +5118,8 @@ type TacticalItem {
   icon: String
   size: Float
   opacity: Float
+  iconWidth: Float
+  iconHeight: Float
   speed: Float
   velocity: Coordinates
   location: Coordinates
@@ -5129,6 +5131,7 @@ type TacticalItem {
   thrusters: Boolean
   rotationMatch: Boolean
   thrusterControls: ThrusterControls
+  keepOnScreen: Boolean
 }
 
 input TacticalItemInput {
@@ -5141,6 +5144,8 @@ input TacticalItemInput {
   icon: String
   size: Float
   opacity: Float
+  iconWidth: Float
+  iconHeight: Float
   speed: Float
   velocity: CoordinatesInput
   location: CoordinatesInput
@@ -5151,6 +5156,7 @@ input TacticalItemInput {
   thrusters: Boolean
   rotationMatch: Boolean
   thrusterControls: ThrusterControlsInput
+  keepOnScreen: Boolean
 }
 
 type TacticalLayer {


### PR DESCRIPTION
## Description

Implemented the ability to lock an tactical map icon to the screen borders. 

As a note, there was a duplicated file, as the logic needed to be shared across the server and the client, and the tsconfig wasn't playing nice with trying to reference files across that barrier. If needed I can go back and do some additional modifications to force that to work, but overall, it should be pretty straightforward. 

Code changes include:

Adding some height and width fields, as well as a boolean field to signify that it should lock to screen. 

Additional code changes are about checking that field, and making sure that the icon stays where it needs to. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/Thorium-Sim/thorium/issues/3513

## Screenshots (if appropriate):
Map: 
<img width="868" height="418" alt="Screenshot 2026-06-30 at 11 17 38 AM" src="https://github.com/user-attachments/assets/482e57d4-9268-4048-8a59-184e6a31e058" />

Original Map after I've thrustered / AWSD / JKLI everything off the map: 
<img width="868" height="418" alt="Screenshot 2026-06-30 at 11 17 28 AM" src="https://github.com/user-attachments/assets/2fcd6021-f276-4875-90c7-a3c59e4ecef0" />


New Map with icons that have the lock to screen boolean added:
<img width="868" height="418" alt="Screenshot 2026-06-30 at 11 18 25 AM" src="https://github.com/user-attachments/assets/e700e4d6-ac7d-40be-8ffc-531bf453ef75" />

- [ ] I submitted a pull request or created an issue for documenting this
      feature on the [Thorium Docs](https://github.com/Thorium-Sim/thorium-docs)
      repo. (Include the issue or pull request url below.)
