### PR TITLE
hotfix: for windows machines w/touch interfaces they have an issue capturing mouse events for DnD

### DIFF
--- a/src/components/views/Aegis/FocusPad.tsx
+++ b/src/components/views/Aegis/FocusPad.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import {DraggableCore, DraggableEvent} from "react-draggable";
 import {throttle} from "helpers/debounce";
+import {beginPointerDrag, getEventCoords} from "helpers/hooks/usePointerDrag";
 
 interface FocusPadProps {
   x: number;
@@ -23,19 +23,17 @@ const FocusPad: React.FC<FocusPadProps> = ({x, y, onChange}) => {
     throttle((nx: number, ny: number) => onChangeRef.current(nx, ny), 100),
   );
 
-  const positionFromEvent = (e: DraggableEvent) => {
+  const positionFromEvent = (e: any) => {
     const pad = padRef.current;
     if (!pad) {
       return null;
     }
     const rect = pad.getBoundingClientRect();
-    const clientX =
-      "clientX" in e ? e.clientX : e.touches && e.touches[0]?.clientX;
-    const clientY =
-      "clientY" in e ? e.clientY : e.touches && e.touches[0]?.clientY;
-    if (typeof clientX !== "number" || typeof clientY !== "number") {
+    const coords = getEventCoords(e);
+    if (!coords) {
       return null;
     }
+    const {clientX, clientY} = coords;
     let nx = (clientX - rect.left - rect.width / 2) / (rect.width / 2);
     let ny = (clientY - rect.top - rect.height / 2) / (rect.height / 2);
     const magnitude = Math.hypot(nx, ny);
@@ -54,7 +52,7 @@ const FocusPad: React.FC<FocusPadProps> = ({x, y, onChange}) => {
     return {x: nx, y: ny};
   };
 
-  const handleDrag = (e: DraggableEvent) => {
+  const handleDrag = (e: any) => {
     const position = positionFromEvent(e);
     if (!position) {
       return;
@@ -63,31 +61,56 @@ const FocusPad: React.FC<FocusPadProps> = ({x, y, onChange}) => {
     throttledChange.current(position.x, position.y);
   };
 
-  const handleStop = (e: DraggableEvent) => {
+  const handleStop = (e: any) => {
     const position = positionFromEvent(e) || dragPosition || {x: 0, y: 0};
     setDragPosition(null);
     onChangeRef.current(position.x, position.y);
   };
 
+  // Pointer events rather than react-draggable's DraggableCore. On a
+  // multi-touch screen DraggableCore's `handleDragStop` bails before removing
+  // its own document listeners whenever the `touchend` does not carry its
+  // tracked touch identifier -- which is exactly what happens when a second
+  // finger lifts first -- leaving the pad latched to every subsequent touch.
+  // See helpers/hooks/usePointerDrag.
+  const cancelDrag = React.useRef<(() => void) | null>(null);
+  const handlePointerDown = (e: React.PointerEvent) => {
+    if (e.button !== 0) return;
+    if (cancelDrag.current) cancelDrag.current();
+    handleDrag(e);
+    cancelDrag.current = beginPointerDrag(e, {
+      onMove: state => handleDrag(state.event),
+      onEnd: state => {
+        cancelDrag.current = null;
+        handleStop(state.event);
+      },
+    });
+  };
+  React.useEffect(
+    () => () => {
+      if (cancelDrag.current) cancelDrag.current();
+      cancelDrag.current = null;
+    },
+    [],
+  );
+
   const shown = dragPosition || {x, y};
   // The whole pad is the drag target so a touch anywhere aims the focus —
   // much easier than grabbing the knob on a touch screen
   return (
-    <DraggableCore onStart={handleDrag} onDrag={handleDrag} onStop={handleStop}>
-      <div className="focus-pad" ref={padRef}>
-        <div className="focus-pad-label focus-pad-fore"></div>
-        <div className="focus-pad-label focus-pad-aft"></div>
-        <div className="focus-pad-label focus-pad-port"></div>
-        <div className="focus-pad-label focus-pad-starboard"></div>
-        <div
-          className="focus-pad-knob"
-          style={{
-            left: `${50 + shown.x * 42}%`,
-            top: `${50 + shown.y * 42}%`,
-          }}
-        />
-      </div>
-    </DraggableCore>
+    <div className="focus-pad" ref={padRef} onPointerDown={handlePointerDown}>
+      <div className="focus-pad-label focus-pad-fore"></div>
+      <div className="focus-pad-label focus-pad-aft"></div>
+      <div className="focus-pad-label focus-pad-port"></div>
+      <div className="focus-pad-label focus-pad-starboard"></div>
+      <div
+        className="focus-pad-knob"
+        style={{
+          left: `${50 + shown.x * 42}%`,
+          top: `${50 + shown.y * 42}%`,
+        }}
+      />
+    </div>
   );
 };
 

--- a/src/components/views/PhaserCharging/index.jsx
+++ b/src/components/views/PhaserCharging/index.jsx
@@ -4,8 +4,9 @@ import gql from "graphql-tag.macro";
 import {graphql, withApollo} from "react-apollo";
 import Tour from "helpers/tourHelper";
 import SubscriptionHelper from "helpers/subscriptionHelper";
+import {beginPointerHold} from "helpers/hooks/usePointerDrag";
 
-import DamageOverlay from '../helpers/DamageOverlay';
+import DamageOverlay from "../helpers/DamageOverlay";
 import "./style.scss";
 export {default as PhaserFire} from "./phaserFire";
 
@@ -48,7 +49,7 @@ class PhaserCharging extends Component {
       selectedBank: id,
     });
   }
-  chargePhasers(beamId) {
+  chargePhasers(beamId, event) {
     const phasers = this.props.data.phasers[0];
     const mutation = gql`
       mutation ChargePhaserBeam($id: ID!, $beamId: ID!) {
@@ -63,12 +64,28 @@ class PhaserCharging extends Component {
       mutation,
       variables,
     });
-    if (phasers.holdToCharge) {
-      document.addEventListener("mouseup", this.stopCharging, {once:true});
+    if (phasers.holdToCharge && event) {
+      this.holdUntilRelease(event);
     }
   }
+  // Hold-to-charge releases run through `beginPointerHold` so a single
+  // `pointerup`/`pointercancel` ends the charge for mouse and touch alike. The
+  // old `document.addEventListener("mouseup", ...)` could never work on a
+  // touchscreen: Chrome fires the entire compat mouse sequence at the *end* of a
+  // tap, so `mouseup` landed a fraction of a millisecond after `mousedown` and
+  // charging stopped before anything accumulated. See
+  // helpers/hooks/usePointerDrag.
+  releaseHold = null;
+  holdUntilRelease(event) {
+    if (this.releaseHold) this.releaseHold();
+    this.releaseHold = beginPointerHold(event, this.stopCharging);
+  }
+  componentWillUnmount() {
+    if (this.releaseHold) this.releaseHold();
+    this.releaseHold = null;
+  }
   stopCharging = () => {
-    document.removeEventListener("mouseup", this.stopCharging, {once:true});
+    this.releaseHold = null;
     const phasers = this.props.data.phasers[0];
     const mutation = gql`
       mutation ChargePhaserBeam($id: ID!) {
@@ -83,7 +100,7 @@ class PhaserCharging extends Component {
       variables,
     });
   };
-  dischargePhasers(beamId) {
+  dischargePhasers(beamId, event) {
     const phasers = this.props.data.phasers[0];
     const mutation = gql`
       mutation DischargePhaserBeam($id: ID!, $beamId: ID!) {
@@ -98,8 +115,8 @@ class PhaserCharging extends Component {
       mutation,
       variables,
     });
-    if (phasers.holdToCharge) {
-      document.addEventListener("mouseup", this.stopCharging);
+    if (phasers.holdToCharge && event) {
+      this.holdUntilRelease(event);
     }
   }
   chargeAll() {
@@ -194,7 +211,7 @@ class PhaserCharging extends Component {
                   color="primary"
                   disabled={!selectedBank}
                   block
-                  onMouseDown={this.dischargePhasers.bind(this, selectedBank)}
+                  onPointerDown={e => this.dischargePhasers(selectedBank, e)}
                 >
                   Discharge Bank
                 </Button>
@@ -204,7 +221,7 @@ class PhaserCharging extends Component {
                   color="primary"
                   disabled={!selectedBank}
                   block
-                  onMouseDown={this.chargePhasers.bind(this, selectedBank)}
+                  onPointerDown={e => this.chargePhasers(selectedBank, e)}
                 >
                   Charge Bank
                 </Button>
@@ -282,7 +299,7 @@ export const PhaserBeam = ({
               block
               color="danger"
               disabled={disabled}
-              onMouseDown={e => firePhasers(id, e)}
+              onPointerDown={e => firePhasers(id, e)}
             >
               Fire {name}
             </Button>
@@ -300,7 +317,7 @@ export const PhaserBeam = ({
             <Button
               block
               color="primary"
-              onMouseDown={()=>chargePhasers(id)}
+              onPointerDown={e => chargePhasers(id, e)}
             >
               Charge
             </Button>
@@ -309,13 +326,13 @@ export const PhaserBeam = ({
             <Button
               block
               color="warning"
-              onClick={()=>dischargePhasers(id)}
+              onPointerDown={e => dischargePhasers(id, e)}
             >
               Discharge
             </Button>
           </Col>
           <Col lg="4" xl="3">
-            <Button block color="info" onMouseDown={()=>coolPhasers(id)}>
+            <Button block color="info" onPointerDown={e => coolPhasers(id, e)}>
               Coolant
             </Button>
           </Col>
@@ -350,11 +367,16 @@ export class PhaserArc extends Component {
     this.state = {
       arc: props.arc,
     };
-    this.mouseUp = () => {
-      document.removeEventListener("mouseup", this.mouseUp);
-      this.arcTimeout = null;
-    };
+    this.releaseArc = null;
     this.arcTimeout = null;
+    this.mouseUp = () => {
+      this.releaseArc = null;
+      // The old version never cleared this timer -- it only nulled the handle,
+      // so one more tick still fired after release.
+      clearTimeout(this.arcTimeout);
+      this.arcTimeout = null;
+      this.setArc();
+    };
   }
   setArc() {
     const {phaserId} = this.props;
@@ -379,16 +401,22 @@ export class PhaserArc extends Component {
         Math.max(0, direction === "up" ? state.arc + 0.04 : state.arc - 0.04),
       ),
     }));
-    if (this.arcTimeout) {
-      this.arcTimeout = setTimeout(() => this.changeArc(direction), 100);
-    } else {
-      this.setArc();
-    }
-  };
-  updateArc(direction) {
-    document.addEventListener("mouseup", this.mouseUp, {once:true});
-    document.addEventListener("touchend", this.mouseUp, {once:true});
     this.arcTimeout = setTimeout(() => this.changeArc(direction), 100);
+  };
+  // One pointerdown/pointerup pair per press. This previously wired both
+  // `onMouseDown` and `onTouchStart`, so a single tap on a touchscreen started
+  // two repeat loops -- Chrome fires the compat `mousedown` after `touchstart`
+  // -- while `mouseUp` only ever cleared one of them and never removed its
+  // `touchend` listener. Stepping immediately also means a quick tap nudges the
+  // arc right away instead of after 100ms.
+  updateArc(direction, event) {
+    if (this.releaseArc) this.releaseArc();
+    this.releaseArc = beginPointerHold(event, this.mouseUp);
+    this.changeArc(direction);
+  }
+  componentWillUnmount() {
+    if (this.releaseArc) this.releaseArc();
+    clearTimeout(this.arcTimeout);
   }
   componentDidUpdate(oldProps) {
     if (oldProps.arc !== this.props.arc) {
@@ -414,16 +442,14 @@ export class PhaserArc extends Component {
       <Row style={{height: "200px"}} className="phaserArc">
         <Col sm={{size: 4}} style={{marginTop: "50px"}}>
           <Button
-            onMouseDown={() => this.updateArc("up")}
-            onTouchStart={() => this.updateArc("up")}
+            onPointerDown={e => this.updateArc("up", e)}
             block
             color="warning"
           >
             Widen Arc
           </Button>
           <Button
-            onMouseDown={() => this.updateArc("down")}
-            onTouchStart={() => this.updateArc("down")}
+            onPointerDown={e => this.updateArc("down", e)}
             block
             color="warning"
           >

--- a/src/components/views/PhaserCharging/phaserFire.jsx
+++ b/src/components/views/PhaserCharging/phaserFire.jsx
@@ -2,6 +2,11 @@ import React from "react";
 import {Button} from "helpers/reactstrap";
 import AnimatedNumber from "react-animated-number";
 
+// Fire/Cool wire a single `onPointerDown` rather than the old
+// `onMouseDown` + `onTouchStart` pair. Chrome fires the compat `mousedown`
+// after `touchstart`, so on a touchscreen every tap ran these twice -- which is
+// what the 2-second `interactionTime` guard in Targeting/index.jsx exists to
+// swallow. Pointer events fire exactly once for mouse and touch alike.
 const PhaserBeam = ({
   coolPhasers,
   firePhasers,
@@ -36,17 +41,11 @@ const PhaserBeam = ({
         size="sm"
         color="danger"
         disabled={disabled}
-        onMouseDown={e => firePhasers(id, e)}
-        onTouchStart={e => firePhasers(id, e)}
+        onPointerDown={e => firePhasers(id, e)}
       >
         Fire
       </Button>
-      <Button
-        size="sm"
-        color="info"
-        onMouseDown={()=>coolPhasers(id)}
-        onTouchStart={()=>coolPhasers(id)}
-      >
+      <Button size="sm" color="info" onPointerDown={e => coolPhasers(id, e)}>
         Cool
       </Button>
     </div>

--- a/src/components/views/Targeting/index.jsx
+++ b/src/components/views/Targeting/index.jsx
@@ -12,6 +12,7 @@ import DamageOverlay from "../helpers/DamageOverlay";
 import TargetControls from "./targetControls";
 import Coordinates from "./coordinates";
 import SubscriptionHelper from "helpers/subscriptionHelper";
+import {beginPointerHold} from "helpers/hooks/usePointerDrag";
 
 const trainingSteps = [
   {
@@ -287,7 +288,7 @@ class Targeting extends Component {
       variables,
     });
   };
-  chargePhasers(beamId) {
+  chargePhasers(beamId, event) {
     const phasers = this.props.data.phasers[0];
     const mutation = gql`
       mutation ChargePhaserBeam($id: ID!, $beamId: ID!) {
@@ -302,12 +303,31 @@ class Targeting extends Component {
       mutation,
       variables,
     });
-    if (phasers.holdToCharge) {
-      document.addEventListener("mouseup", this.stopCharging);
+    if (phasers.holdToCharge && event) {
+      this.hold("charge", event, this.stopCharging);
     }
   }
+  // Press-and-hold releases go through `beginPointerHold`: one
+  // `pointerup`/`pointercancel` per press, for mouse and touch alike. The old
+  // `mouseup` listeners could not work on a touchscreen, where Chrome fires the
+  // whole compat mouse sequence at the *end* of a tap -- `mouseup` arrived a
+  // fraction of a millisecond after `mousedown`, so nothing ever accumulated.
+  // See helpers/hooks/usePointerDrag.
+  releaseHolds = {};
+  hold(key, event, onRelease) {
+    if (this.releaseHolds[key]) this.releaseHolds[key]();
+    this.releaseHolds[key] = beginPointerHold(event, () => {
+      this.releaseHolds[key] = null;
+      onRelease();
+    });
+  }
+  componentWillUnmount() {
+    Object.keys(this.releaseHolds).forEach(key => {
+      if (this.releaseHolds[key]) this.releaseHolds[key]();
+    });
+    this.releaseHolds = {};
+  }
   stopCharging = () => {
-    document.removeEventListener("mouseup", this.stopCharging);
     const phasers = this.props.data.phasers[0];
     const mutation = gql`
       mutation ChargePhaserBeam($id: ID!) {
@@ -338,7 +358,7 @@ class Targeting extends Component {
       variables,
     });
   }
-  coolPhasers(beamId) {
+  coolPhasers(beamId, event) {
     const phasers = this.props.data.phasers[0];
     const mutation = gql`
       mutation PhaserCool($id: ID!, $beamId: ID) {
@@ -353,8 +373,7 @@ class Targeting extends Component {
       mutation,
       variables,
     });
-    document.addEventListener("mouseup", this.stopCoolant);
-    document.addEventListener("touchend", this.stopCoolant);
+    if (event) this.hold("coolant", event, this.stopCoolant);
   }
   interactionTime = 0;
   firePhasers = (beamId, e) => {
@@ -388,8 +407,7 @@ class Targeting extends Component {
         }),
       });
     }, 3000);
-    document.addEventListener("mouseup", this.mouseup);
-    document.addEventListener("touchend", this.mouseup);
+    this.hold("fire", e, this.mouseup);
     return false;
   };
   render() {

--- a/src/components/views/Targeting/standalone.jsx
+++ b/src/components/views/Targeting/standalone.jsx
@@ -12,6 +12,7 @@ import DamageOverlay from "../helpers/DamageOverlay";
 import TargetControls from "./targetControls";
 import Coordinates from "./coordinates";
 import SubscriptionHelper from "helpers/subscriptionHelper";
+import {beginPointerHold} from "helpers/hooks/usePointerDrag";
 import {targetingMessage} from ".";
 
 const trainingSteps = [
@@ -306,7 +307,24 @@ class Targeting extends Component {
       variables,
     });
   }
-  coolPhasers(beamId) {
+  // Press-and-hold releases go through `beginPointerHold`: one
+  // `pointerup`/`pointercancel` per press, for mouse and touch alike. See
+  // helpers/hooks/usePointerDrag.
+  releaseHolds = {};
+  hold(key, event, onRelease) {
+    if (this.releaseHolds[key]) this.releaseHolds[key]();
+    this.releaseHolds[key] = beginPointerHold(event, () => {
+      this.releaseHolds[key] = null;
+      onRelease();
+    });
+  }
+  componentWillUnmount() {
+    Object.keys(this.releaseHolds).forEach(key => {
+      if (this.releaseHolds[key]) this.releaseHolds[key]();
+    });
+    this.releaseHolds = {};
+  }
+  coolPhasers(beamId, event) {
     const phasers = this.props.data.phasers[0];
     const mutation = gql`
       mutation PhaserCool($id: ID!, $beamId: ID) {
@@ -321,8 +339,7 @@ class Targeting extends Component {
       mutation,
       variables,
     });
-    document.addEventListener("mouseup", this.stopCoolant);
-    document.addEventListener("touchend", this.stopCoolant);
+    if (event) this.hold("coolant", event, this.stopCoolant);
   }
   interactionTime = 0;
   firePhasers = (beamId, e) => {
@@ -356,8 +373,7 @@ class Targeting extends Component {
         }),
       });
     }, 3000);
-    document.addEventListener("mouseup", this.mouseup);
-    document.addEventListener("touchend", this.mouseup);
+    this.hold("fire", e, this.mouseup);
     return false;
   };
   render() {

--- a/src/components/views/Thrusters/index.jsx
+++ b/src/components/views/Thrusters/index.jsx
@@ -1,10 +1,10 @@
 import React, {Fragment, Component} from "react";
 import gql from "graphql-tag.macro";
 import {graphql} from "react-apollo";
-import {DraggableCore} from "react-draggable";
 import {Button, Row, Col} from "helpers/reactstrap";
 import ThrusterThree from "./three-view";
 import distance from "helpers/distance";
+import {beginPointerDrag, getEventCoords} from "helpers/hooks/usePointerDrag";
 import Measure from "react-measure";
 import throttle from "helpers/debounce";
 import SubscriptionHelper from "helpers/subscriptionHelper";
@@ -159,6 +159,7 @@ class Thrusters extends Component {
     }, 200);
   }
   componentWillUnmount() {
+    this.cancelAllDrags();
     const id = this.props.data.thrusters[0].id;
     const rotation = {yaw: 0, pitch: 0, roll: 0};
     const direction = {x: 0, y: 0, z: 0};
@@ -256,6 +257,43 @@ gamepadLoop(){
 		this.setState({control:!this.state.control});
 	}
   */
+  // The four knobs used to be wrapped in react-draggable's DraggableCore, which
+  // cannot survive a multi-touch screen. Its `handleDragStop` bails at
+  // `if (position == null) return` *before* removing its own document
+  // listeners, and a `touchend` only carries the finger that actually lifted.
+  // So with two fingers on two knobs, lifting one leaves the other permanently
+  // latched: `dragging` stays true and its orphaned `touchmove` listener has no
+  // guard, so that knob then follows every touch anywhere on the page. Do it
+  // once per knob and all four move at once. It also never listens for
+  // `touchcancel`, which Windows digitizers fire constantly for palm rejection.
+  //
+  // Pointer events avoid all of that: one stream for mouse and touch, a
+  // `pointerId` we match on, pointer capture so the release is guaranteed, and
+  // `pointercancel` handled. See helpers/hooks/usePointerDrag.
+  dragCancels = {};
+  startDrag = which => e => {
+    if (this.props.data.loading || !this.props.data.thrusters) return;
+    const node = e.currentTarget;
+    if (this.dragCancels[which]) this.dragCancels[which]();
+    const handle = name => this.onDragHandler(name, which);
+    handle("onDragStart")(e, {node});
+    this.dragCancels[which] = beginPointerDrag(e, {
+      onMove: state => handle("onDrag")(state.event, {node}),
+      onEnd: state => {
+        this.dragCancels[which] = null;
+        handle("onDragStop")(state.event, {node});
+      },
+    });
+    // No usable pointer -- don't leave the knob stuck mid-drag.
+    if (!this.dragCancels[which]) handle("onDragStop")(e, {node});
+  };
+  cancelAllDrags() {
+    Object.keys(this.dragCancels).forEach(which => {
+      if (this.dragCancels[which]) this.dragCancels[which]();
+    });
+    this.dragCancels = {};
+    document.body.classList.remove("switcherLocked");
+  }
   onDragHandler(handlerName, which) {
     return (e, {node}) => {
       const newPosition = {top: 0, left: 0};
@@ -266,8 +304,11 @@ gamepadLoop(){
       const rotation = {yaw: 0, pitch: 0, roll: 0};
       const direction = {x: 0, y: 0, z: 0};
       const {width} = node.offsetParent.getBoundingClientRect();
-      const clientX = e.clientX || e.clientX === 0 || e.touches[0].clientX;
-      const clientY = e.clientY || e.clientY === 0 || e.touches[0].clientY;
+      // `touchend` carries an empty `touches` list, so the old
+      // `e.touches[0].clientX` threw a TypeError on every touch release.
+      const coords = getEventCoords(e);
+      const clientX = coords ? coords.clientX : 0;
+      const clientY = coords ? coords.clientY : 0;
 
       switch (handlerName) {
         case "onDragStart":
@@ -276,9 +317,7 @@ gamepadLoop(){
           document.body.classList.add("switcherLocked");
           break;
         case "onDrag":
-          if (!this.state[which]) {
-            throw new Error("onDrag called before onDragStart.");
-          }
+          if (!this.state[which] || !coords) return;
           newPosition.left =
             ((parentRect.left + parentRect.width / 2 - clientX) / width) *
             -1 *
@@ -347,9 +386,7 @@ gamepadLoop(){
           break;
         case "onDragStop":
           document.body.classList.remove("switcherLocked");
-          if (!this.state[which]) {
-            throw new Error("onDragEnd called before onDragStart.");
-          }
+          if (!this.state[which]) return;
           newPosition.left = this.state[which].left;
           newPosition.top = this.state[which].top;
           setTimeout(() => {
@@ -442,45 +479,32 @@ gamepadLoop(){
                   <label>Direction</label>
                   <div className="spacer" />
                   <div className="draggerCircle" ref="dirCirc">
-                    <DraggableCore
-                      onStart={this.onDragHandler("onDragStart", "direction")}
-                      onDrag={this.onDragHandler("onDrag", "direction")}
-                      onStop={this.onDragHandler("onDragStop", "direction")}
-                    >
-                      <div
-                        ref="directionDragger"
-                        className="dragger direction alertBack"
-                        style={{
-                          transform: `translate3d(${
-                            (this.state.direction.left * width) / 2
-                          }px,${
-                            (this.state.direction.top * height) / 2
-                          }px,0px)`,
-                        }}
-                      />
-                    </DraggableCore>
+                    <div
+                      onPointerDown={this.startDrag("direction")}
+                      ref="directionDragger"
+                      className="dragger direction alertBack"
+                      style={{
+                        transform: `translate3d(${
+                          (this.state.direction.left * width) / 2
+                        }px,${(this.state.direction.top * height) / 2}px,0px)`,
+                      }}
+                    />
                     <span className="label up">Forward</span>
                     <span className="label right">Starboard</span>
                     <span className="label down">Reverse</span>
                     <span className="label left">Port</span>
                   </div>
                   <div className="draggerBar">
-                    <DraggableCore
-                      axis="x"
-                      onStart={this.onDragHandler("onDragStart", "directionUp")}
-                      onDrag={this.onDragHandler("onDrag", "directionUp")}
-                      onStop={this.onDragHandler("onDragStop", "directionUp")}
-                    >
-                      <div
-                        ref="foreDragger"
-                        className="dragger fore alertBack"
-                        style={{
-                          transform: `translate3d(${
-                            (this.state.directionUp.left * (width - 40)) / 2
-                          }px,0px,0px)`,
-                        }}
-                      />
-                    </DraggableCore>
+                    <div
+                      onPointerDown={this.startDrag("directionUp")}
+                      ref="foreDragger"
+                      className="dragger fore alertBack"
+                      style={{
+                        transform: `translate3d(${
+                          (this.state.directionUp.left * (width - 40)) / 2
+                        }px,0px,0px)`,
+                      }}
+                    />
                     <span className="label right">Up</span>
                     <span className="label left">Down</span>
                   </div>
@@ -531,43 +555,32 @@ gamepadLoop(){
                   <label>Rotation</label>
                   <div className="spacer" />
                   <div className="draggerCircle">
-                    <DraggableCore
-                      onStart={this.onDragHandler("onDragStart", "rotation")}
-                      onDrag={this.onDragHandler("onDrag", "rotation")}
-                      onStop={this.onDragHandler("onDragStop", "rotation")}
-                    >
-                      <div
-                        ref="rotationDragger"
-                        className="dragger rotation alertBack"
-                        style={{
-                          transform: `translate3d(${
-                            (this.state.rotation.left * width) / 2
-                          }px,${(this.state.rotation.top * height) / 2}px,0px)`,
-                        }}
-                      />
-                    </DraggableCore>
+                    <div
+                      onPointerDown={this.startDrag("rotation")}
+                      ref="rotationDragger"
+                      className="dragger rotation alertBack"
+                      style={{
+                        transform: `translate3d(${
+                          (this.state.rotation.left * width) / 2
+                        }px,${(this.state.rotation.top * height) / 2}px,0px)`,
+                      }}
+                    />
                     <span className="label up">Pitch Up</span>
                     <span className="label right">Roll Right</span>
                     <span className="label down">Pitch Down</span>
                     <span className="label left">Roll Left</span>
                   </div>
                   <div className="draggerBar">
-                    <DraggableCore
-                      axis="x"
-                      onStart={this.onDragHandler("onDragStart", "yaw")}
-                      onDrag={this.onDragHandler("onDrag", "yaw")}
-                      onStop={this.onDragHandler("onDragStop", "yaw")}
-                    >
-                      <div
-                        ref="yaw"
-                        className="dragger yaw alertBack"
-                        style={{
-                          transform: `translate3d(${
-                            (this.state.yaw.left * (width - 40)) / 2
-                          }px,0px,0px)`,
-                        }}
-                      />
-                    </DraggableCore>
+                    <div
+                      onPointerDown={this.startDrag("yaw")}
+                      ref="yaw"
+                      className="dragger yaw alertBack"
+                      style={{
+                        transform: `translate3d(${
+                          (this.state.yaw.left * (width - 40)) / 2
+                        }px,0px,0px)`,
+                      }}
+                    />
                     <span className="label right">Yaw Starboard</span>
                     <span className="label left">Yaw Port</span>
                   </div>

--- a/src/components/views/Thrusters/lite.jsx
+++ b/src/components/views/Thrusters/lite.jsx
@@ -1,9 +1,9 @@
 import React, {Component} from "react";
 import gql from "graphql-tag.macro";
 import {graphql} from "react-apollo";
-import {DraggableCore} from "react-draggable";
 import {Row, Col} from "helpers/reactstrap";
 import distance from "helpers/distance";
+import {beginPointerDrag, getEventCoords} from "helpers/hooks/usePointerDrag";
 import throttle from "helpers/debounce";
 import SubscriptionHelper from "helpers/subscriptionHelper";
 import compose from "lodash.flowright";
@@ -151,6 +151,7 @@ class Thrusters extends Component {
     }, 15);
   }
   componentWillUnmount() {
+    this.cancelAllDrags();
     const id = this.props.data.thrusters[0].id;
     const rotation = {yaw: 0, pitch: 0, roll: 0};
     const direction = {x: 0, y: 0, z: 0};
@@ -248,6 +249,43 @@ gamepadLoop(){
 		this.setState({control:!this.state.control});
 	}
   */
+  // The four knobs used to be wrapped in react-draggable's DraggableCore, which
+  // cannot survive a multi-touch screen. Its `handleDragStop` bails at
+  // `if (position == null) return` *before* removing its own document
+  // listeners, and a `touchend` only carries the finger that actually lifted.
+  // So with two fingers on two knobs, lifting one leaves the other permanently
+  // latched: `dragging` stays true and its orphaned `touchmove` listener has no
+  // guard, so that knob then follows every touch anywhere on the page. Do it
+  // once per knob and all four move at once. It also never listens for
+  // `touchcancel`, which Windows digitizers fire constantly for palm rejection.
+  //
+  // Pointer events avoid all of that: one stream for mouse and touch, a
+  // `pointerId` we match on, pointer capture so the release is guaranteed, and
+  // `pointercancel` handled. See helpers/hooks/usePointerDrag.
+  dragCancels = {};
+  startDrag = which => e => {
+    if (this.props.data.loading || !this.props.data.thrusters) return;
+    const node = e.currentTarget;
+    if (this.dragCancels[which]) this.dragCancels[which]();
+    const handle = name => this.onDragHandler(name, which);
+    handle("onDragStart")(e, {node});
+    this.dragCancels[which] = beginPointerDrag(e, {
+      onMove: state => handle("onDrag")(state.event, {node}),
+      onEnd: state => {
+        this.dragCancels[which] = null;
+        handle("onDragStop")(state.event, {node});
+      },
+    });
+    // No usable pointer -- don't leave the knob stuck mid-drag.
+    if (!this.dragCancels[which]) handle("onDragStop")(e, {node});
+  };
+  cancelAllDrags() {
+    Object.keys(this.dragCancels).forEach(which => {
+      if (this.dragCancels[which]) this.dragCancels[which]();
+    });
+    this.dragCancels = {};
+    document.body.classList.remove("switcherLocked");
+  }
   onDragHandler(handlerName, which) {
     return (e, {node}) => {
       const newPosition = {top: 0, left: 0};
@@ -258,8 +296,11 @@ gamepadLoop(){
       const rotation = {yaw: 0, pitch: 0, roll: 0};
       const direction = {x: 0, y: 0, z: 0};
       const {width} = node.offsetParent.getBoundingClientRect();
-      const clientX = e.clientX || e.clientX === 0 || e.touches[0].clientX;
-      const clientY = e.clientY || e.clientY === 0 || e.touches[0].clientY;
+      // `touchend` carries an empty `touches` list, so the old
+      // `e.touches[0].clientX` threw a TypeError on every touch release.
+      const coords = getEventCoords(e);
+      const clientX = coords ? coords.clientX : 0;
+      const clientY = coords ? coords.clientY : 0;
       switch (handlerName) {
         case "onDragStart":
           obj[which] = newPosition;
@@ -267,9 +308,7 @@ gamepadLoop(){
           this.setState(obj);
           break;
         case "onDrag":
-          if (!this.state[which]) {
-            throw new Error("onDrag called before onDragStart.");
-          }
+          if (!this.state[which] || !coords) return;
           newPosition.left =
             ((parentRect.left + parentRect.width / 2 - clientX) / width) *
             -1 *
@@ -338,9 +377,7 @@ gamepadLoop(){
           break;
         case "onDragStop":
           document.body.classList.remove("switcherLocked");
-          if (!this.state[which]) {
-            throw new Error("onDragEnd called before onDragStart.");
-          }
+          if (!this.state[which]) return;
           newPosition.left = this.state[which].left;
           newPosition.top = this.state[which].top;
           setTimeout(() => {
@@ -423,43 +460,32 @@ gamepadLoop(){
             <label>Direction</label>
             <div className="spacer" />
             <div className="draggerCircle" ref="dirCirc">
-              <DraggableCore
-                onStart={this.onDragHandler("onDragStart", "direction")}
-                onDrag={this.onDragHandler("onDrag", "direction")}
-                onStop={this.onDragHandler("onDragStop", "direction")}
-              >
-                <div
-                  ref="directionDragger"
-                  className="dragger direction alertBack"
-                  style={{
-                    transform: `translate3d(${
-                      (this.state.direction.left * width) / 2
-                    }px,${(this.state.direction.top * height) / 2}px,0px)`,
-                  }}
-                />
-              </DraggableCore>
+              <div
+                onPointerDown={this.startDrag("direction")}
+                ref="directionDragger"
+                className="dragger direction alertBack"
+                style={{
+                  transform: `translate3d(${
+                    (this.state.direction.left * width) / 2
+                  }px,${(this.state.direction.top * height) / 2}px,0px)`,
+                }}
+              />
               <span className="label up">Forward</span>
               <span className="label right">Starboard</span>
               <span className="label down">Reverse</span>
               <span className="label left">Port</span>
             </div>
             <div className="draggerBar">
-              <DraggableCore
-                axis="x"
-                onStart={this.onDragHandler("onDragStart", "directionUp")}
-                onDrag={this.onDragHandler("onDrag", "directionUp")}
-                onStop={this.onDragHandler("onDragStop", "directionUp")}
-              >
-                <div
-                  ref="foreDragger"
-                  className="dragger fore alertBack"
-                  style={{
-                    transform: `translate3d(${
-                      (this.state.directionUp.left * (width - 40)) / 2
-                    }px,0px,0px)`,
-                  }}
-                />
-              </DraggableCore>
+              <div
+                onPointerDown={this.startDrag("directionUp")}
+                ref="foreDragger"
+                className="dragger fore alertBack"
+                style={{
+                  transform: `translate3d(${
+                    (this.state.directionUp.left * (width - 40)) / 2
+                  }px,0px,0px)`,
+                }}
+              />
               <span className="label right">Up</span>
               <span className="label left">Down</span>
             </div>
@@ -498,43 +524,32 @@ gamepadLoop(){
             <label>Rotation</label>
             <div className="spacer" />
             <div className="draggerCircle">
-              <DraggableCore
-                onStart={this.onDragHandler("onDragStart", "rotation")}
-                onDrag={this.onDragHandler("onDrag", "rotation")}
-                onStop={this.onDragHandler("onDragStop", "rotation")}
-              >
-                <div
-                  ref="rotationDragger"
-                  className="dragger rotation alertBack"
-                  style={{
-                    transform: `translate3d(${
-                      (this.state.rotation.left * width) / 2
-                    }px,${(this.state.rotation.top * height) / 2}px,0px)`,
-                  }}
-                />
-              </DraggableCore>
+              <div
+                onPointerDown={this.startDrag("rotation")}
+                ref="rotationDragger"
+                className="dragger rotation alertBack"
+                style={{
+                  transform: `translate3d(${
+                    (this.state.rotation.left * width) / 2
+                  }px,${(this.state.rotation.top * height) / 2}px,0px)`,
+                }}
+              />
               <span className="label up">Pitch Up</span>
               <span className="label right">Roll Right</span>
               <span className="label down">Pitch Down</span>
               <span className="label left">Roll Left</span>
             </div>
             <div className="draggerBar">
-              <DraggableCore
-                axis="x"
-                onStart={this.onDragHandler("onDragStart", "yaw")}
-                onDrag={this.onDragHandler("onDrag", "yaw")}
-                onStop={this.onDragHandler("onDragStop", "yaw")}
-              >
-                <div
-                  ref="yaw"
-                  className="dragger yaw alertBack"
-                  style={{
-                    transform: `translate3d(${
-                      (this.state.yaw.left * (width - 40)) / 2
-                    }px,0px,0px)`,
-                  }}
-                />
-              </DraggableCore>
+              <div
+                onPointerDown={this.startDrag("yaw")}
+                ref="yaw"
+                className="dragger yaw alertBack"
+                style={{
+                  transform: `translate3d(${
+                    (this.state.yaw.left * (width - 40)) / 2
+                  }px,0px,0px)`,
+                }}
+              />
               <span className="label right">Yaw Starboard</span>
               <span className="label left">Yaw Port</span>
             </div>

--- a/src/components/views/Thrusters/style.scss
+++ b/src/components/views/Thrusters/style.scss
@@ -30,6 +30,11 @@ body.switcherLocked {
     margin-top: calc(100% + 30px);
   }
   .draggerCircle {
+    // Keep the browser from claiming the gesture as a pan/scroll on a
+    // touchscreen. This is the correct mechanism -- preventDefault() inside a
+    // React onTouchStart is a no-op, since React 16 delegates to `document`
+    // where Chrome forces touchstart listeners passive.
+    touch-action: none;
     margin-top: 30px;
     position: absolute;
     top: 0;
@@ -47,6 +52,7 @@ body.switcherLocked {
       linear-gradient(165deg, #000000 0%, rgba(0, 0, 0, 0) 50%, #000000 100%);
   }
   .draggerBar {
+    touch-action: none;
     bottom: -20%;
     height: 15.5%;
     position: absolute;
@@ -64,6 +70,7 @@ body.switcherLocked {
     margin-top: 50px;
   }
   .dragger {
+    touch-action: none;
     width: 14%;
     height: 14%;
     position: absolute;

--- a/src/helpers/hooks/usePointerDrag.ts
+++ b/src/helpers/hooks/usePointerDrag.ts
@@ -1,0 +1,360 @@
+import React from "react";
+
+/**
+ * Pointer-event helpers for controls that must work identically with a mouse
+ * and with a Windows touchscreen.
+ *
+ * Why this exists
+ * ---------------
+ * Chrome synthesizes "compatibility" mouse events for touch, but only for a
+ * clean tap, and only at the very end of the gesture:
+ *
+ *   touchstart -> touchend -> mousemove x1 -> mousedown -> mouseup -> click
+ *
+ * Two consequences break hand-rolled mouse drag code:
+ *
+ *  1. `mousedown` and `mouseup` arrive back to back in the same task. Any code
+ *     that registers its `mouseup` listener from a React effect (i.e. after the
+ *     next commit) misses the release entirely and latches "dragging" forever.
+ *  2. Once a gesture accumulates enough `touchmove`s to stop being a tap, the
+ *     compat mouse events are suppressed completely. There is no synthesized
+ *     `mousemove` stream, so `mousemove`-driven dragging never happens at all.
+ *
+ * Pointer events sidestep both: they fire exactly once per input for mouse,
+ * touch and pen alike, and `setPointerCapture` guarantees that the matching
+ * `pointerup` is delivered even if the finger leaves the element. Wiring a
+ * single `onPointerDown` also removes the double-fire you get from wiring
+ * `onMouseDown` and `onTouchStart` to the same handler.
+ *
+ * Note that scroll/pan interference is handled with CSS `touch-action: none`
+ * on the draggable element -- not `preventDefault()`. React 16 delegates events
+ * to `document`, where Chrome forces `touchstart`/`touchmove` listeners passive,
+ * so `preventDefault()` inside a React `onTouchStart` is a no-op.
+ */
+
+export interface PointerCoords {
+  clientX: number;
+  clientY: number;
+  pageX: number;
+  pageY: number;
+}
+
+export interface PointerDragState extends PointerCoords {
+  /**
+   * Movement since the previous move. Computed here rather than read from
+   * `movementX`/`movementY`, which are mouse-only and are always 0 on
+   * synthesized events.
+   */
+  dx: number;
+  dy: number;
+  /** Movement since the drag started. */
+  totalDx: number;
+  totalDy: number;
+  /** True once the pointer has travelled further than `threshold`. */
+  moved: boolean;
+  pointerType: string;
+  event: PointerEvent;
+}
+
+type CoordSource = {
+  clientX?: unknown;
+  pageX?: unknown;
+  clientY?: unknown;
+  pageY?: unknown;
+};
+
+/**
+ * Normalize a mouse, touch or pointer event -- native or React synthetic -- to
+ * page/client coordinates. Returns null instead of throwing when the event
+ * carries no usable coordinates.
+ *
+ * `changedTouches` is read before `touches` because `touches` is *empty* on
+ * `touchend`; reading `touches[0]` there is what makes naive code throw on
+ * every touch release.
+ */
+export function getEventCoords(event: any): PointerCoords | null {
+  if (!event) return null;
+  const e = event.nativeEvent || event;
+  const touch =
+    (e.changedTouches && e.changedTouches[0]) ||
+    (e.touches && e.touches[0]) ||
+    null;
+  const source: CoordSource = touch || e;
+  const {clientX, clientY} = source;
+  if (typeof clientX !== "number" || typeof clientY !== "number") return null;
+  const {pageX, pageY} = source;
+  return {
+    clientX,
+    clientY,
+    pageX: typeof pageX === "number" ? pageX : clientX + window.pageXOffset,
+    pageY: typeof pageY === "number" ? pageY : clientY + window.pageYOffset,
+  };
+}
+
+/** Distance in px a pointer may travel and still count as a tap. */
+export const TAP_THRESHOLD = 3;
+
+function capture(target: Element, pointerId: number) {
+  try {
+    if (typeof (target as any).setPointerCapture === "function") {
+      target.setPointerCapture(pointerId);
+    }
+  } catch (err) {
+    // Safe to ignore: the pointer may already be gone. Document-level
+    // listeners still deliver the release.
+  }
+}
+
+function releaseCapture(target: Element, pointerId: number) {
+  try {
+    if (
+      typeof (target as any).hasPointerCapture === "function" &&
+      target.hasPointerCapture(pointerId)
+    ) {
+      target.releasePointerCapture(pointerId);
+    }
+  } catch (err) {
+    // Ignore -- capture was already released or the node is detached.
+  }
+}
+
+export interface PointerDragHandlers {
+  onMove?: (state: PointerDragState) => void;
+  /** `cancelled` is true when the gesture ended via `pointercancel`. */
+  onEnd?: (state: PointerDragState, cancelled: boolean) => void;
+  /** Tap threshold in px. Defaults to {@link TAP_THRESHOLD}. */
+  threshold?: number;
+}
+
+/**
+ * Imperative drag core. Call this from inside a `pointerdown` handler; it
+ * captures the pointer and wires move/up/cancel listeners *synchronously*, so
+ * the immediate compat release that follows a touch tap can never be missed.
+ *
+ * Returns a function that tears the drag down without firing `onEnd`, for use
+ * in unmount cleanup. Returns null when the event carries no coordinates.
+ */
+export function beginPointerDrag(
+  event: any,
+  {onMove, onEnd, threshold = TAP_THRESHOLD}: PointerDragHandlers,
+): (() => void) | null {
+  const coords = getEventCoords(event);
+  if (!coords) return null;
+
+  const native: PointerEvent = event.nativeEvent || event;
+  const target: Element = (event.currentTarget || native.target) as Element;
+  const pointerId = typeof native.pointerId === "number" ? native.pointerId : 1;
+  const pointerType = native.pointerType || "mouse";
+
+  let lastX = coords.clientX;
+  let lastY = coords.clientY;
+  let lastCoords = coords;
+  let finished = false;
+
+  const buildState = (
+    next: PointerCoords,
+    ev: PointerEvent,
+  ): PointerDragState => {
+    const totalDx = next.clientX - coords.clientX;
+    const totalDy = next.clientY - coords.clientY;
+    return {
+      ...next,
+      dx: next.clientX - lastX,
+      dy: next.clientY - lastY,
+      totalDx,
+      totalDy,
+      moved: Math.sqrt(totalDx * totalDx + totalDy * totalDy) > threshold,
+      pointerType,
+      event: ev,
+    };
+  };
+
+  const detach = () => {
+    document.removeEventListener("pointermove", handleMove);
+    document.removeEventListener("pointerup", handleUp);
+    document.removeEventListener("pointercancel", handleCancel);
+    if (target) releaseCapture(target, pointerId);
+  };
+
+  const finish = (ev: PointerEvent, cancelled: boolean) => {
+    if (finished) return;
+    finished = true;
+    detach();
+    const next = getEventCoords(ev) || lastCoords;
+    if (onEnd) onEnd(buildState(next, ev), cancelled);
+  };
+
+  function handleMove(ev: PointerEvent) {
+    if (ev.pointerId !== pointerId) return;
+    const next = getEventCoords(ev);
+    if (!next) return;
+    const state = buildState(next, ev);
+    lastX = next.clientX;
+    lastY = next.clientY;
+    lastCoords = next;
+    if (onMove) onMove(state);
+  }
+  function handleUp(ev: PointerEvent) {
+    if (ev.pointerId !== pointerId) return;
+    finish(ev, false);
+  }
+  function handleCancel(ev: PointerEvent) {
+    if (ev.pointerId !== pointerId) return;
+    finish(ev, true);
+  }
+
+  if (target) capture(target, pointerId);
+  document.addEventListener("pointermove", handleMove);
+  document.addEventListener("pointerup", handleUp);
+  document.addEventListener("pointercancel", handleCancel);
+
+  return () => {
+    if (finished) return;
+    finished = true;
+    detach();
+  };
+}
+
+export interface UsePointerDragOptions extends PointerDragHandlers {
+  onStart?: (state: PointerDragState, event: React.PointerEvent) => void;
+}
+
+/**
+ * Hook wrapper around {@link beginPointerDrag}. Spread the result onto the
+ * draggable element and give that element `touch-action: none` in CSS.
+ *
+ * On unmount any in-flight drag is detached without firing `onEnd`, so an
+ * unmounted component is never asked to update state.
+ */
+export function usePointerDrag(options: UsePointerDragOptions) {
+  const optionsRef = React.useRef(options);
+  optionsRef.current = options;
+  const cancelRef = React.useRef<(() => void) | null>(null);
+
+  const onPointerDown = React.useCallback((event: React.PointerEvent) => {
+    // Primary button only -- right/middle click should not start a drag.
+    if (event.button !== 0) return;
+    if (event.isPrimary === false) return;
+    if (cancelRef.current) return;
+
+    const {onStart, onMove, onEnd, threshold} = optionsRef.current;
+    const coords = getEventCoords(event);
+    if (!coords) return;
+
+    cancelRef.current = beginPointerDrag(event, {
+      threshold,
+      onMove: state => {
+        const handler = optionsRef.current.onMove || onMove;
+        if (handler) handler(state);
+      },
+      onEnd: (state, cancelled) => {
+        cancelRef.current = null;
+        const handler = optionsRef.current.onEnd || onEnd;
+        if (handler) handler(state, cancelled);
+      },
+    });
+    if (!cancelRef.current) return;
+
+    if (onStart) {
+      onStart(
+        {
+          ...coords,
+          dx: 0,
+          dy: 0,
+          totalDx: 0,
+          totalDy: 0,
+          moved: false,
+          pointerType:
+            (event.nativeEvent as PointerEvent).pointerType || "mouse",
+          event: event.nativeEvent as PointerEvent,
+        },
+        event,
+      );
+    }
+  }, []);
+
+  React.useEffect(
+    () => () => {
+      if (cancelRef.current) cancelRef.current();
+      cancelRef.current = null;
+    },
+    [],
+  );
+
+  return {onPointerDown};
+}
+
+/**
+ * Imperative press-and-hold core, for buttons that start something on press and
+ * must stop it on release (hold-to-charge, hold-to-repeat).
+ *
+ * Call from a `pointerdown` handler. `onRelease` is invoked exactly once, on
+ * `pointerup` *or* `pointercancel`. Returns a teardown function that suppresses
+ * that call, for unmount cleanup.
+ */
+export function beginPointerHold(
+  event: any,
+  onRelease: () => void,
+): () => void {
+  const native: PointerEvent = event.nativeEvent || event;
+  const target: Element = (event.currentTarget || native.target) as Element;
+  const pointerId = typeof native.pointerId === "number" ? native.pointerId : 1;
+  let finished = false;
+
+  const detach = () => {
+    document.removeEventListener("pointerup", handleUp);
+    document.removeEventListener("pointercancel", handleUp);
+    if (target) releaseCapture(target, pointerId);
+  };
+
+  function handleUp(ev: PointerEvent) {
+    if (ev.pointerId !== pointerId) return;
+    if (finished) return;
+    finished = true;
+    detach();
+    onRelease();
+  }
+
+  if (target) capture(target, pointerId);
+  document.addEventListener("pointerup", handleUp);
+  document.addEventListener("pointercancel", handleUp);
+
+  return () => {
+    if (finished) return;
+    finished = true;
+    detach();
+  };
+}
+
+/**
+ * Hook wrapper around {@link beginPointerHold}. Spread the result onto the
+ * button. `onStart` fires on press, `onEnd` exactly once on release.
+ */
+export function usePointerHold(
+  onStart: (event: React.PointerEvent) => void,
+  onEnd: () => void = () => {},
+) {
+  const handlersRef = React.useRef({onStart, onEnd});
+  handlersRef.current = {onStart, onEnd};
+  const cancelRef = React.useRef<(() => void) | null>(null);
+
+  const onPointerDown = React.useCallback((event: React.PointerEvent) => {
+    if (event.button !== 0) return;
+    if (cancelRef.current) return;
+    cancelRef.current = beginPointerHold(event, () => {
+      cancelRef.current = null;
+      handlersRef.current.onEnd();
+    });
+    handlersRef.current.onStart(event);
+  }, []);
+
+  React.useEffect(
+    () => () => {
+      if (cancelRef.current) cancelRef.current();
+      cancelRef.current = null;
+    },
+    [],
+  );
+
+  return {onPointerDown};
+}

--- a/src/helpers/laserGame/LaserGame.jsx
+++ b/src/helpers/laserGame/LaserGame.jsx
@@ -71,13 +71,18 @@ const Cell = React.memo(
     hilite,
     cellSize,
     objects,
-    mouseDown,
+    pointerDown,
+    didJustDrag,
     checkPoints,
     width,
   }) => {
     return (
       <div
-        onClick={() => addMirror(x, y)}
+        onClick={() => {
+          // Ignore the click the browser emits at a drag's origin.
+          if (didJustDrag()) return;
+          addMirror(x, y);
+        }}
         className={`game-cell ${hilite ? "hilite" : ""}`}
         style={{
           width: `${cellSize}px`,
@@ -86,7 +91,7 @@ const Cell = React.memo(
         }}
       >
         <Sprite
-          onMouseDown={e => mouseDown(e, objects[x][y], {x, y})}
+          onPointerDown={e => pointerDown(e, objects[x][y], {x, y})}
           name={objects[x][y]}
           active={checkPoints[`${x},${y}`]}
           side={getSide(x, y, width)}
@@ -160,7 +165,8 @@ const LaserGame = ({height: width, objects: initObjects, onWin = () => {}}) => {
     [laserSegments],
   );
   const {
-    mouseDown,
+    pointerDown,
+    didJustDrag,
     position,
     movingCell,
     positionCell,
@@ -212,7 +218,7 @@ const LaserGame = ({height: width, objects: initObjects, onWin = () => {}}) => {
           return (
             <div
               draggable={false}
-              onMouseDown={e => mouseDown(e, obj, "top")}
+              onPointerDown={e => pointerDown(e, obj, "top")}
               className="game-object"
               style={{
                 height: `${cellSize}px`,
@@ -246,7 +252,8 @@ const LaserGame = ({height: width, objects: initObjects, onWin = () => {}}) => {
               )}
               cellSize={cellSize}
               objects={objects}
-              mouseDown={mouseDown}
+              pointerDown={pointerDown}
+              didJustDrag={didJustDrag}
               checkPoints={checkPoints}
               width={width}
             />

--- a/src/helpers/laserGame/Sprite.jsx
+++ b/src/helpers/laserGame/Sprite.jsx
@@ -10,7 +10,6 @@ import EmitterGreen from "./images/EmitterGreen.svg";
 import Checkpoint from "./images/Checkpoint.svg";
 import CheckpointOn from "./images/Checkpoint-On.svg";
 
-
 export function getSprite(name, active) {
   if (!name) return {};
   name = name.replace("-Locked", "");
@@ -49,7 +48,7 @@ export function getSprite(name, active) {
   }
   return {};
 }
-const Sprite = ({name, side, active, onMouseDown}) => {
+const Sprite = ({name, side, active, onPointerDown}) => {
   let {src, className = ""} = getSprite(name, active);
   const locked =
     name.includes("-Locked") ||
@@ -57,7 +56,7 @@ const Sprite = ({name, side, active, onMouseDown}) => {
     name.includes("CheckPoint");
   return (
     <div
-      onMouseDown={locked ? null : onMouseDown}
+      onPointerDown={locked ? null : onPointerDown}
       className={`${locked ? "locked" : ""} sprite ${
         name.includes("Emitter") ? side : ""
       } ${name.replace("-Locked", "")} ${

--- a/src/helpers/laserGame/styles.scss
+++ b/src/helpers/laserGame/styles.scss
@@ -37,6 +37,11 @@
     background-color: rgba(0, 0, 0, 0.8);
   }
   .game-area {
+    // Stop the browser claiming these gestures as a pan/scroll on a
+    // touchscreen. This is the correct mechanism -- preventDefault() inside a
+    // React onTouchStart is a no-op, because React 16 delegates to `document`
+    // where Chrome forces touchstart listeners passive.
+    touch-action: none;
     position: relative;
     display: flex;
     flex-direction: column;
@@ -54,6 +59,7 @@
     transform: translate3d(var(--tx), var(--ty), 100px);
   }
   .game-object {
+    touch-action: none;
     width: 100%;
     background-size: 80%;
     background-position: center;
@@ -66,6 +72,7 @@
     cursor: grabbing;
   }
   .game-board {
+    touch-action: none;
     border: solid 3px rgba(0, 0, 0, 0.5);
     position: relative;
   }
@@ -99,6 +106,7 @@
     --deg: 0deg;
   }
   .sprite {
+    touch-action: none;
     position: relative;
     width: 100%;
     height: 100%;

--- a/src/helpers/laserGame/useDraggable.jsx
+++ b/src/helpers/laserGame/useDraggable.jsx
@@ -2,116 +2,172 @@ import React from "react";
 import {getSprite} from "./Sprite";
 import getSide from "./getSide";
 import distance from "./distance";
+import {beginPointerDrag, getEventCoords} from "../hooks/usePointerDrag";
 
+/**
+ * Drag/tap handling for the laser upgrade board.
+ *
+ * This used to attach its `mousemove`/`mouseup` listeners from a `useEffect`
+ * gated on drag state. On a Windows touchscreen that is fatal: Chrome fires the
+ * whole compat mouse sequence at the *end* of a tap, so `mouseup` arrives in the
+ * same task as `mousedown` -- before React ever commits the effect. The release
+ * was never observed, the piece stayed latched to the pointer forever, and
+ * moving a physical mouse afterwards dragged it around the board.
+ *
+ * The listeners are now attached synchronously during `pointerdown`, and go
+ * through pointer events so mouse and touch take exactly the same path. Because
+ * they are attached before the next render, they must not close over
+ * render-scoped values -- everything they need lives in `latest` below.
+ */
 export default function useDraggable({dispatch, objects, cellSize, width}) {
-  // Mouse Dragging
-  const [offset, setOffset] = React.useState(null);
   const [position, setPosition] = React.useState(null);
   const [movingObject, setMovingObject] = React.useState(null);
   const [movingCell, setMovingCell] = React.useState(null);
   const positionSide = React.useRef();
-  const originalPosition = React.useRef({x: 0, y: 0});
   const containerRef = React.useRef();
+  const cancelDrag = React.useRef(null);
+  // When a pointer is captured, the browser retargets the follow-up `click` to
+  // the element the drag *started* on. Without this the cell's own onClick
+  // (which auto-places a mirror) would fire on the origin cell every time you
+  // dragged a piece away from it.
+  const lastDragEnd = React.useRef(0);
 
-  const mouseDown = (e, movingObject, cell) => {
-    const dimensions = containerRef.current.getBoundingClientRect();
-    const targetDims = e.target.getBoundingClientRect();
-    const offset = {
-      x: e.clientX - targetDims.x + dimensions.left,
-      y: e.clientY - targetDims.y + dimensions.top,
-    };
-    setMovingObject(movingObject);
-    setPosition({x: e.pageX - offset.x, y: e.pageY - offset.y});
-    setMovingCell(cell);
-    setOffset(offset);
-    originalPosition.current = {x: e.pageX - offset.x, y: e.pageY - offset.y};
-    const timeout = setTimeout(() => {
-      document.removeEventListener("mouseup", mouseUp);
-      dispatch({type: "remove", ...cell});
-    }, 300);
-    const mouseUp = () => {
-      document.removeEventListener("mouseup", mouseUp);
-      clearTimeout(timeout);
-    };
+  const latest = React.useRef({dispatch, objects, cellSize, width});
+  latest.current = {dispatch, objects, cellSize, width};
 
-    document.addEventListener("mouseup", mouseUp);
-  };
-  const positionCell = position && {
-    x: Math.floor((position.x - cellSize / 2) / cellSize - 1) + 2,
-    y: Math.floor((position.y - cellSize / 2) / cellSize),
-  };
-  const moved =
-    distance(originalPosition.current, position || {x: 0, y: 0}) > 3;
+  const toCell = pos => ({
+    x:
+      Math.floor(
+        (pos.x - latest.current.cellSize / 2) / latest.current.cellSize - 1,
+      ) + 2,
+    y: Math.floor(
+      (pos.y - latest.current.cellSize / 2) / latest.current.cellSize,
+    ),
+  });
 
-  React.useEffect(() => {
-    const click = ({x, y}) => {
-      const cell = objects[x] && objects[x][y];
-
-      if (!cell) return;
-      if (cell.includes("Red")) doDispatch(cell.replace("Red", "Green"));
-      if (cell.includes("Green")) doDispatch(cell.replace("Green", "Blue"));
-      if (cell.includes("Blue")) doDispatch(cell.replace("Blue", "Red"));
-      if (cell.includes("Mirror")) {
-        const mirrorNum = (parseInt(cell.replace("Mirror", ""), 10) % 5) + 1;
-        doDispatch(`Mirror${mirrorNum}`);
-        if (mirrorNum === 5) {
-          setTimeout(() => {
-            doDispatch(`Mirror${1}`);
-          }, 200);
-        }
-      }
-      function doDispatch(newValue) {
-        dispatch({
-          type: "update",
-          x,
-          y,
-          new: newValue,
-        });
-      }
-    };
-    function mouseMove(e) {
-      setPosition({
-        x: e.pageX - offset.x,
-        y: e.pageY - offset.y,
-      });
+  // A tap (rather than a drag) cycles the cell's color or mirror angle.
+  const clickCell = ({x, y}) => {
+    const cell = latest.current.objects[x] && latest.current.objects[x][y];
+    if (!cell) return;
+    function doDispatch(newValue) {
+      latest.current.dispatch({type: "update", x, y, new: newValue});
     }
-    function mouseUp(e) {
-      const cell =
-        objects[positionCell.x] && objects[positionCell.x][positionCell.y];
-
-      if (moved) {
-        if (
-          (cell || cell === "") &&
-          !cell.includes("-Locked") &&
-          !cell.includes("Obstacle") &&
-          !cell.includes("CheckPoint")
-        ) {
-          dispatch({type: "add", ...positionCell, movingObject});
-        }
-      } else {
-        click(positionCell);
+    if (cell.includes("Red")) doDispatch(cell.replace("Red", "Green"));
+    if (cell.includes("Green")) doDispatch(cell.replace("Green", "Blue"));
+    if (cell.includes("Blue")) doDispatch(cell.replace("Blue", "Red"));
+    if (cell.includes("Mirror")) {
+      const mirrorNum = (parseInt(cell.replace("Mirror", ""), 10) % 5) + 1;
+      doDispatch(`Mirror${mirrorNum}`);
+      if (mirrorNum === 5) {
+        setTimeout(() => {
+          doDispatch(`Mirror${1}`);
+        }, 200);
       }
-      setOffset(null);
+    }
+  };
+
+  const pointerDown = (e, obj, cell) => {
+    const container = containerRef.current;
+    if (!container) return;
+    const coords = getEventCoords(e);
+    if (!coords) return;
+
+    const dimensions = container.getBoundingClientRect();
+    const targetDims = e.target.getBoundingClientRect();
+    const dragOffset = {
+      x: coords.clientX - targetDims.x + dimensions.left,
+      y: coords.clientY - targetDims.y + dimensions.top,
+    };
+    const start = {
+      x: coords.pageX - dragOffset.x,
+      y: coords.pageY - dragOffset.y,
+    };
+    // Tracked locally rather than read back from state, because the handlers
+    // below are attached before the next render.
+    let current = start;
+
+    setMovingObject(obj);
+    setMovingCell(cell);
+    setPosition(start);
+
+    // Holding for 300ms lifts the piece off the board. Releasing sooner is a
+    // tap, which cycles the cell instead.
+    const holdTimeout = setTimeout(() => {
+      latest.current.dispatch({type: "remove", ...cell});
+    }, 300);
+
+    cancelDrag.current = beginPointerDrag(e, {
+      onMove: state => {
+        current = {
+          x: state.pageX - dragOffset.x,
+          y: state.pageY - dragOffset.y,
+        };
+        setPosition(current);
+      },
+      onEnd: () => {
+        cancelDrag.current = null;
+        clearTimeout(holdTimeout);
+        const dropCell = toCell(current);
+        const target =
+          latest.current.objects[dropCell.x] &&
+          latest.current.objects[dropCell.x][dropCell.y];
+        const moved = distance(start, current) > 3;
+        if (moved) lastDragEnd.current = Date.now();
+        if (moved) {
+          if (
+            (target || target === "") &&
+            !target.includes("-Locked") &&
+            !target.includes("Obstacle") &&
+            !target.includes("CheckPoint")
+          ) {
+            latest.current.dispatch({
+              type: "add",
+              ...dropCell,
+              movingObject: obj,
+            });
+          }
+        } else {
+          clickCell(dropCell);
+        }
+        setPosition(null);
+        setMovingObject(null);
+        setMovingCell(false);
+      },
+    });
+    // No usable pointer -- don't leave the board mid-pickup.
+    if (!cancelDrag.current) {
+      clearTimeout(holdTimeout);
       setPosition(null);
       setMovingObject(null);
       setMovingCell(false);
     }
-    if (offset) {
-      document.addEventListener("mousemove", mouseMove);
-      document.addEventListener("mouseup", mouseUp);
-    }
-    return () => {
-      document.removeEventListener("mousemove", mouseMove);
-      document.removeEventListener("mouseup", mouseUp);
-    };
-  }, [offset, objects, moved, movingObject, positionCell, dispatch]);
+  };
+
+  React.useEffect(
+    () => () => {
+      if (cancelDrag.current) cancelDrag.current();
+      cancelDrag.current = null;
+    },
+    [],
+  );
+
+  const positionCell = position && toCell(position);
   const positionSprite = movingObject && getSprite(movingObject);
 
   positionSide.current =
     position &&
     (getSide(positionCell.x, positionCell.y, width) || positionSide.current);
+
+  // True just after a real drag, so click handlers can ignore the trailing
+  // click the browser emits at the drag's origin.
+  const didJustDrag = React.useCallback(
+    () => Date.now() - lastDragEnd.current < 300,
+    [],
+  );
+
   return {
-    mouseDown,
+    pointerDown,
+    didJustDrag,
     position,
     movingCell,
     positionCell,

--- a/src/helpers/robozzleGame/commands.jsx
+++ b/src/helpers/robozzleGame/commands.jsx
@@ -1,40 +1,34 @@
 import React, {Fragment} from "react";
 
-const Red = ({onMouseDown}) => {
+const Red = ({onPointerDown}) => {
   return (
     <div
       className="command paint paint-red"
-      onMouseDown={evt =>
-        onMouseDown({x: evt.clientX, y: evt.clientY}, "paint-red")
-      }
+      onPointerDown={evt => onPointerDown(evt, "paint-red")}
     />
   );
 };
-const Green = ({onMouseDown}) => {
+const Green = ({onPointerDown}) => {
   return (
     <div
       className="command paint paint-green"
-      onMouseDown={evt =>
-        onMouseDown({x: evt.clientX, y: evt.clientY}, "paint-green")
-      }
+      onPointerDown={evt => onPointerDown(evt, "paint-green")}
     />
   );
 };
-const Blue = ({onMouseDown}) => {
+const Blue = ({onPointerDown}) => {
   return (
     <div
       className="command paint paint-blue"
-      onMouseDown={evt =>
-        onMouseDown({x: evt.clientX, y: evt.clientY}, "paint-blue")
-      }
+      onPointerDown={evt => onPointerDown(evt, "paint-blue")}
     />
   );
 };
-const ColorCommands = ({colors, onMouseDown}) => {
+const ColorCommands = ({colors, onPointerDown}) => {
   if (colors === 1) {
     return (
       <Fragment>
-        <Red onMouseDown={onMouseDown} />
+        <Red onPointerDown={onPointerDown} />
         <div className="divider" />
       </Fragment>
     );
@@ -42,7 +36,7 @@ const ColorCommands = ({colors, onMouseDown}) => {
   if (colors === 2) {
     return (
       <Fragment>
-        <Green onMouseDown={onMouseDown} />
+        <Green onPointerDown={onPointerDown} />
         <div className="divider" />
       </Fragment>
     );
@@ -50,8 +44,8 @@ const ColorCommands = ({colors, onMouseDown}) => {
   if (colors === 3) {
     return (
       <Fragment>
-        <Red onMouseDown={onMouseDown} />
-        <Green onMouseDown={onMouseDown} />
+        <Red onPointerDown={onPointerDown} />
+        <Green onPointerDown={onPointerDown} />
         <div className="divider" />
       </Fragment>
     );
@@ -59,57 +53,51 @@ const ColorCommands = ({colors, onMouseDown}) => {
   if (colors === 4) {
     return (
       <Fragment>
-        <Blue onMouseDown={onMouseDown} /> <div className="divider" />
+        <Blue onPointerDown={onPointerDown} /> <div className="divider" />
       </Fragment>
     );
   }
   if (colors === 5) {
     return (
       <Fragment>
-        <Red onMouseDown={onMouseDown} />
-        <Blue onMouseDown={onMouseDown} /> <div className="divider" />
+        <Red onPointerDown={onPointerDown} />
+        <Blue onPointerDown={onPointerDown} /> <div className="divider" />
       </Fragment>
     );
   }
   if (colors === 6) {
     return (
       <Fragment>
-        <Green onMouseDown={onMouseDown} />
-        <Blue onMouseDown={onMouseDown} /> <div className="divider" />
+        <Green onPointerDown={onPointerDown} />
+        <Blue onPointerDown={onPointerDown} /> <div className="divider" />
       </Fragment>
     );
   }
   if (colors === 7) {
     return (
       <Fragment>
-        <Red onMouseDown={onMouseDown} />
-        <Green onMouseDown={onMouseDown} />
-        <Blue onMouseDown={onMouseDown} /> <div className="divider" />
+        <Red onPointerDown={onPointerDown} />
+        <Green onPointerDown={onPointerDown} />
+        <Blue onPointerDown={onPointerDown} /> <div className="divider" />
       </Fragment>
     );
   }
   return null;
 };
-const Commands = ({SubLengths, AllowedCommands, dragging, onMouseDown}) => {
+const Commands = ({SubLengths, AllowedCommands, dragging, onPointerDown}) => {
   return (
     <div className={`commands-area ${dragging ? "dragging" : ""}`}>
       <div
         className="command forward"
-        onMouseDown={evt =>
-          onMouseDown({x: evt.clientX, y: evt.clientY}, "forward", "")
-        }
+        onPointerDown={evt => onPointerDown(evt, "forward", "")}
       />
       <div
         className="command left"
-        onMouseDown={evt =>
-          onMouseDown({x: evt.clientX, y: evt.clientY}, "left", "")
-        }
+        onPointerDown={evt => onPointerDown(evt, "left", "")}
       />
       <div
         className="command right"
-        onMouseDown={evt =>
-          onMouseDown({x: evt.clientX, y: evt.clientY}, "right", "")
-        }
+        onPointerDown={evt => onPointerDown(evt, "right", "")}
       />
       <div className="divider" />
       {SubLengths.map(
@@ -118,40 +106,30 @@ const Commands = ({SubLengths, AllowedCommands, dragging, onMouseDown}) => {
             <div
               key={`sublength-${i}`}
               className={`command f${i + 1}`}
-              onMouseDown={evt =>
-                onMouseDown({x: evt.clientX, y: evt.clientY}, `f${i + 1}`)
-              }
+              onPointerDown={evt => onPointerDown(evt, `f${i + 1}`)}
             />
           ),
       )}
       <div className="divider" />
       <ColorCommands
         colors={parseInt(AllowedCommands, 10)}
-        onMouseDown={onMouseDown}
+        onPointerDown={onPointerDown}
       />
       <div
         className="command color clear"
-        onMouseDown={evt =>
-          onMouseDown({x: evt.clientX, y: evt.clientY}, null, "clear")
-        }
+        onPointerDown={evt => onPointerDown(evt, null, "clear")}
       />
       <div
         className="command color red"
-        onMouseDown={evt =>
-          onMouseDown({x: evt.clientX, y: evt.clientY}, null, "red")
-        }
+        onPointerDown={evt => onPointerDown(evt, null, "red")}
       />
       <div
         className="command color green"
-        onMouseDown={evt =>
-          onMouseDown({x: evt.clientX, y: evt.clientY}, null, "green")
-        }
+        onPointerDown={evt => onPointerDown(evt, null, "green")}
       />
       <div
         className="command color blue"
-        onMouseDown={evt =>
-          onMouseDown({x: evt.clientX, y: evt.clientY}, null, "blue")
-        }
+        onPointerDown={evt => onPointerDown(evt, null, "blue")}
       />
     </div>
   );

--- a/src/helpers/robozzleGame/controls.jsx
+++ b/src/helpers/robozzleGame/controls.jsx
@@ -1,13 +1,13 @@
 import React from "react";
 
-import f1 from "./img/f1.svg?url"
-import f2 from "./img/f2.svg?url"
-import f3 from "./img/f3.svg?url"
-import f4 from "./img/f4.svg?url"
-import f5 from "./img/f5.svg?url"
-import f6 from "./img/f6.svg?url"
+import f1 from "./img/f1.svg?url";
+import f2 from "./img/f2.svg?url";
+import f3 from "./img/f3.svg?url";
+import f4 from "./img/f4.svg?url";
+import f5 from "./img/f5.svg?url";
+import f6 from "./img/f6.svg?url";
 
-const fimg = [f1,f2,f3,f4,f5,f6];
+const fimg = [f1, f2, f3, f4, f5, f6];
 const functionClasses = (func, pos, functions) => {
   const funcObj = functions[func];
   if (!funcObj) return "";
@@ -19,18 +19,14 @@ const functionClasses = (func, pos, functions) => {
     color ? `${color} color` : ""
   }`;
 };
-const Commands = ({SubLengths, dragging, functions, onMouseDown}) => {
+const Commands = ({SubLengths, dragging, functions, onPointerDown}) => {
   return (
     <div className={`game-controls ${dragging ? "dragging" : ""}`}>
       {SubLengths.map(
         (s, i) =>
           parseInt(s, 10) > 0 && (
             <div key={`f${i + 1}`} className="function-holder">
-              <img
-                draggable="false"
-                src={fimg[i]}
-                alt={`F${i + 1}`}
-              />
+              <img draggable="false" src={fimg[i]} alt={`F${i + 1}`} />
               <div className="function-area">
                 {Array(parseInt(s, 10))
                   .fill(0)
@@ -44,7 +40,7 @@ const Commands = ({SubLengths, dragging, functions, onMouseDown}) => {
                       )}`}
                       data-funcnum={`f${i + 1}`}
                       data-position={fi}
-                      onMouseDown={onMouseDown}
+                      onPointerDown={onPointerDown}
                     />
                   ))}
               </div>

--- a/src/helpers/robozzleGame/game.jsx
+++ b/src/helpers/robozzleGame/game.jsx
@@ -2,6 +2,7 @@ import React, {Component, Fragment} from "react";
 import GameBoard from "./gameboard";
 import Controls from "./controls";
 import Commands from "./commands";
+import {beginPointerDrag, getEventCoords} from "../hooks/usePointerDrag";
 
 function replaceAt(string, index, replace) {
   return string.substring(0, index) + replace + string.substring(index + 1);
@@ -27,87 +28,93 @@ class Game extends Component {
       ...this.props.board,
     }));
   };
-  commandMouseDown = evt => {
+  // Dragging runs on pointer events so mouse and touch take the same path.
+  // The old code was unusable on a touchscreen for two independent reasons:
+  // it moved the piece with `evt.movementX/Y`, which is mouse-only, and it
+  // resolved the drop slot from `evt.target`, which on touch is the element the
+  // gesture *started* on rather than the one under the finger.
+  cancelDrag = null;
+  // Lift an already-placed command back out of its slot.
+  commandPointerDown = evt => {
     const funcnum = evt.target.dataset.funcnum;
     const index = evt.target.dataset.position;
-    const dimensions = this.gameboardRef.current.getBoundingClientRect();
-
-    const position = {
-      x: evt.clientX - dimensions.left - 15,
-      y: evt.clientY - dimensions.top - 15,
-    };
-    this.setState(state => {
-      // Check to see if there is a function there.
-      if (state.functions[funcnum] && state.functions[funcnum][index]) {
-        const {command, color} = state.functions[funcnum][index];
-        this.props.setDragging(true);
-        document.addEventListener("mousemove", this.mouseMove);
-        document.addEventListener("mouseup", this.mouseUp);
-        return {
-          dragging: {
-            position,
-            command,
-            color,
-          },
-          functions: {
-            ...state.functions,
-            [funcnum]: state.functions[funcnum].map((f, i) => {
-              if (i === parseInt(index, 10)) return null;
-              return f;
-            }),
-          },
-        };
-      }
-      return {};
-    });
-  };
-  mouseDown = (position, command, color) => {
-    this.props.setDragging(true);
-    const dimensions = this.gameboardRef.current.getBoundingClientRect();
-    this.setState({
-      dragging: {
-        position: {
-          x: position.x - 20 - dimensions.left,
-          y: position.y - 20 - dimensions.top,
-        },
-        command,
-        color,
-      },
-    });
-    document.addEventListener("mousemove", this.mouseMove);
-    document.addEventListener("mouseup", this.mouseUp);
-  };
-  mouseMove = evt => {
+    const existing =
+      this.state.functions[funcnum] && this.state.functions[funcnum][index];
+    if (!existing) return;
+    const {command, color} = existing;
     this.setState(state => ({
-      dragging: {
-        ...state.dragging,
-        position: {
-          x: state.dragging.position.x + evt.movementX,
-          y: state.dragging.position.y + evt.movementY,
-        },
+      functions: {
+        ...state.functions,
+        [funcnum]: state.functions[funcnum].map((f, i) => {
+          if (i === parseInt(index, 10)) return null;
+          return f;
+        }),
       },
     }));
+    this.startDrag(evt, command, color, 15);
   };
-  mouseUp = evt => {
-    document.removeEventListener("mousemove", this.mouseMove);
-    this.props.setDragging(false);
-    document.removeEventListener("mouseup", this.mouseUp);
-    const funcNum = evt.target.dataset.funcnum;
-    const position = parseInt(evt.target.dataset.position, 10);
-    if (!funcNum) return this.setState({dragging: null});
-    const action = {};
-    this.setState(state => {
-      if (state.dragging.command) action.command = state.dragging.command;
-      if (state.dragging.color) action.color = state.dragging.color;
-      if (state.dragging.color === "clear") action.color = null;
-      const func = state.functions[funcNum] || [];
-      func[position] = {...func[position], ...action};
-      return {
-        dragging: null,
-        functions: {...state.functions, [funcNum]: func},
-      };
+  // Pick a fresh command up off the palette.
+  pointerDown = (evt, command, color) => {
+    this.startDrag(evt, command, color, 20);
+  };
+  startDrag(evt, command, color, grabOffset) {
+    const board = this.gameboardRef.current;
+    const coords = getEventCoords(evt);
+    if (!board || !coords) return;
+    const dimensions = board.getBoundingClientRect();
+    // Absolute position each time rather than an accumulated delta, so there is
+    // no dependence on `movementX`/`movementY`.
+    const toLocal = c => ({
+      x: c.clientX - grabOffset - dimensions.left,
+      y: c.clientY - grabOffset - dimensions.top,
     });
-  };
+
+    this.props.setDragging(true);
+    this.setState({dragging: {position: toLocal(coords), command, color}});
+
+    this.cancelDrag = beginPointerDrag(evt, {
+      onMove: state => {
+        this.setState({dragging: {position: toLocal(state), command, color}});
+      },
+      onEnd: state => {
+        this.cancelDrag = null;
+        this.props.setDragging(false);
+        // Hit-test the release point. Pointer capture retargets `pointerup` to
+        // the element the drag started on, so the event's own target is never
+        // the slot being dropped into.
+        const dropTarget = document.elementFromPoint(
+          state.clientX,
+          state.clientY,
+        );
+        const dataset = (dropTarget && dropTarget.dataset) || {};
+        const funcNum = dataset.funcnum;
+        const position = parseInt(dataset.position, 10);
+        if (!funcNum) return this.setState({dragging: null});
+        const action = {};
+        this.setState(prev => {
+          if (!prev.dragging) return {dragging: null};
+          if (prev.dragging.command) action.command = prev.dragging.command;
+          if (prev.dragging.color) action.color = prev.dragging.color;
+          if (prev.dragging.color === "clear") action.color = null;
+          const func = prev.functions[funcNum] || [];
+          func[position] = {...func[position], ...action};
+          return {
+            dragging: null,
+            functions: {...prev.functions, [funcNum]: func},
+          };
+        });
+      },
+    });
+    if (!this.cancelDrag) {
+      this.props.setDragging(false);
+      this.setState({dragging: null});
+    }
+  }
+  componentWillUnmount() {
+    clearTimeout(this.timeout);
+    if (this.cancelDrag) this.cancelDrag();
+    this.cancelDrag = null;
+  }
   start = () => {
     this.reset();
     clearTimeout(this.timeout);
@@ -263,11 +270,11 @@ class Game extends Component {
                 {...this.state}
                 dragging={dragging}
                 functions={functions}
-                onMouseDown={this.commandMouseDown}
+                onPointerDown={this.commandPointerDown}
               />
               <Commands
                 {...this.state}
-                onMouseDown={this.mouseDown}
+                onPointerDown={this.pointerDown}
                 dragging={dragging}
               />
               <div style={{display: "flex"}}>

--- a/src/helpers/robozzleGame/styles.scss
+++ b/src/helpers/robozzleGame/styles.scss
@@ -116,7 +116,12 @@
     display: flex;
     flex-direction: column;
   }
+  // Stop the browser claiming these gestures as a pan/scroll on a touchscreen.
+  // This is the correct mechanism -- preventDefault() inside a React
+  // onTouchStart is a no-op, because React 16 delegates to `document` where
+  // Chrome forces touchstart listeners passive.
   .player-controls {
+    touch-action: none;
     display: flex;
     flex-direction: column;
     justify-content: space-around;


### PR DESCRIPTION
## Description

Crew stations on Windows touchscreens could not reliably operate Thrusters, Phasers, Transporters, the Aegis focus pad, or the Exocomp upgrade puzzles. This replaces the mouse-only and react-draggable-based input on every affected crew card with Pointer Events, and adds a shared helper so the pattern isn't hand-rolled per component again.

Fixes the root causes detailed in the issue: Chrome's compat-event model, react-draggable's multi-touch listener leak, a TypeError on every Thrusters touch release, and drag listeners attached from a useEffect.

This PR is Client-only. No GraphQL schema, resolver, or server changes.

I've built a windows build for James to test, and it was successful in fixing the odd behavior I was seeing. I also tested it on my machine to make sure we didn't hit any regressions from mac users. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/Thorium-Sim/thorium/issues/3546

## Screenshots (if appropriate):

- [ ] I submitted a pull request or created an issue for documenting this
      feature on the [Thorium Docs](https://github.com/Thorium-Sim/thorium-docs)
      repo. (Include the issue or pull request url below.)


### Extra details

Pointer events fire exactly once per input for mouse, touch and pen alike, which fixes the touch gap and removes the pre-existing double-fire bugs rather than papering over them. setPointerCapture guarantees the matching pointerup is delivered even when the finger leaves the element, and pointercancel is handled, which structurally eliminates the "drag latches forever" class of bug.

Scroll and pan interference is handled with CSS touch-action: none, the correct mechanism. preventDefault() inside a React onTouchStart is a no-op here, since React 16 delegates to document where Chrome forces touchstart listeners passive.

To help with that, we've created a suite of helper functions to aid with that transition in those areas: src/helpers/hooks/usePointerDrag.ts


