### PR TITLE
Fix/repeatable timeline actions and advnav estop

### DIFF
--- a/server/__tests__/classes/flightSetHelpers.test.js
+++ b/server/__tests__/classes/flightSetHelpers.test.js
@@ -1,0 +1,43 @@
+import {
+  getLastVisitedCoordinate,
+  getPositionAtTime,
+} from "../../classes/flightSets/helpers";
+
+// A flight path that has been engaged but has not finished starting up has no
+// generated coordinates yet. These used to walk off the end of the array and hand
+// back `undefined`, which was then assigned to the non-null `currentLocation`
+// field and took every advanced navigation card down with it.
+describe("flight set path helpers with an empty path", () => {
+  test("getPositionAtTime returns a usable coordinate", () => {
+    const position = getPositionAtTime(1, [], 0);
+    expect(position).toBeDefined();
+    expect(Number.isFinite(position.x)).toBe(true);
+    expect(Number.isFinite(position.y)).toBe(true);
+  });
+
+  test("getLastVisitedCoordinate returns a usable coordinate", () => {
+    const coordinate = getLastVisitedCoordinate(1, [], 0);
+    expect(coordinate).toBeDefined();
+    expect(Number.isFinite(coordinate.x)).toBe(true);
+    expect(Number.isFinite(coordinate.y)).toBe(true);
+  });
+});
+
+describe("flight set path helpers with a real path", () => {
+  const path = [
+    {x: 0, y: 0, speed: 1, color: "white"},
+    {x: 100, y: 0, speed: 1, color: "white"},
+  ];
+
+  test("getPositionAtTime interpolates along the path", () => {
+    expect(getPositionAtTime(5, path, 10)).toEqual({x: 50, y: 0});
+  });
+
+  test("getPositionAtTime clamps to the end of the path", () => {
+    expect(getPositionAtTime(500, path, 10)).toEqual(path[path.length - 1]);
+  });
+
+  test("getLastVisitedCoordinate returns the start before departure", () => {
+    expect(getLastVisitedCoordinate(0, path, 10)).toEqual(path[0]);
+  });
+});

--- a/server/classes/advancedNavigationAndAstrometrics.ts
+++ b/server/classes/advancedNavigationAndAstrometrics.ts
@@ -67,6 +67,7 @@ export default class AdvancedNavigationAndAstrometrics extends System {
         this.locationMap = {}
         this.resyncProbes();
         this.lastTransitIndex = 0;
+        this.normalizeCurrentLocation();
     }
 
 
@@ -152,7 +153,28 @@ export default class AdvancedNavigationAndAstrometrics extends System {
     }
 
 
+    // currentLocation is a non-null GraphQL field. If it ever goes missing or picks up NaN
+    // coordinates the whole system serializes to null and every advanced nav card throws while
+    // rendering, so repair it rather than letting it out the door. Also heals a snapshot that
+    // was saved while the state was bad.
+    normalizeCurrentLocation() {
+        const location = this.currentLocation as BasicCoordinate | undefined;
+        if (
+            location &&
+            Number.isFinite(location.x) &&
+            Number.isFinite(location.y)
+        ) {
+            return;
+        }
+        const fallback = this.currentFlightSet?.defaultStartingLocation;
+        this.currentLocation =
+            fallback && Number.isFinite(fallback.x) && Number.isFinite(fallback.y)
+                ? { ...fallback }
+                : { x: 0, y: 0 };
+    }
+
     executeLoopInterval() {
+        this.normalizeCurrentLocation();
         if (this.currentFlightPath && this.currentFlightSet) {
 
             const currentTimestamp = generateCurrentUnixTimestamp();
@@ -187,6 +209,12 @@ export default class AdvancedNavigationAndAstrometrics extends System {
             else if (this.engineStatus === EngineStatus.ENGAGED || this.engineStatus === EngineStatus.FULL_POWER || this.engineStatus === EngineStatus.FLUX) {
                 if (this.power.power < this.power.powerLevels[0] || this.damage.damaged) {
                     // shutdown the engine
+                    this.engineStatus = EngineStatus.STOPPED;
+                    return;
+                }
+                if (!this.flightPathCoords?.length || !this.totalEta) {
+                    // Under way with nothing to travel along - there is no position to
+                    // interpolate, so stop instead of walking off the end of the path.
                     this.engineStatus = EngineStatus.STOPPED;
                     return;
                 }
@@ -280,6 +308,9 @@ export default class AdvancedNavigationAndAstrometrics extends System {
     }
 
     updateFlightSet(flightSet: FlightSet) {
+        // Never stash a bad location into locationMap - that is what makes a corrupted
+        // location survive switching flight sets and coming back.
+        this.normalizeCurrentLocation();
         const oldFlightPaths = [...this.flightPaths];
         const locationMap = { ...this.locationMap };
         const setMap = { ...this.flightSetPathMap };
@@ -336,10 +367,32 @@ export default class AdvancedNavigationAndAstrometrics extends System {
         }
     }
     handleEmergencyStop() {
+        // Stopping during startup is an abort: the ship never left, and no flight path
+        // coordinates or ETA have been generated yet. Leaving the path in place would let
+        // the crew "resume" into a flight with an empty path, which corrupts currentLocation.
+        if (this.engineStatus === EngineStatus.STARTUP) {
+            this.currentFlightPath = undefined;
+            this.remainingStartupTime = undefined;
+            this.flightPathCoords = [];
+            this.remainingEta = 0;
+            this.totalEta = 0;
+            this.lastTransitIndex = 0;
+        }
         this.engineStatus = EngineStatus.STOPPED;
     }
     handleResumePath() {
-        this.engineStatus = EngineStatus.ENGAGED;
+        // Only a flight that actually got under way can be resumed - anything else has no
+        // path coordinates to move along.
+        if (!this.currentFlightPath || !this.flightPathCoords?.length || !this.totalEta) {
+            this.engineStatus = EngineStatus.STOPPED;
+            return;
+        }
+        if (this.currentFlightPath.speedOption?.requiresMaxEngines) {
+            this.engineStatus = EngineStatus.FULL_POWER;
+        }
+        else {
+            this.engineStatus = EngineStatus.ENGAGED;
+        }
     }
     handleShowFlightSet(show: boolean) {
         this.showFlightSet = show;

--- a/server/classes/flightSets/helpers.ts
+++ b/server/classes/flightSets/helpers.ts
@@ -235,6 +235,12 @@ export const generateSpeedColor = (index: number) => {
 }
 
 export function getPositionAtTime(t: number, path: FullCoordinate[], totalTime: number): { x: number, y: number } {
+    // An empty path has no position to report. Returning path[-1] here would hand back
+    // undefined, which nulls out the non-null currentLocation field downstream.
+    if (!path?.length) {
+        return { x: 0, y: 0 };
+    }
+
     // Calculate the total distance of the path
     const segmentDistances: number[] = [];
     let totalDistance = 0;
@@ -283,6 +289,9 @@ export function getPositionAtTime(t: number, path: FullCoordinate[], totalTime: 
 
 
 export function getLastVisitedCoordinate(t: number, path: FullCoordinate[], T: number): BasicCoordinate {
+    if (!path?.length) {
+        return { x: 0, y: 0 };
+    }
     if (t <= 0) {
         return path[0];  // If time is zero or negative, return the starting point
     }

--- a/server/classes/mission.ts
+++ b/server/classes/mission.ts
@@ -188,6 +188,7 @@ interface TimelineItemParams {
   args?: string;
   delay?: number;
   noCancelOnReset?: boolean;
+  repeatable?: boolean;
 }
 
 export class TimelineItem {
@@ -198,6 +199,9 @@ export class TimelineItem {
   args: string;
   delay: number;
   noCancelOnReset: boolean;
+  // Repeatable actions re-run every time their step is triggered, instead of
+  // being skipped once they show up in the simulator's executedTimelineSteps.
+  repeatable: boolean;
   constructor(timelineItemId, params: TimelineItemParams = {}) {
     this.id = timelineItemId || uuid.v4();
     this.name = params.name || "Item";
@@ -206,8 +210,9 @@ export class TimelineItem {
     this.args = params.args || null;
     this.delay = params.delay || 0;
     this.noCancelOnReset = params.noCancelOnReset || false;
+    this.repeatable = params.repeatable || false;
   }
-  update({name, type, event, delay, args, noCancelOnReset}) {
+  update({name, type, event, delay, args, noCancelOnReset, repeatable}) {
     if (name) this.name = name;
     if (type) this.type = type;
     if (event) this.event = event;
@@ -215,5 +220,6 @@ export class TimelineItem {
     if (args) this.args = args;
     if (noCancelOnReset || noCancelOnReset === false)
       this.noCancelOnReset = noCancelOnReset;
+    if (repeatable || repeatable === false) this.repeatable = repeatable;
   }
 }

--- a/server/events/simulator.ts
+++ b/server/events/simulator.ts
@@ -270,6 +270,7 @@ App.on("autoAdvance", ({simulatorId, prev}) => {
   const macros = timelineStep.timelineItems.filter(t => {
     if (executedTimelineSteps.indexOf(t.id) === -1) return true;
     if (allowedMacros.indexOf(t.event) > -1) return true;
+    if (t.repeatable) return true;
     if (executedTimelineSteps.indexOf(t.id) > -1) return false;
     return true;
   });

--- a/server/processes/advanced-nav.ts
+++ b/server/processes/advanced-nav.ts
@@ -21,25 +21,35 @@ const sendStarsUpdate = throttle(() => {
 })
 
 const updateValues = () => {
-    App.flights.filter(f => f.running === true)
-        .forEach(f => {
-            f.simulators.forEach(s => {
-                App.systems.filter(sys => sys.simulatorId === s && sys.type === "AdvancedNavigationAndAstrometrics").forEach((nav: AdvancedNavigationAndAstrometrics) => {
-                    nav.executeHeatInterval();
-                    nav.executeLoopInterval();
-                    nav.executeProbeInterval();
-                    const speed = nav.getCurrentSpeed();
-                    if (speed.velocity !== prevSpeed) {
-                        sendStarsUpdate();
-                        prevSpeed = speed.velocity;
-                    }
-
-                })
+    // A throw anywhere in here used to kill the tick for every simulator on the server,
+    // since the reschedule was the last statement. Keep the loop alive no matter what.
+    try {
+        App.flights.filter(f => f.running === true)
+            .forEach(f => {
+                f.simulators.forEach(s => {
+                    App.systems.filter(sys => sys.simulatorId === s && sys.type === "AdvancedNavigationAndAstrometrics").forEach((nav: AdvancedNavigationAndAstrometrics) => {
+                        try {
+                            nav.executeHeatInterval();
+                            nav.executeLoopInterval();
+                            nav.executeProbeInterval();
+                            const speed = nav.getCurrentSpeed();
+                            if (speed.velocity !== prevSpeed) {
+                                sendStarsUpdate();
+                                prevSpeed = speed.velocity;
+                            }
+                        } catch (err) {
+                            console.error(`Error updating advanced navigation for simulator ${s}:`, err);
+                        }
+                    })
+                });
             });
-        });
 
-    sendUpdate();
-    setTimeout(updateValues, 1000);
+        sendUpdate();
+    } catch (err) {
+        console.error('Error in the advanced navigation update loop:', err);
+    } finally {
+        setTimeout(updateValues, 1000);
+    }
 };
 updateValues();
 

--- a/server/typeDefs/mission.ts
+++ b/server/typeDefs/mission.ts
@@ -25,6 +25,7 @@ const schema = gql`
     args: String
     delay: Int
     noCancelOnReset: Boolean
+    repeatable: Boolean
   }
   input RequirementInput {
     cards: [String]
@@ -47,6 +48,7 @@ const schema = gql`
     args: String
     delay: Int
     noCancelOnReset: Boolean
+    repeatable: Boolean
   }
 
   enum TIMELINE_ITEM_CONFIG_TYPE {
@@ -61,6 +63,7 @@ const schema = gql`
     args: String
     delay: Int
     noCancelOnReset: Boolean
+    repeatable: Boolean
   }
 
   type TimelineInstance {

--- a/src/components/views/AdvancedNavAndAstrometrics/AdvancedNavigationCard.tsx
+++ b/src/components/views/AdvancedNavAndAstrometrics/AdvancedNavigationCard.tsx
@@ -18,6 +18,7 @@ import SubscriptionHelper from "helpers/subscriptionHelper";
 import {graphql, withApollo} from "react-apollo";
 import {AdvancedNavigation} from "./AdvancedNavigation";
 import DamageOverlay from "../helpers/DamageOverlay";
+import parseAdvancedNavData from "./helpers/parseAdvancedNavData";
 import {EngineStatus} from "./types";
 import {FlightSet} from "containers/FlightDirector/FlightSets/types";
 import {FormattedMessage} from "react-intl";
@@ -61,22 +62,16 @@ const AdvancedNavigationCard: React.FC<AdvancedNavigationCardProps> = ({
   const [SaveFlightPath] = useHandleSaveFlightPathMutation();
   const [ResumePath] = useHandleResumePathMutation();
   const [UpdateCurrentFlightPath] = useHandleUpdateCurrentFlightPathMutation();
-  let parsedData = undefined;
   const {assets} = simulator;
 
-  if (data && data.advancedNavAndAstrometrics) {
-    parsedData = data.advancedNavAndAstrometrics.map(d => {
-      return {
-        ...d,
-        flightSetPathMap: JSON.parse(d.flightSetPathMap),
-        probeAssignments: Object.keys(JSON.parse(d.probeAssignments)).map(
-          k => JSON.parse(d.probeAssignments)[k],
-        ),
-      };
-    });
-  }
+  const parsedData = parseAdvancedNavData(
+    data?.advancedNavAndAstrometrics,
+  ).map(d => ({
+    ...d,
+    probeAssignments: Object.values(d.probeAssignments),
+  }));
 
-  const advancedNav = parsedData && parsedData[0];
+  const advancedNav = parsedData[0];
   if (!data || data.loading || !advancedNav || !assets) {
     return <React.Fragment />;
   }

--- a/src/components/views/AdvancedNavAndAstrometrics/AstrometricsCard.tsx
+++ b/src/components/views/AdvancedNavAndAstrometrics/AstrometricsCard.tsx
@@ -13,6 +13,7 @@ import SubscriptionHelper from "helpers/subscriptionHelper";
 import {graphql, withApollo} from "react-apollo";
 import {FlightSet, Probe} from "containers/FlightDirector/FlightSets/types";
 import {Astrometrics} from "./Astrometrics";
+import parseAdvancedNavData from "./helpers/parseAdvancedNavData";
 import {FormattedMessage} from "react-intl";
 import Tour from "helpers/tourHelper";
 
@@ -50,19 +51,10 @@ const AstrometricsCard: React.FC<AstrometricsCardProps> = ({
   simulator,
 }) => {
   const [AssignProbe] = useHandleOnAssignProbeMutation();
-  let parsedData = undefined;
   const {assets} = simulator;
 
-  if (data && data.advancedNavAndAstrometrics) {
-    parsedData = data.advancedNavAndAstrometrics.map(d => {
-      return {
-        ...d,
-        flightSetPathMap: JSON.parse(d.flightSetPathMap),
-        probeAssignments: JSON.parse(d.probeAssignments),
-      };
-    });
-  }
-  const advancedNav = parsedData && parsedData[0];
+  const parsedData = parseAdvancedNavData(data?.advancedNavAndAstrometrics);
+  const advancedNav = parsedData[0];
   if (!data || data.loading || !advancedNav || !assets) {
     return <React.Fragment />;
   }

--- a/src/components/views/AdvancedNavAndAstrometrics/CoreAdvancedNavigation.tsx
+++ b/src/components/views/AdvancedNavAndAstrometrics/CoreAdvancedNavigation.tsx
@@ -26,6 +26,7 @@ import {
 } from "./core-queries";
 import {graphql, withApollo} from "react-apollo";
 import {CoreAdvancedNavigation as CoreAdvancedNavigationModal} from "./components/CoreComponents/advanced-flight";
+import parseAdvancedNavData from "./helpers/parseAdvancedNavData";
 import {EngineStatus} from "./types";
 import {FlightSet} from "containers/FlightDirector/FlightSets/types";
 import "./styles.css";
@@ -65,19 +66,9 @@ const CoreAdvancedNavigation: React.FC<CoreAdvancedNavigationProps> = ({
   const [UpdateFlightSetData] = useHandleUpdateAdvNavFlightSetDataMutation();
 
   const flightSetQuery = useGetBasicFlightSetsQuery();
-  let parsedData = undefined;
 
-  if (data && data.advancedNavAndAstrometrics) {
-    parsedData = data.advancedNavAndAstrometrics.map(d => {
-      return {
-        ...d,
-        flightSetPathMap: JSON.parse(d.flightSetPathMap),
-        probeAssignments: JSON.parse(d.probeAssignments),
-      };
-    });
-  }
-
-  const advancedNav = parsedData && parsedData[0];
+  const parsedData = parseAdvancedNavData(data?.advancedNavAndAstrometrics);
+  const advancedNav = parsedData[0];
 
   const notIncludedFlightSets = React.useMemo(() => {
     return (
@@ -87,7 +78,7 @@ const CoreAdvancedNavigation: React.FC<CoreAdvancedNavigationProps> = ({
     );
   }, [flightSetQuery.data, advancedNav]);
 
-  if (!data || data.loading || !parsedData) {
+  if (!data || data.loading || !parsedData.length) {
     return <div>No Values</div>;
   }
 

--- a/src/components/views/AdvancedNavAndAstrometrics/CoreAstrometrics.tsx
+++ b/src/components/views/AdvancedNavAndAstrometrics/CoreAstrometrics.tsx
@@ -14,6 +14,7 @@ import {FormattedMessage} from "react-intl";
 import {Container} from "reactstrap";
 import SubscriptionHelper from "helpers/subscriptionHelper";
 import {AstrometricsCoreComponent} from "./CoreAstrometricsBase";
+import parseAdvancedNavData from "./helpers/parseAdvancedNavData";
 import {Probe} from "containers/FlightDirector/FlightSets/types";
 
 interface CoreAstrometricsProps {
@@ -33,20 +34,9 @@ const CoreAstrometrics: React.FC<CoreAstrometricsProps> = ({
   client,
 }) => {
   const [HandleAssignments] = useHandleUpdateProbeAssignmentsMutation();
-  let parsedData = undefined;
-
-  if (data && data.advancedNavAndAstrometrics) {
-    parsedData = data.advancedNavAndAstrometrics.map(d => {
-      return {
-        ...d,
-        flightSetPathMap: JSON.parse(d.flightSetPathMap),
-        probeAssignments: JSON.parse(d.probeAssignments),
-      };
-    });
-  }
-
-  const advancedNav = parsedData && parsedData[0];
-  if (!data || data.loading || !parsedData) {
+  const parsedData = parseAdvancedNavData(data?.advancedNavAndAstrometrics);
+  const advancedNav = parsedData[0];
+  if (!data || data.loading || !parsedData.length) {
     return <div>No Values</div>;
   }
 

--- a/src/components/views/AdvancedNavAndAstrometrics/helpers/parseAdvancedNavData.ts
+++ b/src/components/views/AdvancedNavAndAstrometrics/helpers/parseAdvancedNavData.ts
@@ -1,0 +1,36 @@
+/**
+ * Unpacks the stringified-JSON fields on the AdvancedNavigationAndAstrometrics systems
+ * returned by the query/subscription.
+ *
+ * The list is deliberately null-tolerant. `currentLocation` is a non-null GraphQL field, so
+ * any bad server-side coordinate nulls out the whole system object and the list arrives as
+ * `[null]`. Mapping over that directly throws during render, which drops the station on the
+ * "Perform Diagnostic" error boundary - including the flight director's core screen, leaving
+ * no way to repair the simulator from the UI.
+ */
+export type ParsedAdvancedNav<T> = Omit<
+  T,
+  "flightSetPathMap" | "probeAssignments"
+> & {
+  flightSetPathMap: any;
+  probeAssignments: Record<string, any>;
+};
+
+export default function parseAdvancedNavData<
+  T extends {flightSetPathMap: string; probeAssignments: string},
+>(list?: (T | null | undefined)[] | null): ParsedAdvancedNav<T>[] {
+  if (!list) return [];
+  return list.reduce<ParsedAdvancedNav<T>[]>((acc, d) => {
+    if (!d) return acc;
+    try {
+      acc.push({
+        ...d,
+        flightSetPathMap: JSON.parse(d.flightSetPathMap),
+        probeAssignments: JSON.parse(d.probeAssignments),
+      });
+    } catch (err) {
+      console.error("Unable to parse advanced navigation data", err);
+    }
+    return acc;
+  }, []);
+}

--- a/src/components/views/Timeline/auxTimelineData.jsx
+++ b/src/components/views/Timeline/auxTimelineData.jsx
@@ -22,6 +22,7 @@ const fragment = gql`
           args
           event
           delay
+          repeatable
         }
       }
     }

--- a/src/components/views/Timeline/classicMission.tsx
+++ b/src/components/views/Timeline/classicMission.tsx
@@ -144,6 +144,7 @@ const TimelineStep: React.FC<TimelineStepProps> = ({
                 name={i.name || ""}
                 event={i.event}
                 args={i.args || "{}"}
+                repeatable={i.repeatable}
                 showDescription={false}
                 steps={timeline}
                 itemDelay={i.delay || 0}

--- a/src/components/views/Timeline/isRepeatable.test.ts
+++ b/src/components/views/Timeline/isRepeatable.test.ts
@@ -1,0 +1,60 @@
+import {describe, expect, it} from "vitest";
+import isRepeatableAction, {getArmedActions} from "./isRepeatable";
+
+describe("isRepeatableAction", () => {
+  it("treats the viewscreen macros as repeatable", () => {
+    expect(isRepeatableAction({event: "updateViewscreenComponent"})).toBe(true);
+    expect(isRepeatableAction({event: "setViewscreenToAuto"})).toBe(true);
+  });
+  it("does not treat an ordinary macro as repeatable", () => {
+    expect(isRepeatableAction({event: "processedData"})).toBe(false);
+  });
+  it("treats an item flagged in Mission Config as repeatable", () => {
+    expect(isRepeatableAction({event: "processedData", repeatable: true})).toBe(
+      true,
+    );
+  });
+  it("copes with a missing event", () => {
+    expect(isRepeatableAction({})).toBe(false);
+    expect(isRepeatableAction({event: null, repeatable: null})).toBe(false);
+  });
+});
+
+describe("getArmedActions", () => {
+  const items = [
+    {id: "data", event: "processedData"},
+    {id: "repeat-data", event: "processedData", repeatable: true},
+    {id: "viewscreen", event: "updateViewscreenComponent"},
+  ];
+
+  it("arms everything before the step has been run", () => {
+    expect(getArmedActions(items, [])).toEqual({
+      data: true,
+      "repeat-data": true,
+      viewscreen: true,
+    });
+  });
+
+  it("keeps repeatable actions armed after the step has been run", () => {
+    // This is the reported bug: coming back to a step left processedData
+    // unchecked, so running the step again sent nothing.
+    expect(
+      getArmedActions(items, ["data", "repeat-data", "viewscreen"]),
+    ).toEqual({
+      "repeat-data": true,
+      viewscreen: true,
+    });
+  });
+
+  it("still disarms an ordinary action that already fired", () => {
+    expect(getArmedActions(items, ["data"])).toEqual({
+      "repeat-data": true,
+      viewscreen: true,
+    });
+  });
+
+  it("handles a step with no items", () => {
+    expect(getArmedActions(undefined, ["data"])).toEqual({});
+    expect(getArmedActions([], ["data"])).toEqual({});
+  });
+});

--- a/src/components/views/Timeline/isRepeatable.ts
+++ b/src/components/views/Timeline/isRepeatable.ts
@@ -1,0 +1,50 @@
+import allowedMacros from "./allowedMacros";
+
+interface RepeatableAction {
+  event?: string | null;
+  repeatable?: boolean | null;
+}
+
+/**
+ * Actions which should re-run every time their step is triggered, instead of
+ * being unchecked and greyed out once they land in executedTimelineSteps.
+ *
+ * Two things qualify: the viewscreen macros, which have always behaved this way,
+ * and any timeline item the flight director marked "Repeatable" in Mission Config.
+ *
+ * Note this is deliberately separate from `allowedMacros` itself — classic and
+ * thumbnail modes use that list to mean "viewscreen-only actions", which is a
+ * different question and must not pick up repeatable items.
+ */
+export default function isRepeatableAction({
+  event,
+  repeatable,
+}: RepeatableAction) {
+  if (repeatable) return true;
+  return Boolean(event) && allowedMacros.indexOf(event as string) > -1;
+}
+
+/**
+ * Which of a step's actions start out checked, and so will actually be sent when
+ * the flight director runs the step.
+ *
+ * An action that has already fired this flight is left unchecked so it doesn't
+ * repeat by accident — unless it is repeatable, which is the whole point of the
+ * flag: the same step can be run as many times as the mission needs.
+ */
+export function getArmedActions<T extends RepeatableAction & {id: string}>(
+  timelineItems: T[] | undefined,
+  executedTimelineSteps: string[],
+): {[key: string]: boolean} {
+  if (!timelineItems) return {};
+  return timelineItems.reduce<{[key: string]: boolean}>((prev, next) => {
+    if (
+      executedTimelineSteps.indexOf(next.id) > -1 &&
+      !isRepeatableAction(next)
+    ) {
+      return prev;
+    }
+    prev[next.id] = true;
+    return prev;
+  }, {});
+}

--- a/src/components/views/Timeline/mission.tsx
+++ b/src/components/views/Timeline/mission.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import {Label, Input} from "helpers/reactstrap";
 import TimelineControl from "./timelineControl";
 import TimelineStep from "./timelineStep";
-import allowedMacros from "./allowedMacros";
+import {getArmedActions} from "./isRepeatable";
 import {
   TimelineStep as TimelineStepI,
   Station,
@@ -42,31 +42,14 @@ const Mission: React.FC<MissionProps> = ({
   );
   const [values, setValues] = React.useState<{[key: string]: any}>({});
   const [delay, setDelay] = React.useState<{[key: string]: number}>({});
-  const [actions, setActions] = React.useState<{[key: string]: boolean}>(
-    currentStep
-      ? currentStep.timelineItems.reduce(
-          (prev, next) =>
-            executedTimelineSteps.indexOf(next.id) > -1 &&
-            allowedMacros.indexOf(next.event) === -1
-              ? prev
-              : Object.assign(prev, {[next.id]: true}),
-          {},
-        )
-      : {},
+  const [actions, setActions] = React.useState<{[key: string]: boolean}>(() =>
+    getArmedActions(currentStep?.timelineItems, executedTimelineSteps),
   );
 
   React.useEffect(() => {
-    const actions = currentStep
-      ? currentStep.timelineItems.reduce(
-          (prev, next) =>
-            executedTimelineSteps.indexOf(next.id) > -1 &&
-            allowedMacros.indexOf(next.event) === -1
-              ? prev
-              : Object.assign(prev, {[next.id]: true}),
-          {},
-        )
-      : {};
-    setActions(actions);
+    setActions(
+      getArmedActions(currentStep?.timelineItems, executedTimelineSteps),
+    );
   }, [currentStep, executedTimelineSteps]);
 
   return (

--- a/src/components/views/Timeline/queries/timelineSub.graphql
+++ b/src/components/views/Timeline/queries/timelineSub.graphql
@@ -16,6 +16,7 @@ subscription TimelineMission {
         args
         event
         delay
+        repeatable
       }
     }
   }

--- a/src/components/views/Timeline/timelineItem.tsx
+++ b/src/components/views/Timeline/timelineItem.tsx
@@ -2,7 +2,7 @@ import React, {Fragment} from "react";
 import * as MacrosPrint from "../../macrosPrint";
 import * as Macros from "../../macros";
 import {Button, Input, Label} from "helpers/reactstrap";
-import allowedMacros from "./allowedMacros";
+import isRepeatableAction from "./isRepeatable";
 import EventName from "../../../containers/FlightDirector/MissionConfig/EventName";
 import {FaArrowDown, FaArrowRight} from "react-icons/fa";
 import {TimelineStep, Station, Client, Mission} from "generated/graphql";
@@ -124,6 +124,7 @@ interface TimelineItemProps {
   event: string;
   name: string;
   args: string;
+  repeatable?: boolean | null;
   executedTimelineSteps: string[];
   steps: TimelineStep[];
   simulatorId: string;
@@ -147,6 +148,7 @@ const TimelineItem: React.FC<TimelineItemProps> = ({
   event,
   name,
   args,
+  repeatable,
   executedTimelineSteps,
   actions,
   checkAction,
@@ -186,13 +188,22 @@ const TimelineItem: React.FC<TimelineItemProps> = ({
       <span
         className={
           executedTimelineSteps.indexOf(id) > -1 &&
-          allowedMacros.indexOf(event) === -1
+          !isRepeatableAction({event, repeatable})
             ? "text-success"
             : ""
         }
       >
         <EventName id={event} label={name} />
       </span>
+      {repeatable && (
+        <span
+          className="text-info"
+          title="Repeatable - this action runs again every time the step is triggered"
+        >
+          {" "}
+          &#8635;
+        </span>
+      )}
 
       {args && (
         <Fragment>

--- a/src/components/views/Timeline/timelineStep.tsx
+++ b/src/components/views/Timeline/timelineStep.tsx
@@ -72,6 +72,7 @@ const TimelineStep: React.FC<TimelineStepProps> = ({
                 event={i.event}
                 name={i.name || ""}
                 args={i.args || "{}"}
+                repeatable={i.repeatable}
                 steps={timeline}
                 simulatorId={simulatorId}
                 showDescription={showDescription}

--- a/src/containers/FlightDirector/MissionConfig/TimelineConfig.tsx
+++ b/src/containers/FlightDirector/MissionConfig/TimelineConfig.tsx
@@ -146,6 +146,16 @@ export const TimelineMacroConfig: React.FC<{
               Don't Cancel Delay on Flight Reset
             </Label>
           </FormGroup>
+          <FormGroup style={{marginLeft: "5ch"}}>
+            <Label title="Normally an action only runs once per flight - going back to its step leaves it unchecked. Repeatable actions stay checked and run again every time the step is triggered.">
+              <Input
+                type="checkbox"
+                defaultChecked={Boolean(item.repeatable)}
+                onChange={e => updateMacro("repeatable", e.target.checked)}
+              />
+              Repeatable — Re-run Every Time the Step is Triggered
+            </Label>
+          </FormGroup>
           <MacroWrapper
             id={item.id}
             delay={item.delay}

--- a/src/containers/FlightDirector/MissionConfig/TimelineTypes.ts
+++ b/src/containers/FlightDirector/MissionConfig/TimelineTypes.ts
@@ -5,6 +5,7 @@ export interface TimelineItem {
   args: string;
   delay: number | undefined;
   noCancelOnReset: boolean;
+  repeatable: boolean;
 }
 export interface TimelineStep {
   id: string;

--- a/src/containers/FlightDirector/MissionConfig/queries/missionsSub.graphql
+++ b/src/containers/FlightDirector/MissionConfig/queries/missionsSub.graphql
@@ -29,6 +29,7 @@ subscription MissionSubscription($missionId: ID!) {
         delay
         needsConfig
         noCancelOnReset
+        repeatable
       }
     }
   }

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -2087,6 +2087,7 @@ export type MacroInput = {
   args?: Maybe<Scalars['String']>;
   delay?: Maybe<Scalars['Int']>;
   noCancelOnReset?: Maybe<Scalars['Boolean']>;
+  repeatable?: Maybe<Scalars['Boolean']>;
 };
 
 export type MapBorder = {
@@ -12188,6 +12189,7 @@ export type TimelineItem = {
   args?: Maybe<Scalars['String']>;
   delay?: Maybe<Scalars['Int']>;
   noCancelOnReset?: Maybe<Scalars['Boolean']>;
+  repeatable?: Maybe<Scalars['Boolean']>;
 };
 
 export type TimelineItemInput = {
@@ -12198,6 +12200,7 @@ export type TimelineItemInput = {
   args?: Maybe<Scalars['String']>;
   delay?: Maybe<Scalars['Int']>;
   noCancelOnReset?: Maybe<Scalars['Boolean']>;
+  repeatable?: Maybe<Scalars['Boolean']>;
 };
 
 export type TimelineStep = {
@@ -15064,7 +15067,7 @@ export type TimelineMissionSubscription = (
       & Pick<TimelineStep, 'id' | 'name' | 'order' | 'description'>
       & { timelineItems: Array<(
         { __typename?: 'TimelineItem' }
-        & Pick<TimelineItem, 'id' | 'name' | 'type' | 'args' | 'event' | 'delay'>
+        & Pick<TimelineItem, 'id' | 'name' | 'type' | 'args' | 'event' | 'delay' | 'repeatable'>
       )> }
     )> }
   )> }
@@ -16031,7 +16034,7 @@ export type MissionSubscriptionSubscription = (
       & Pick<TimelineStep, 'id' | 'name' | 'description' | 'order'>
       & { timelineItems: Array<(
         { __typename?: 'TimelineItem' }
-        & Pick<TimelineItem, 'id' | 'name' | 'type' | 'event' | 'args' | 'delay' | 'needsConfig' | 'noCancelOnReset'>
+        & Pick<TimelineItem, 'id' | 'name' | 'type' | 'event' | 'args' | 'delay' | 'needsConfig' | 'noCancelOnReset' | 'repeatable'>
       )> }
     )> }
   )> }
@@ -20255,6 +20258,7 @@ export const TimelineMissionDocument = gql`
         args
         event
         delay
+        repeatable
       }
     }
   }
@@ -21284,6 +21288,7 @@ export const MissionSubscriptionDocument = gql`
         delay
         needsConfig
         noCancelOnReset
+        repeatable
       }
     }
   }

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -1941,6 +1941,7 @@ input MacroInput {
   args: String
   delay: Int
   noCancelOnReset: Boolean
+  repeatable: Boolean
 }
 
 type MapBorder {
@@ -5661,6 +5662,7 @@ type TimelineItem {
   args: String
   delay: Int
   noCancelOnReset: Boolean
+  repeatable: Boolean
 }
 
 input TimelineItemInput {
@@ -5671,6 +5673,7 @@ input TimelineItemInput {
   args: String
   delay: Int
   noCancelOnReset: Boolean
+  repeatable: Boolean
 }
 
 type TimelineStep {


### PR DESCRIPTION
## Description

Two adds here:
1. This adds the ability to create "repeatable" timeline actions. This is a direct request from the Falcon staff, who use a bunch of jump steps and having to check a box bothers them. 

2. A fix for advanced nav where if a user hits emergency stop while engines are spooling, would break the universe. It no longer does. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

No issue, just a bug report that came to me a couple days ago. I can go back and do so though

## Screenshots (if appropriate):

- [ ] I submitted a pull request or created an issue for documenting this
      feature on the [Thorium Docs](https://github.com/Thorium-Sim/thorium-docs)
      repo. (Include the issue or pull request url below.)
