### PR TITLE
feat: Added the ability to create a "repeatable" timeline action

### DIFF
--- a/server/classes/mission.ts
+++ b/server/classes/mission.ts
@@ -188,6 +188,7 @@ interface TimelineItemParams {
   args?: string;
   delay?: number;
   noCancelOnReset?: boolean;
+  repeatable?: boolean;
 }
 
 export class TimelineItem {
@@ -198,6 +199,9 @@ export class TimelineItem {
   args: string;
   delay: number;
   noCancelOnReset: boolean;
+  // Repeatable actions re-run every time their step is triggered, instead of
+  // being skipped once they show up in the simulator's executedTimelineSteps.
+  repeatable: boolean;
   constructor(timelineItemId, params: TimelineItemParams = {}) {
     this.id = timelineItemId || uuid.v4();
     this.name = params.name || "Item";
@@ -206,8 +210,9 @@ export class TimelineItem {
     this.args = params.args || null;
     this.delay = params.delay || 0;
     this.noCancelOnReset = params.noCancelOnReset || false;
+    this.repeatable = params.repeatable || false;
   }
-  update({name, type, event, delay, args, noCancelOnReset}) {
+  update({name, type, event, delay, args, noCancelOnReset, repeatable}) {
     if (name) this.name = name;
     if (type) this.type = type;
     if (event) this.event = event;
@@ -215,5 +220,6 @@ export class TimelineItem {
     if (args) this.args = args;
     if (noCancelOnReset || noCancelOnReset === false)
       this.noCancelOnReset = noCancelOnReset;
+    if (repeatable || repeatable === false) this.repeatable = repeatable;
   }
 }

--- a/server/events/simulator.ts
+++ b/server/events/simulator.ts
@@ -270,6 +270,7 @@ App.on("autoAdvance", ({simulatorId, prev}) => {
   const macros = timelineStep.timelineItems.filter(t => {
     if (executedTimelineSteps.indexOf(t.id) === -1) return true;
     if (allowedMacros.indexOf(t.event) > -1) return true;
+    if (t.repeatable) return true;
     if (executedTimelineSteps.indexOf(t.id) > -1) return false;
     return true;
   });

--- a/server/typeDefs/mission.ts
+++ b/server/typeDefs/mission.ts
@@ -25,6 +25,7 @@ const schema = gql`
     args: String
     delay: Int
     noCancelOnReset: Boolean
+    repeatable: Boolean
   }
   input RequirementInput {
     cards: [String]
@@ -47,6 +48,7 @@ const schema = gql`
     args: String
     delay: Int
     noCancelOnReset: Boolean
+    repeatable: Boolean
   }
 
   enum TIMELINE_ITEM_CONFIG_TYPE {
@@ -61,6 +63,7 @@ const schema = gql`
     args: String
     delay: Int
     noCancelOnReset: Boolean
+    repeatable: Boolean
   }
 
   type TimelineInstance {

--- a/src/components/views/Timeline/auxTimelineData.jsx
+++ b/src/components/views/Timeline/auxTimelineData.jsx
@@ -22,6 +22,7 @@ const fragment = gql`
           args
           event
           delay
+          repeatable
         }
       }
     }

--- a/src/components/views/Timeline/classicMission.tsx
+++ b/src/components/views/Timeline/classicMission.tsx
@@ -144,6 +144,7 @@ const TimelineStep: React.FC<TimelineStepProps> = ({
                 name={i.name || ""}
                 event={i.event}
                 args={i.args || "{}"}
+                repeatable={i.repeatable}
                 showDescription={false}
                 steps={timeline}
                 itemDelay={i.delay || 0}

--- a/src/components/views/Timeline/isRepeatable.test.ts
+++ b/src/components/views/Timeline/isRepeatable.test.ts
@@ -1,0 +1,60 @@
+import {describe, expect, it} from "vitest";
+import isRepeatableAction, {getArmedActions} from "./isRepeatable";
+
+describe("isRepeatableAction", () => {
+  it("treats the viewscreen macros as repeatable", () => {
+    expect(isRepeatableAction({event: "updateViewscreenComponent"})).toBe(true);
+    expect(isRepeatableAction({event: "setViewscreenToAuto"})).toBe(true);
+  });
+  it("does not treat an ordinary macro as repeatable", () => {
+    expect(isRepeatableAction({event: "processedData"})).toBe(false);
+  });
+  it("treats an item flagged in Mission Config as repeatable", () => {
+    expect(isRepeatableAction({event: "processedData", repeatable: true})).toBe(
+      true,
+    );
+  });
+  it("copes with a missing event", () => {
+    expect(isRepeatableAction({})).toBe(false);
+    expect(isRepeatableAction({event: null, repeatable: null})).toBe(false);
+  });
+});
+
+describe("getArmedActions", () => {
+  const items = [
+    {id: "data", event: "processedData"},
+    {id: "repeat-data", event: "processedData", repeatable: true},
+    {id: "viewscreen", event: "updateViewscreenComponent"},
+  ];
+
+  it("arms everything before the step has been run", () => {
+    expect(getArmedActions(items, [])).toEqual({
+      data: true,
+      "repeat-data": true,
+      viewscreen: true,
+    });
+  });
+
+  it("keeps repeatable actions armed after the step has been run", () => {
+    // This is the reported bug: coming back to a step left processedData
+    // unchecked, so running the step again sent nothing.
+    expect(
+      getArmedActions(items, ["data", "repeat-data", "viewscreen"]),
+    ).toEqual({
+      "repeat-data": true,
+      viewscreen: true,
+    });
+  });
+
+  it("still disarms an ordinary action that already fired", () => {
+    expect(getArmedActions(items, ["data"])).toEqual({
+      "repeat-data": true,
+      viewscreen: true,
+    });
+  });
+
+  it("handles a step with no items", () => {
+    expect(getArmedActions(undefined, ["data"])).toEqual({});
+    expect(getArmedActions([], ["data"])).toEqual({});
+  });
+});

--- a/src/components/views/Timeline/isRepeatable.ts
+++ b/src/components/views/Timeline/isRepeatable.ts
@@ -1,0 +1,50 @@
+import allowedMacros from "./allowedMacros";
+
+interface RepeatableAction {
+  event?: string | null;
+  repeatable?: boolean | null;
+}
+
+/**
+ * Actions which should re-run every time their step is triggered, instead of
+ * being unchecked and greyed out once they land in executedTimelineSteps.
+ *
+ * Two things qualify: the viewscreen macros, which have always behaved this way,
+ * and any timeline item the flight director marked "Repeatable" in Mission Config.
+ *
+ * Note this is deliberately separate from `allowedMacros` itself — classic and
+ * thumbnail modes use that list to mean "viewscreen-only actions", which is a
+ * different question and must not pick up repeatable items.
+ */
+export default function isRepeatableAction({
+  event,
+  repeatable,
+}: RepeatableAction) {
+  if (repeatable) return true;
+  return Boolean(event) && allowedMacros.indexOf(event as string) > -1;
+}
+
+/**
+ * Which of a step's actions start out checked, and so will actually be sent when
+ * the flight director runs the step.
+ *
+ * An action that has already fired this flight is left unchecked so it doesn't
+ * repeat by accident — unless it is repeatable, which is the whole point of the
+ * flag: the same step can be run as many times as the mission needs.
+ */
+export function getArmedActions<T extends RepeatableAction & {id: string}>(
+  timelineItems: T[] | undefined,
+  executedTimelineSteps: string[],
+): {[key: string]: boolean} {
+  if (!timelineItems) return {};
+  return timelineItems.reduce<{[key: string]: boolean}>((prev, next) => {
+    if (
+      executedTimelineSteps.indexOf(next.id) > -1 &&
+      !isRepeatableAction(next)
+    ) {
+      return prev;
+    }
+    prev[next.id] = true;
+    return prev;
+  }, {});
+}

--- a/src/components/views/Timeline/mission.tsx
+++ b/src/components/views/Timeline/mission.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import {Label, Input} from "helpers/reactstrap";
 import TimelineControl from "./timelineControl";
 import TimelineStep from "./timelineStep";
-import allowedMacros from "./allowedMacros";
+import {getArmedActions} from "./isRepeatable";
 import {
   TimelineStep as TimelineStepI,
   Station,
@@ -42,31 +42,14 @@ const Mission: React.FC<MissionProps> = ({
   );
   const [values, setValues] = React.useState<{[key: string]: any}>({});
   const [delay, setDelay] = React.useState<{[key: string]: number}>({});
-  const [actions, setActions] = React.useState<{[key: string]: boolean}>(
-    currentStep
-      ? currentStep.timelineItems.reduce(
-          (prev, next) =>
-            executedTimelineSteps.indexOf(next.id) > -1 &&
-            allowedMacros.indexOf(next.event) === -1
-              ? prev
-              : Object.assign(prev, {[next.id]: true}),
-          {},
-        )
-      : {},
+  const [actions, setActions] = React.useState<{[key: string]: boolean}>(() =>
+    getArmedActions(currentStep?.timelineItems, executedTimelineSteps),
   );
 
   React.useEffect(() => {
-    const actions = currentStep
-      ? currentStep.timelineItems.reduce(
-          (prev, next) =>
-            executedTimelineSteps.indexOf(next.id) > -1 &&
-            allowedMacros.indexOf(next.event) === -1
-              ? prev
-              : Object.assign(prev, {[next.id]: true}),
-          {},
-        )
-      : {};
-    setActions(actions);
+    setActions(
+      getArmedActions(currentStep?.timelineItems, executedTimelineSteps),
+    );
   }, [currentStep, executedTimelineSteps]);
 
   return (

--- a/src/components/views/Timeline/queries/timelineSub.graphql
+++ b/src/components/views/Timeline/queries/timelineSub.graphql
@@ -16,6 +16,7 @@ subscription TimelineMission {
         args
         event
         delay
+        repeatable
       }
     }
   }

--- a/src/components/views/Timeline/timelineItem.tsx
+++ b/src/components/views/Timeline/timelineItem.tsx
@@ -2,7 +2,7 @@ import React, {Fragment} from "react";
 import * as MacrosPrint from "../../macrosPrint";
 import * as Macros from "../../macros";
 import {Button, Input, Label} from "helpers/reactstrap";
-import allowedMacros from "./allowedMacros";
+import isRepeatableAction from "./isRepeatable";
 import EventName from "../../../containers/FlightDirector/MissionConfig/EventName";
 import {FaArrowDown, FaArrowRight} from "react-icons/fa";
 import {TimelineStep, Station, Client, Mission} from "generated/graphql";
@@ -124,6 +124,7 @@ interface TimelineItemProps {
   event: string;
   name: string;
   args: string;
+  repeatable?: boolean | null;
   executedTimelineSteps: string[];
   steps: TimelineStep[];
   simulatorId: string;
@@ -147,6 +148,7 @@ const TimelineItem: React.FC<TimelineItemProps> = ({
   event,
   name,
   args,
+  repeatable,
   executedTimelineSteps,
   actions,
   checkAction,
@@ -186,13 +188,22 @@ const TimelineItem: React.FC<TimelineItemProps> = ({
       <span
         className={
           executedTimelineSteps.indexOf(id) > -1 &&
-          allowedMacros.indexOf(event) === -1
+          !isRepeatableAction({event, repeatable})
             ? "text-success"
             : ""
         }
       >
         <EventName id={event} label={name} />
       </span>
+      {repeatable && (
+        <span
+          className="text-info"
+          title="Repeatable - this action runs again every time the step is triggered"
+        >
+          {" "}
+          &#8635;
+        </span>
+      )}
 
       {args && (
         <Fragment>

--- a/src/components/views/Timeline/timelineStep.tsx
+++ b/src/components/views/Timeline/timelineStep.tsx
@@ -72,6 +72,7 @@ const TimelineStep: React.FC<TimelineStepProps> = ({
                 event={i.event}
                 name={i.name || ""}
                 args={i.args || "{}"}
+                repeatable={i.repeatable}
                 steps={timeline}
                 simulatorId={simulatorId}
                 showDescription={showDescription}

--- a/src/containers/FlightDirector/MissionConfig/TimelineConfig.tsx
+++ b/src/containers/FlightDirector/MissionConfig/TimelineConfig.tsx
@@ -146,6 +146,16 @@ export const TimelineMacroConfig: React.FC<{
               Don't Cancel Delay on Flight Reset
             </Label>
           </FormGroup>
+          <FormGroup style={{marginLeft: "5ch"}}>
+            <Label title="Normally an action only runs once per flight - going back to its step leaves it unchecked. Repeatable actions stay checked and run again every time the step is triggered.">
+              <Input
+                type="checkbox"
+                defaultChecked={Boolean(item.repeatable)}
+                onChange={e => updateMacro("repeatable", e.target.checked)}
+              />
+              Repeatable — Re-run Every Time the Step is Triggered
+            </Label>
+          </FormGroup>
           <MacroWrapper
             id={item.id}
             delay={item.delay}

--- a/src/containers/FlightDirector/MissionConfig/TimelineTypes.ts
+++ b/src/containers/FlightDirector/MissionConfig/TimelineTypes.ts
@@ -5,6 +5,7 @@ export interface TimelineItem {
   args: string;
   delay: number | undefined;
   noCancelOnReset: boolean;
+  repeatable: boolean;
 }
 export interface TimelineStep {
   id: string;

--- a/src/containers/FlightDirector/MissionConfig/queries/missionsSub.graphql
+++ b/src/containers/FlightDirector/MissionConfig/queries/missionsSub.graphql
@@ -29,6 +29,7 @@ subscription MissionSubscription($missionId: ID!) {
         delay
         needsConfig
         noCancelOnReset
+        repeatable
       }
     }
   }

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -2087,6 +2087,7 @@ export type MacroInput = {
   args?: Maybe<Scalars['String']>;
   delay?: Maybe<Scalars['Int']>;
   noCancelOnReset?: Maybe<Scalars['Boolean']>;
+  repeatable?: Maybe<Scalars['Boolean']>;
 };
 
 export type MapBorder = {
@@ -12188,6 +12189,7 @@ export type TimelineItem = {
   args?: Maybe<Scalars['String']>;
   delay?: Maybe<Scalars['Int']>;
   noCancelOnReset?: Maybe<Scalars['Boolean']>;
+  repeatable?: Maybe<Scalars['Boolean']>;
 };
 
 export type TimelineItemInput = {
@@ -12198,6 +12200,7 @@ export type TimelineItemInput = {
   args?: Maybe<Scalars['String']>;
   delay?: Maybe<Scalars['Int']>;
   noCancelOnReset?: Maybe<Scalars['Boolean']>;
+  repeatable?: Maybe<Scalars['Boolean']>;
 };
 
 export type TimelineStep = {
@@ -15064,7 +15067,7 @@ export type TimelineMissionSubscription = (
       & Pick<TimelineStep, 'id' | 'name' | 'order' | 'description'>
       & { timelineItems: Array<(
         { __typename?: 'TimelineItem' }
-        & Pick<TimelineItem, 'id' | 'name' | 'type' | 'args' | 'event' | 'delay'>
+        & Pick<TimelineItem, 'id' | 'name' | 'type' | 'args' | 'event' | 'delay' | 'repeatable'>
       )> }
     )> }
   )> }
@@ -16031,7 +16034,7 @@ export type MissionSubscriptionSubscription = (
       & Pick<TimelineStep, 'id' | 'name' | 'description' | 'order'>
       & { timelineItems: Array<(
         { __typename?: 'TimelineItem' }
-        & Pick<TimelineItem, 'id' | 'name' | 'type' | 'event' | 'args' | 'delay' | 'needsConfig' | 'noCancelOnReset'>
+        & Pick<TimelineItem, 'id' | 'name' | 'type' | 'event' | 'args' | 'delay' | 'needsConfig' | 'noCancelOnReset' | 'repeatable'>
       )> }
     )> }
   )> }
@@ -20255,6 +20258,7 @@ export const TimelineMissionDocument = gql`
         args
         event
         delay
+        repeatable
       }
     }
   }
@@ -21284,6 +21288,7 @@ export const MissionSubscriptionDocument = gql`
         delay
         needsConfig
         noCancelOnReset
+        repeatable
       }
     }
   }

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -1941,6 +1941,7 @@ input MacroInput {
   args: String
   delay: Int
   noCancelOnReset: Boolean
+  repeatable: Boolean
 }
 
 type MapBorder {
@@ -5661,6 +5662,7 @@ type TimelineItem {
   args: String
   delay: Int
   noCancelOnReset: Boolean
+  repeatable: Boolean
 }
 
 input TimelineItemInput {
@@ -5671,6 +5673,7 @@ input TimelineItemInput {
   args: String
   delay: Int
   noCancelOnReset: Boolean
+  repeatable: Boolean
 }
 
 type TimelineStep {


### PR DESCRIPTION
## Description

This PR adds the ability to create a timeline action that is immune from the green text that prevents repeat actions from firing in a timeline. 

It adds code to do so server side, as well as adds a simple icon in the timeline viewer that shows that the step is repeatable. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/Thorium-Sim/thorium/issues/3534

## Screenshots (if appropriate):

- [ ] I submitted a pull request or created an issue for documenting this
      feature on the [Thorium Docs](https://github.com/Thorium-Sim/thorium-docs)
      repo. (Include the issue or pull request url below.)
